### PR TITLE
improve provider panel and multiprovider support

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -1,24 +1,220 @@
+import {
+    getProviderSettings,
+    getStoredProvider,
+    providerSupportsModelDiscovery,
+    setProviderField,
+} from "./providerConfig.js";
+
 // main.jsx - AI chat module
-// Supports Gemini and custom OpenAI-compatible endpoints (e.g. Ollama)
+// Supports Gemini, OpenAI, Anthropic, and OpenAI-compatible endpoints
 // Usage: import { sendMessage, sendDiplomaticMessage, startChat, startDiplomaticChat, loadHistory, loadDiplomaticHistory, buildDiplomaticSystemPrompt } from './main.jsx'
 
-// ── Provider detection ────────────────────────────────────────────────────────
+const GEMINI_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview";
+const ANTHROPIC_DEFAULT_MODEL = "claude-haiku-4-5";
+const OPENAI_API_ENDPOINT = "https://api.openai.com/v1";
+const ANTHROPIC_API_ENDPOINT = "https://api.anthropic.com/v1";
 
-function getProvider() {
-    return localStorage.getItem("api_provider") || "gemini";
+const CHAT_MODEL_HINTS = [
+    /^gpt/i,
+    /^o\d/i,
+    /claude/i,
+    /gemini/i,
+    /llama/i,
+    /mistral/i,
+    /mixtral/i,
+    /qwen/i,
+    /deepseek/i,
+    /command/i,
+    /phi/i,
+];
+
+const NON_CHAT_MODEL_HINTS = [
+    /embedding/i,
+    /moderation/i,
+    /whisper/i,
+    /tts/i,
+    /transcribe/i,
+    /speech/i,
+    /image/i,
+    /rerank/i,
+];
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// ── Gemini API ────────────────────────────────────────────────────────────────
+function normalizeEndpoint(endpoint) {
+    return (endpoint ?? "").trim().replace(/\/$/, "");
+}
 
-function getGeminiUrl() {
-    const API_KEY = localStorage.getItem("gemini_api_key");
-    if (!API_KEY) throw new Error("Go to the **settings** and paste your Gemini API key - you can get it at https://aistudio.google.com/app/apikey");
-        return `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent?key=${API_KEY}`;
+function normalizeGeminiModel(model) {
+    return (model ?? "").replace(/^models\//, "").trim();
+}
+
+async function readErrorPayload(response) {
+    const text = await response.text();
+
+    if (!text) return {};
+
+    try {
+        return JSON.parse(text);
+    } catch {
+        return { rawText: text };
+    }
+}
+
+function extractErrorMessage(payload, fallback) {
+    if (!payload) return fallback;
+    if (typeof payload === "string" && payload.trim()) return payload.trim();
+    if (payload.error?.message) return payload.error.message;
+    if (payload.message) return payload.message;
+    if (typeof payload.rawText === "string" && payload.rawText.trim()) return payload.rawText.trim();
+    return fallback;
+}
+
+function pickLikelyChatModel(models) {
+    const modelIds = models
+    .map((entry) => entry?.id)
+    .filter((id) => typeof id === "string" && id.trim());
+
+    const preferredModel = modelIds.find((id) => (
+        CHAT_MODEL_HINTS.some((pattern) => pattern.test(id))
+        && !NON_CHAT_MODEL_HINTS.some((pattern) => pattern.test(id))
+    ));
+
+    if (preferredModel) return preferredModel;
+
+    const safeFallbackModel = modelIds.find((id) => (
+        !NON_CHAT_MODEL_HINTS.some((pattern) => pattern.test(id))
+    ));
+
+    return safeFallbackModel ?? modelIds[0] ?? "";
+}
+
+function joinGeminiParts(parts) {
+    return (parts ?? [])
+    .map((part) => part?.text ?? "")
+    .join("")
+    .trim();
+}
+
+function extractOpenAIMessageText(data) {
+    const content = data?.choices?.[0]?.message?.content;
+
+    if (typeof content === "string") {
+        return content.trim();
+    }
+
+    if (Array.isArray(content)) {
+        return content
+        .map((part) => {
+            if (typeof part === "string") return part;
+            if (typeof part?.text === "string") return part.text;
+            return "";
+        })
+        .join("")
+        .trim();
+    }
+
+    return "";
+}
+
+function extractAnthropicText(data) {
+    return (data?.content ?? [])
+    .filter((block) => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("\n\n")
+    .trim();
+}
+
+function getGeminiUrl(model, apiKey) {
+    return `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${apiKey}`;
+}
+
+function toOpenAIMessages(systemPrompt, history) {
+    const messages = [{ role: "system", content: systemPrompt }];
+
+    for (const entry of history) {
+        messages.push({
+            role: entry.role === "model" ? "assistant" : "user",
+            content: entry.parts?.[0]?.text ?? "",
+        });
+    }
+
+    return messages;
+}
+
+function toAnthropicMessages(history) {
+    return history.map((entry) => ({
+        role: entry.role === "model" ? "assistant" : "user",
+        content: [{
+            type: "text",
+            text: entry.parts?.[0]?.text ?? "",
+        }],
+    }));
+}
+
+async function resolveModel(provider, { endpoint = "", headers = {}, fallbackModel = "", providerLabel } = {}) {
+    const settings = getProviderSettings(provider);
+    const configuredModel = settings.model.trim();
+
+    if (configuredModel) {
+        return provider === "gemini" ? normalizeGeminiModel(configuredModel) : configuredModel;
+    }
+
+    if (fallbackModel) {
+        return fallbackModel;
+    }
+
+    if (!providerSupportsModelDiscovery(provider)) {
+        throw new Error(`Go to **settings** and enter a model for ${providerLabel}.`);
+    }
+
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+
+    if (!normalizedEndpoint) {
+        throw new Error(`Go to **settings** and enter an endpoint for ${providerLabel}.`);
+    }
+
+    try {
+        const response = await fetch(`${normalizedEndpoint}/models`, { headers });
+
+        if (!response.ok) {
+            const payload = await readErrorPayload(response);
+            throw new Error(extractErrorMessage(payload, `Could not load models from ${providerLabel}.`));
+        }
+
+        const data = await response.json();
+        const discoveredModel = pickLikelyChatModel(data?.data ?? []);
+
+        if (!discoveredModel) {
+            throw new Error(`No models were returned by ${providerLabel}.`);
+        }
+
+        console.log(`Auto-detected ${providerLabel} model:`, discoveredModel);
+        setProviderField(provider, "model", discoveredModel);
+        return discoveredModel;
+    } catch (error) {
+        console.warn(`Could not auto-detect model for ${providerLabel}:`, error);
+        throw new Error(`Could not auto-detect a model for ${providerLabel}. Enter a model manually in **settings**.`);
+    }
 }
 
 async function callGemini(systemPrompt, history, { retries = 3, retryDelay = 15000 } = {}) {
+    const settings = getProviderSettings("gemini");
+    const apiKey = settings.apiKey.trim();
+
+    if (!apiKey) {
+        throw new Error("Go to **settings** and paste your Gemini API key - you can get it at https://aistudio.google.com/app/apikey");
+    }
+
+    const model = await resolveModel("gemini", {
+        fallbackModel: GEMINI_DEFAULT_MODEL,
+        providerLabel: "Gemini",
+    });
+
     for (let attempt = 1; attempt <= retries; attempt++) {
-        const response = await fetch(getGeminiUrl(), {
+        const response = await fetch(getGeminiUrl(model, apiKey), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
@@ -27,152 +223,265 @@ async function callGemini(systemPrompt, history, { retries = 3, retryDelay = 150
             }),
         });
 
-        if (response.status === 429 || response.status === 503) {
-            if (attempt === retries) throw new Error(`Rate limit/server overload after ${retries} attempts. Try again in a minute.`);
-            console.warn(`Rate limited. Retrying in ${retryDelay / 1000}s… (attempt ${attempt}/${retries})`);
-            await new Promise(res => setTimeout(res, retryDelay));
+        if (response.status === 429) {
+            const payload = await readErrorPayload(response);
+            const details = extractErrorMessage(payload, "Gemini returned 429.");
+            throw new Error(`Gemini returned 429. Your balance or quota appears to be exhausted. ${details}`.trim());
+        }
+
+        if (response.status === 503) {
+            if (attempt === retries) {
+                throw new Error(`Gemini is temporarily unavailable after ${retries} attempts. Try again in a minute.`);
+            }
+
+            console.warn(`Gemini is busy. Retrying in ${retryDelay / 1000}s... (attempt ${attempt}/${retries})`);
+            await sleep(retryDelay);
             continue;
         }
 
         if (!response.ok) {
-            const err = await response.json();
-            throw new Error(err.error?.message || "Gemini API request failed");
+            const payload = await readErrorPayload(response);
+            throw new Error(extractErrorMessage(payload, `Gemini API request failed (${response.status})`));
         }
 
         const data = await response.json();
-        return data.candidates[0].content.parts[0].text;
-    }
-}
+        const text = joinGeminiParts(data?.candidates?.[0]?.content?.parts);
 
-// ── Custom / Ollama API (OpenAI-compatible) ───────────────────────────────────
-
-function getCustomUrl() {
-    const endpoint = localStorage.getItem("custom_api_endpoint");
-    if (!endpoint) throw new Error("Go to **settings**, select Custom API, and enter your endpoint (e.g. http://localhost:11434/v1)");
-        return endpoint.replace(/\/$/, "") + "/chat/completions";
-}
-
-// Convert Gemini-style history to OpenAI messages format
-function toOpenAIMessages(systemPrompt, history) {
-    const messages = [{ role: "system", content: systemPrompt }];
-    for (const entry of history) {
-        messages.push({
-            role: entry.role === "model" ? "assistant" : "user",
-            content: entry.parts[0].text,
-        });
-    }
-    return messages;
-}
-async function getFirstAvailableModel() {
-    try {
-        const endpoint = localStorage.getItem("custom_api_endpoint")?.replace(/\/$/, "");
-        const res = await fetch(`${endpoint}/models`);
-        const data = await res.json();
-        const model = data.data?.[0]?.id;
-        if (model) {
-            console.log("Auto-detected model:", model);
-            localStorage.setItem("custom_api_model", model); // cache it
-            return model;
+        if (!text) {
+            throw new Error("Gemini response did not contain text.");
         }
-    } catch (e) {
-        console.warn("Could not auto-detect model:", e);
+
+        return text;
     }
-    return "llama3"; // final fallback
 }
 
-async function callCustom(systemPrompt, history, { retries = 3, retryDelay = 15000 } = {}) {
+async function callOpenAIStyleChatCompletions({
+    endpoint,
+    headers,
+    model,
+    systemPrompt,
+    history,
+    providerLabel,
+    retries = 3,
+    retryDelay = 15000,
+}) {
     for (let attempt = 1; attempt <= retries; attempt++) {
-        const response = await fetch(getCustomUrl(), {
+        const response = await fetch(`${normalizeEndpoint(endpoint)}/chat/completions`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers,
             body: JSON.stringify({
-                model: await getFirstAvailableModel(),
+                model,
                 messages: toOpenAIMessages(systemPrompt, history),
             }),
         });
 
         if (response.status === 429 || response.status === 503) {
-            if (attempt === retries) throw new Error(`Server overloaded after ${retries} attempts. Try again in a moment.`);
-            console.warn(`Server busy. Retrying in ${retryDelay / 1000}s… (attempt ${attempt}/${retries})`);
-            await new Promise(res => setTimeout(res, retryDelay));
+            if (attempt === retries) {
+                const payload = await readErrorPayload(response);
+                throw new Error(extractErrorMessage(payload, `${providerLabel} is busy right now. Try again in a moment.`));
+            }
+
+            console.warn(`${providerLabel} is busy. Retrying in ${retryDelay / 1000}s... (attempt ${attempt}/${retries})`);
+            await sleep(retryDelay);
             continue;
         }
 
         if (!response.ok) {
-            const err = await response.json().catch(() => ({}));
-            throw new Error(err.error?.message || `Custom API request failed (${response.status})`);
+            const payload = await readErrorPayload(response);
+            throw new Error(extractErrorMessage(payload, `${providerLabel} request failed (${response.status})`));
         }
 
         const data = await response.json();
-        return data.choices[0].message.content;
+        const text = extractOpenAIMessageText(data);
+
+        if (!text) {
+            throw new Error(`${providerLabel} response did not contain text.`);
+        }
+
+        return text;
     }
 }
 
-// ── Unified call ──────────────────────────────────────────────────────────────
+async function callOpenAI(systemPrompt, history, opts = {}) {
+    const settings = getProviderSettings("openai");
+    const apiKey = settings.apiKey.trim();
 
-async function callAI(systemPrompt, history, opts) {
-    return getProvider() === "gemini"
-    ? callGemini(systemPrompt, history, opts)
-    : callCustom(systemPrompt, history, opts);
+    if (!apiKey) {
+        throw new Error("Go to **settings** and paste your OpenAI API key.");
+    }
+
+    const headers = {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+    };
+
+    const model = await resolveModel("openai", {
+        endpoint: OPENAI_API_ENDPOINT,
+        headers,
+        providerLabel: "OpenAI",
+    });
+
+    return callOpenAIStyleChatCompletions({
+        endpoint: OPENAI_API_ENDPOINT,
+        headers,
+        model,
+        systemPrompt,
+        history,
+        providerLabel: "OpenAI",
+        ...opts,
+    });
 }
 
-// ── Prompt templates (loaded once from prompts.json) ──────────────────────────
+async function callOpenAICompatible(systemPrompt, history, opts = {}) {
+    const settings = getProviderSettings("openai-compatible");
+    const endpoint = normalizeEndpoint(settings.endpoint);
+
+    if (!endpoint) {
+        throw new Error("Go to **settings**, select OpenAI Compatible, and enter your endpoint (for example http://localhost:11434/v1).");
+    }
+
+    const headers = {
+        "Content-Type": "application/json",
+        ...(settings.apiKey.trim() ? { Authorization: `Bearer ${settings.apiKey.trim()}` } : {}),
+    };
+
+    const model = await resolveModel("openai-compatible", {
+        endpoint,
+        headers,
+        providerLabel: "OpenAI Compatible",
+    });
+
+    return callOpenAIStyleChatCompletions({
+        endpoint,
+        headers,
+        model,
+        systemPrompt,
+        history,
+        providerLabel: "OpenAI Compatible",
+        ...opts,
+    });
+}
+
+async function callAnthropic(systemPrompt, history, { retries = 3, retryDelay = 15000 } = {}) {
+    const settings = getProviderSettings("anthropic");
+    const apiKey = settings.apiKey.trim();
+
+    if (!apiKey) {
+        throw new Error("Go to **settings** and paste your Anthropic API key.");
+    }
+
+    const model = await resolveModel("anthropic", {
+        fallbackModel: ANTHROPIC_DEFAULT_MODEL,
+        providerLabel: "Anthropic",
+    });
+
+    const headers = {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "anthropic-dangerous-direct-browser-access": "true",
+    };
+
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        const response = await fetch(`${ANTHROPIC_API_ENDPOINT}/messages`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                model,
+                system: systemPrompt,
+                max_tokens: 1024,
+                messages: toAnthropicMessages(history),
+            }),
+        });
+
+        if (response.status === 429 || response.status === 503) {
+            if (attempt === retries) {
+                const payload = await readErrorPayload(response);
+                throw new Error(extractErrorMessage(payload, "Anthropic is busy right now. Try again in a moment."));
+            }
+
+            console.warn(`Anthropic is busy. Retrying in ${retryDelay / 1000}s... (attempt ${attempt}/${retries})`);
+            await sleep(retryDelay);
+            continue;
+        }
+
+        if (!response.ok) {
+            const payload = await readErrorPayload(response);
+            throw new Error(extractErrorMessage(payload, `Anthropic request failed (${response.status})`));
+        }
+
+        const data = await response.json();
+        const text = extractAnthropicText(data);
+
+        if (!text) {
+            throw new Error("Anthropic response did not contain text.");
+        }
+
+        return text;
+    }
+}
+
+async function callAI(systemPrompt, history, opts) {
+    switch (getStoredProvider()) {
+    case "openai":
+        return callOpenAI(systemPrompt, history, opts);
+    case "anthropic":
+        return callAnthropic(systemPrompt, history, opts);
+    case "openai-compatible":
+        return callOpenAICompatible(systemPrompt, history, opts);
+    case "gemini":
+    default:
+        return callGemini(systemPrompt, history, opts);
+    }
+}
 
 let advisorTemplate = "";
-let leaderTemplate  = "";
+let leaderTemplate = "";
 
 const promptsReady = fetch("/saves/save0/prompts.json")
-.then(res => res.json())
-.then(data => {
+.then((res) => res.json())
+.then((data) => {
     advisorTemplate = data.advisor ?? "";
-    leaderTemplate  = data.leader  ?? "";
+    leaderTemplate = data.leader ?? "";
 })
 .catch(() => { console.warn("Could not load prompts.json"); });
 
-// ── Advisor prompt builder ────────────────────────────────────────────────────
-
 async function buildAdvisorSystemPrompt() {
     await promptsReady;
-    const gameData   = await fetch("/saves/save0/game.json").then(res => res.json());
-    const actionData = await fetch("/saves/save0/storage/actions.json").then(res => res.json()).catch(() => []);
-    const chatData   = await fetch("/saves/save0/storage/chat.json").then(res => res.json()).catch(() => []);
+    const gameData = await fetch("/saves/save0/game.json").then((res) => res.json());
+    const actionData = await fetch("/saves/save0/storage/actions.json").then((res) => res.json()).catch(() => []);
+    const chatData = await fetch("/saves/save0/storage/chat.json").then((res) => res.json()).catch(() => []);
 
     return advisorTemplate
-    .replace(/\$\{country\}/g,   gameData.country)
+    .replace(/\$\{country\}/g, gameData.country)
     .replace(/\$\{startdate\}/g, gameData.startDate)
-    .replace(/\$\{date\}/g,      gameData.gameDate)
-    .replace(/\$\{actions\}/g,   actionData.join("\n"))
-    .replace(/\$\{chat\}/g,      JSON.stringify(chatData));
+    .replace(/\$\{date\}/g, gameData.gameDate)
+    .replace(/\$\{actions\}/g, actionData.join("\n"))
+    .replace(/\$\{chat\}/g, JSON.stringify(chatData));
 }
-
-// ── Diplomatic prompt builder ─────────────────────────────────────────────────
 
 export async function buildDiplomaticSystemPrompt(countries, playerCountry, gameDate) {
     await promptsReady;
-    const participantList = countries.map(c => `- ${c}`).join("\n");
-    const gameData   = await fetch("/saves/save0/game.json").then(res => res.json());
-    const actionData = await fetch("/saves/save0/storage/actions.json").then(res => res.json()).catch(() => []);
-    const chatData   = await fetch("/saves/save0/storage/chat.json").then(res => res.json()).catch(() => []);
+    const participantList = countries.map((country) => `- ${country}`).join("\n");
+    const gameData = await fetch("/saves/save0/game.json").then((res) => res.json());
+    const actionData = await fetch("/saves/save0/storage/actions.json").then((res) => res.json()).catch(() => []);
+    const chatData = await fetch("/saves/save0/storage/chat.json").then((res) => res.json()).catch(() => []);
 
     return leaderTemplate
     .replace(/\$\{participantList\}/g, participantList)
-    .replace(/\$\{country\}/g,   gameData.country)
+    .replace(/\$\{country\}/g, gameData.country)
     .replace(/\$\{startdate\}/g, gameData.startDate)
-    .replace(/\$\{date\}/g,      gameData.gameDate)
-    .replace(/\$\{actions\}/g,   actionData.join("\n"))
-    .replace(/\$\{chat\}/g,      JSON.stringify(chatData));
+    .replace(/\$\{date\}/g, gameData.gameDate)
+    .replace(/\$\{actions\}/g, actionData.join("\n"))
+    .replace(/\$\{chat\}/g, JSON.stringify(chatData));
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// ADVISOR — completely isolated state
-// ─────────────────────────────────────────────────────────────────────────────
 
 let advisorHistory = [];
 
-/** Send a message to the advisor. */
 export async function sendMessage(userMessage, opts) {
     const systemPrompt = await buildAdvisorSystemPrompt();
     advisorHistory.push({ role: "user", parts: [{ text: userMessage }] });
+
     try {
         const reply = await callAI(systemPrompt, advisorHistory, opts);
         advisorHistory.push({ role: "model", parts: [{ text: reply }] });
@@ -183,25 +492,19 @@ export async function sendMessage(userMessage, opts) {
     }
 }
 
-/** Restore advisor history from saved messages. */
 export function loadHistory(savedMessages) {
     advisorHistory = savedMessages
-    .filter(msg => msg.role === "user" || msg.role === "advisor")
-    .map(msg => ({
+    .filter((msg) => msg.role === "user" || msg.role === "advisor")
+    .map((msg) => ({
         role: msg.role === "user" ? "user" : "model",
         parts: [{ text: msg.text }],
     }));
 }
 
-/** Clear advisor history. */
 export function startChat() {
     advisorHistory = [];
     console.log("Advisor chat started. History cleared.");
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// DIPLOMATIC CHAT — completely isolated state, one instance at a time
-// ─────────────────────────────────────────────────────────────────────────────
 
 let diplomaticHistory = [];
 
@@ -211,14 +514,12 @@ export function startDiplomaticChat() {
 
 export function loadDiplomaticHistory(savedMessages) {
     diplomaticHistory = savedMessages
-    .filter(msg => ["user", "leader"].includes(msg.role))
-    .map(msg => ({
+    .filter((msg) => ["user", "leader"].includes(msg.role))
+    .map((msg) => ({
         role: msg.role === "user" ? "user" : "model",
         parts: [{ text: msg.text }],
     }));
 }
-
-// ── Reaction parser ───────────────────────────────────────────────────────────
 
 function parseReaction(raw) {
     const match = raw.match(/[\s]*REACTION\s*:\s*(\S+)\s*$/i);
@@ -233,7 +534,7 @@ export async function sendDiplomaticMessage(playerMessage, speakingAs, countries
 
     diplomaticHistory.push({ role: "user", parts: [{ text: playerMessage }] });
 
-    const turnInstruction = `[It is now ${speakingAs}'s turn to respond to the above. Respond only as the leader of ${speakingAs}, naturally, without prefixing your country name.\n\nOptionally, if the message warrants a emotional reaction (surprise, offense, delight, suspicion, confusion etc.), append a single line at the very end in this exact format:\nREACTION:<emoji>\n— use only a single emoji in utf-8 format after the colon, no spaces, no extra text. Otherwise omit it entirely.]`;
+    const turnInstruction = `[It is now ${speakingAs}'s turn to respond to the above. Respond only as the leader of ${speakingAs}, naturally, without prefixing your country name.\n\nOptionally, if the message warrants a emotional reaction (surprise, offense, delight, suspicion, confusion etc.), append a single line at the very end in this exact format:\nREACTION:<emoji>\n- use only a single emoji in utf-8 format after the colon, no spaces, no extra text. Otherwise omit it entirely.]`;
 
     const historyWithInstruction = [
         ...diplomaticHistory,

--- a/src/Game/AI/providerConfig.js
+++ b/src/Game/AI/providerConfig.js
@@ -1,0 +1,150 @@
+export const DEFAULT_PROVIDER = "gemini";
+
+export const PROVIDER_OPTIONS = [
+    {
+        value: "gemini",
+        label: "Gemini",
+        group: "Native APIs",
+        description: "Google AI Studio / Gemini API",
+        searchTerms: ["google", "ai studio", "generativelanguage"],
+    },
+    {
+        value: "openai",
+        label: "OpenAI",
+        group: "Native APIs",
+        description: "Official OpenAI API",
+        searchTerms: ["gpt", "o3", "o4", "responses", "chatgpt"],
+    },
+    {
+        value: "anthropic",
+        label: "Anthropic",
+        group: "Native APIs",
+        description: "Claude via Messages API",
+        searchTerms: ["claude", "haiku", "sonnet", "opus"],
+    },
+    {
+        value: "openai-compatible",
+        label: "OpenAI Compatible",
+        group: "Gateways and self-hosted",
+        description: "Ollama, LM Studio, OpenRouter, local gateways",
+        searchTerms: ["ollama", "lm studio", "openrouter", "vllm", "gateway", "proxy"],
+    },
+];
+
+const PROVIDER_SETTINGS = {
+    gemini: {
+        apiKey: { storageKey: "gemini_api_key", defaultValue: "" },
+        model: { storageKey: "gemini_model", defaultValue: "gemini-3.1-flash-lite-preview" },
+    },
+    openai: {
+        apiKey: { storageKey: "openai_api_key", defaultValue: "" },
+        model: { storageKey: "openai_model", defaultValue: "" },
+    },
+    anthropic: {
+        apiKey: { storageKey: "anthropic_api_key", defaultValue: "" },
+        model: { storageKey: "anthropic_model", defaultValue: "claude-haiku-4-5" },
+    },
+    "openai-compatible": {
+        apiKey: { storageKey: "openai_compatible_api_key", defaultValue: "" },
+        endpoint: {
+            storageKey: "openai_compatible_endpoint",
+            legacyKeys: ["custom_api_endpoint"],
+            defaultValue: "http://localhost:11434/v1",
+        },
+        model: {
+            storageKey: "openai_compatible_model",
+            legacyKeys: ["custom_api_model"],
+            defaultValue: "",
+        },
+    },
+};
+
+const FORM_FIELD_MAP = {
+    geminiApiKey: { provider: "gemini", field: "apiKey" },
+    geminiModel: { provider: "gemini", field: "model" },
+    openaiApiKey: { provider: "openai", field: "apiKey" },
+    openaiModel: { provider: "openai", field: "model" },
+    anthropicApiKey: { provider: "anthropic", field: "apiKey" },
+    anthropicModel: { provider: "anthropic", field: "model" },
+    openaiCompatibleApiKey: { provider: "openai-compatible", field: "apiKey" },
+    openaiCompatibleEndpoint: { provider: "openai-compatible", field: "endpoint" },
+    openaiCompatibleModel: { provider: "openai-compatible", field: "model" },
+};
+
+function isSupportedProvider(value) {
+    return PROVIDER_OPTIONS.some((provider) => provider.value === value);
+}
+
+function readStoredValue(setting) {
+    if (!setting?.storageKey) return setting?.defaultValue ?? "";
+
+    const primaryValue = localStorage.getItem(setting.storageKey);
+    if (primaryValue !== null) return primaryValue;
+
+    for (const legacyKey of setting.legacyKeys ?? []) {
+        const legacyValue = localStorage.getItem(legacyKey);
+        if (legacyValue !== null) return legacyValue;
+    }
+
+    return setting.defaultValue ?? "";
+}
+
+function getSettingConfig(provider, field) {
+    return PROVIDER_SETTINGS[normalizeProvider(provider)]?.[field] ?? null;
+}
+
+export function normalizeProvider(provider) {
+    if (provider === "custom") return "openai-compatible";
+    return isSupportedProvider(provider) ? provider : DEFAULT_PROVIDER;
+}
+
+export function getStoredProvider() {
+    return normalizeProvider(localStorage.getItem("api_provider"));
+}
+
+export function getProviderMeta(provider) {
+    return PROVIDER_OPTIONS.find((option) => option.value === normalizeProvider(provider))
+        ?? PROVIDER_OPTIONS[0];
+}
+
+export function providerSupportsModelDiscovery(provider) {
+    const normalized = normalizeProvider(provider);
+    return normalized === "openai" || normalized === "openai-compatible";
+}
+
+export function getProviderField(provider, field) {
+    const setting = getSettingConfig(provider, field);
+    return setting ? readStoredValue(setting) : "";
+}
+
+export function setProviderField(provider, field, value) {
+    const setting = getSettingConfig(provider, field);
+    if (!setting?.storageKey) return;
+    localStorage.setItem(setting.storageKey, value ?? "");
+}
+
+export function getProviderSettings(provider) {
+    const normalized = normalizeProvider(provider);
+    return {
+        provider: normalized,
+        apiKey: getProviderField(normalized, "apiKey"),
+        endpoint: getProviderField(normalized, "endpoint"),
+        model: getProviderField(normalized, "model"),
+    };
+}
+
+export function loadProviderSettingsFormState() {
+    const state = {};
+
+    for (const [stateKey, mapping] of Object.entries(FORM_FIELD_MAP)) {
+        state[stateKey] = getProviderField(mapping.provider, mapping.field);
+    }
+
+    return state;
+}
+
+export function persistProviderSetting(stateKey, value) {
+    const mapping = FORM_FIELD_MAP[stateKey];
+    if (!mapping) return;
+    setProviderField(mapping.provider, mapping.field, value);
+}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -5,6 +5,12 @@ import { DateWidget } from "./time";
 import { Other } from "./other";
 import { Toolbar } from "./chat";
 import { Search } from "./search";
+import {
+  getStoredProvider,
+  loadProviderSettingsFormState,
+  normalizeProvider,
+  persistProviderSetting,
+} from "../AI/providerConfig.js";
 
 const checkWebGL = () => {
   try {
@@ -62,9 +68,8 @@ const Main = ({ mapRef }) => {
   const [showWebGLWarning, setShowWebGLWarning] = useState(false);
 
   // API provider state
-  const [apiProvider, setApiProvider] = useState(() => localStorage.getItem("api_provider") || "gemini");
-  const [geminiKey, setGeminiKey] = useState(() => localStorage.getItem("gemini_api_key") || "");
-  const [customApiEndpoint, setCustomApiEndpoint] = useState(() => localStorage.getItem("custom_api_endpoint") || "http://localhost:11434/v1");
+  const [apiProvider, setApiProvider] = useState(() => getStoredProvider());
+  const [providerSettings, setProviderSettings] = useState(() => loadProviderSettingsFormState());
 
   const [isGlobeEnabled, setIsGlobeEnabled] = useState(() => {
     const saved = localStorage.getItem("Globe");
@@ -82,9 +87,18 @@ const Main = ({ mapRef }) => {
     useEffect(() => { localStorage.setItem("Fullscreen", JSON.stringify(isFullscreenEnabled)); }, [isFullscreenEnabled]);
     useEffect(() => { localStorage.setItem("Globe", JSON.stringify(isGlobeEnabled)); }, [isGlobeEnabled]);
     useEffect(() => { localStorage.setItem("Terrain", JSON.stringify(isTerrainEnabled)); }, [isTerrainEnabled]);
-    useEffect(() => { localStorage.setItem("gemini_api_key", geminiKey); }, [geminiKey]);
-    useEffect(() => { localStorage.setItem("custom_api_endpoint", customApiEndpoint); }, [customApiEndpoint]);
-    useEffect(() => { localStorage.setItem("api_provider", apiProvider); }, [apiProvider]);
+    useEffect(() => { localStorage.setItem("api_provider", normalizeProvider(apiProvider)); }, [apiProvider]);
+    useEffect(() => {
+      if (isSettingsOpen) {
+        setApiProvider(getStoredProvider());
+        setProviderSettings(loadProviderSettingsFormState());
+      }
+    }, [isSettingsOpen]);
+
+    const handleProviderSettingChange = (key, value) => {
+      setProviderSettings((prev) => ({ ...prev, [key]: value }));
+      persistProviderSetting(key, value);
+    };
 
     const toggleFullscreen = (shouldBeFull) => {
       if (shouldBeFull) {
@@ -105,11 +119,6 @@ const Main = ({ mapRef }) => {
       document.addEventListener("fullscreenchange", handleFullscreenChange);
       return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
     }, []);
-
-    // Derive the active config for use anywhere in the app
-    const activeApiConfig = apiProvider === "gemini"
-    ? { provider: "gemini", apiKey: geminiKey, endpoint: null }
-    : { provider: "custom", apiKey: null, endpoint: customApiEndpoint };
 
     const rightShift = isAdvisorOpen ? `calc(${ADVISOR_PANEL_WIDTH} + 0.5rem)` : "0.5rem";
 
@@ -143,10 +152,8 @@ const Main = ({ mapRef }) => {
         onToggleTerrain={() => setIsTerrainEnabled(!isTerrainEnabled)}
         apiProvider={apiProvider}
         onApiProviderChange={setApiProvider}
-        geminiKey={geminiKey}
-        onGeminiKeyChange={setGeminiKey}
-        customApiEndpoint={customApiEndpoint}
-        onCustomApiEndpointChange={setCustomApiEndpoint}
+        providerSettings={providerSettings}
+        onProviderSettingChange={handleProviderSettingChange}
         />
       )}
       </>

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -1,4 +1,10 @@
 import React, { useEffect, useState } from "react";
+import {
+    DEFAULT_PROVIDER,
+    PROVIDER_OPTIONS,
+    getProviderMeta,
+    providerSupportsModelDiscovery,
+} from "../AI/providerConfig.js";
 
 const baseStyle = {
     position: "fixed",
@@ -14,6 +20,70 @@ const baseStyle = {
     border: "1px solid rgba(255,255,255,0.1)",
     boxShadow: "0 4px 6px -1px rgba(0,0,0,0.2)",
 };
+
+const labelStyle = {
+    display: "block",
+    fontSize: "0.82rem",
+    marginBottom: "0.45rem",
+    color: "rgba(255,255,255,0.92)",
+    cursor: "text",
+};
+
+const inputStyle = {
+    width: "100%",
+    padding: "0.65rem 0.7rem",
+    borderRadius: "8px",
+    border: "1px solid rgba(255,255,255,0.16)",
+    backgroundColor: "rgba(0,0,0,0.22)",
+    color: "white",
+    fontSize: "0.85rem",
+    outline: "none",
+    boxSizing: "border-box",
+    cursor: "text",
+};
+
+const helperStyle = {
+    marginTop: "0.35rem",
+    fontSize: "0.74rem",
+    color: "rgba(255,255,255,0.58)",
+    lineHeight: 1.45,
+};
+
+const fieldGroupStyle = {
+    marginBottom: "0.85rem",
+};
+
+function providerMatchesQuery(option, query) {
+    if (!query) return true;
+
+    const haystack = [
+        option.label,
+        option.group,
+        option.description,
+        ...(option.searchTerms ?? []),
+    ]
+    .join(" ")
+    .toLowerCase();
+
+    return haystack.includes(query);
+}
+
+function groupProviders(options) {
+    const groups = [];
+
+    for (const option of options) {
+        let group = groups.find((entry) => entry.name === option.group);
+
+        if (!group) {
+            group = { name: option.group, items: [] };
+            groups.push(group);
+        }
+
+        group.items.push(option);
+    }
+
+    return groups;
+}
 
 const Toggle = ({ label, enabled, onToggle }) => (
     <div
@@ -49,108 +119,292 @@ const Toggle = ({ label, enabled, onToggle }) => (
         borderRadius: "50%",
         transition: "0.3s",
         boxShadow: "0 1px 2px rgba(0,0,0,0.2)",
-                                                  pointerEvents: "none",
+        pointerEvents: "none",
     }}
     />
     </button>
     </div>
 );
 
-const ApiProviderSelector = ({ provider, onProviderChange }) => (
-    <div style={{ marginBottom: "1rem" }}>
-    <label style={{ display: "block", fontSize: "0.9rem", marginBottom: "0.5rem", color: "white" }}>
-    AI Provider
-    </label>
-    <div style={{ display: "flex", gap: "0.5rem" }}>
-    {[
-        { value: "gemini", label: "Gemini" },
-        { value: "custom", label: "Custom API" },
-    ].map(({ value, label }) => (
-        <button
-        key={value}
-        onClick={() => onProviderChange(value)}
-        style={{
-            flex: 1,
-            padding: "0.45rem 0",
-            borderRadius: "6px",
-            border: "1px solid",
-            borderColor: provider === value ? "#3b82f6" : "rgba(255,255,255,0.15)",
-                                 backgroundColor: provider === value ? "rgba(59,130,246,0.25)" : "rgba(0,0,0,0.2)",
-                                 color: "white",
-                                 fontSize: "0.85rem",
-                                 fontWeight: provider === value ? 600 : 400,
-                                 cursor: "pointer",
-                                 transition: "0.2s",
-        }}
-        >
-        {label}
-        </button>
-    ))}
-    </div>
-    </div>
-);
+const ApiProviderSelector = ({ provider, onProviderChange }) => {
+    const [isCatalogOpen, setIsCatalogOpen] = useState(false);
+    const [query, setQuery] = useState("");
+    const selectedProvider = getProviderMeta(provider);
+    const normalizedQuery = query.trim().toLowerCase();
+    const filteredProviders = PROVIDER_OPTIONS.filter((option) => providerMatchesQuery(option, normalizedQuery));
+    const groupedProviders = groupProviders(filteredProviders);
 
-const ApiKeyInput = ({ label, storageKey, value, onChange }) => {
-    const handleChange = (newVal) => {
-        onChange(newVal);
-        localStorage.setItem(storageKey, newVal);
+    useEffect(() => {
+        setQuery("");
+        setIsCatalogOpen(false);
+    }, [provider]);
+
+    const handleProviderSelect = (value) => {
+        onProviderChange(value);
+        setQuery("");
+        setIsCatalogOpen(false);
     };
 
     return (
         <div style={{ marginBottom: "1rem" }}>
-        <label style={{ display: "block", fontSize: "0.9rem", marginBottom: "0.5rem", color: "white", cursor: "text" }}>
-        {label}
+        <label style={{ display: "block", fontSize: "0.9rem", marginBottom: "0.6rem", color: "white" }}>
+        AI Provider
         </label>
-        <input
-        type="password"
-        value={value}
-        onChange={(e) => handleChange(e.target.value)}
-        placeholder="Enter API Key..."
+
+        <button
+        onClick={() => setIsCatalogOpen((prev) => !prev)}
         style={{
             width: "100%",
-            padding: "0.6rem",
-            borderRadius: "6px",
-            border: "1px solid rgba(255,255,255,0.2)",
-            backgroundColor: "rgba(0,0,0,0.2)",
+            padding: "0.8rem 0.9rem",
+            borderRadius: "10px",
+            border: "1px solid rgba(255,255,255,0.12)",
+            backgroundColor: "rgba(0,0,0,0.18)",
             color: "white",
-            fontSize: "0.85rem",
-            outline: "none",
-            boxSizing: "border-box",
-            cursor: "text",
+            cursor: "pointer",
+            textAlign: "left",
         }}
-        />
+        >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.75rem" }}>
+        <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: "0.9rem", fontWeight: 700 }}>
+        {selectedProvider.label}
+        </div>
+        <div style={{ marginTop: "0.2rem", fontSize: "0.72rem", color: "rgba(255,255,255,0.6)", lineHeight: 1.45 }}>
+        {selectedProvider.group} · {selectedProvider.description}
+        </div>
+        </div>
+        <div style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+        {isCatalogOpen ? "Hide" : "Change"}
+        </div>
+        </div>
+        </button>
+
+        <div style={{ ...helperStyle, marginBottom: isCatalogOpen ? "0.65rem" : 0 }}>
+        Searchable catalog instead of a wall of provider buttons.
+        </div>
+
+        {isCatalogOpen && (
+            <div
+            style={{
+                marginTop: "0.7rem",
+                padding: "0.75rem",
+                borderRadius: "10px",
+                border: "1px solid rgba(255,255,255,0.1)",
+                backgroundColor: "rgba(255,255,255,0.04)",
+            }}
+            >
+            <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search provider, protocol or gateway..."
+            autoComplete="off"
+            spellCheck={false}
+            style={{
+                ...inputStyle,
+                marginBottom: "0.65rem",
+            }}
+            />
+
+            <div style={{ maxHeight: "12rem", overflowY: "auto", display: "flex", flexDirection: "column", gap: "0.7rem" }}>
+            {groupedProviders.length > 0 ? groupedProviders.map((group) => (
+                <div key={group.name}>
+                <div style={{ marginBottom: "0.35rem", fontSize: "0.68rem", fontWeight: 700, color: "rgba(255,255,255,0.45)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                {group.name}
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
+                {group.items.map((option) => {
+                    const selected = option.value === provider;
+
+                    return (
+                        <button
+                        key={option.value}
+                        onClick={() => handleProviderSelect(option.value)}
+                        style={{
+                            width: "100%",
+                            padding: "0.7rem 0.75rem",
+                            borderRadius: "8px",
+                            border: "1px solid",
+                            borderColor: selected ? "rgba(59,130,246,0.8)" : "rgba(255,255,255,0.08)",
+                            backgroundColor: selected ? "rgba(59,130,246,0.18)" : "rgba(0,0,0,0.16)",
+                            color: "white",
+                            cursor: "pointer",
+                            textAlign: "left",
+                        }}
+                        >
+                        <div style={{ display: "flex", justifyContent: "space-between", gap: "0.75rem", alignItems: "center" }}>
+                        <span style={{ fontSize: "0.84rem", fontWeight: selected ? 700 : 600 }}>
+                        {option.label}
+                        </span>
+                        {selected && (
+                            <span style={{ fontSize: "0.68rem", color: "#93c5fd", fontWeight: 700 }}>
+                            Active
+                            </span>
+                        )}
+                        </div>
+                        <div style={{ marginTop: "0.18rem", fontSize: "0.72rem", lineHeight: 1.4, color: "rgba(255,255,255,0.6)" }}>
+                        {option.description}
+                        </div>
+                        </button>
+                    );
+                })}
+                </div>
+                </div>
+            )) : (
+                <div style={{ ...helperStyle, marginTop: 0 }}>
+                Nothing matched the search.
+                </div>
+            )}
+            </div>
+            </div>
+        )}
         </div>
     );
 };
 
-const CustomApiFields = ({ endpoint, onEndpointChange }) => (
-    <div style={{ marginBottom: "1rem" }}>
-    <label style={{ display: "block", fontSize: "0.9rem", marginBottom: "0.5rem", color: "white", cursor: "text" }}>
-    API Endpoint
+const SettingsInput = ({
+    label,
+    value,
+    onChange,
+    placeholder,
+    type = "text",
+    helperText,
+}) => (
+    <div style={fieldGroupStyle}>
+    <label style={labelStyle}>
+    {label}
     </label>
     <input
-    type="text"
-    value={endpoint}
-    onChange={(e) => {
-        onEndpointChange(e.target.value);
-        localStorage.setItem("custom_api_endpoint", e.target.value);
-    }}
-    placeholder="http://localhost:11434/v1"
-    style={{
-        width: "100%",
-        padding: "0.6rem",
-        borderRadius: "6px",
-        border: "1px solid rgba(255,255,255,0.2)",
-                                                             backgroundColor: "rgba(0,0,0,0.2)",
-                                                             color: "white",
-                                                             fontSize: "0.85rem",
-                                                             outline: "none",
-                                                             boxSizing: "border-box",
-                                                             cursor: "text",
-    }}
+    type={type}
+    value={value}
+    onChange={(event) => onChange(event.target.value)}
+    placeholder={placeholder}
+    autoComplete="off"
+    spellCheck={false}
+    style={inputStyle}
     />
+    {helperText && (
+        <div style={helperStyle}>
+        {helperText}
+        </div>
+    )}
     </div>
 );
+
+const ProviderSettingsPanel = ({ provider, settings, onSettingChange }) => {
+    const meta = getProviderMeta(provider);
+    const supportsModelDiscovery = providerSupportsModelDiscovery(provider);
+
+    return (
+        <div
+        style={{
+            marginBottom: "1rem",
+            padding: "0.85rem",
+            borderRadius: "10px",
+            border: "1px solid rgba(255,255,255,0.1)",
+            backgroundColor: "rgba(255,255,255,0.04)",
+        }}
+        >
+        <div style={{ fontSize: "0.84rem", fontWeight: 700, marginBottom: "0.25rem" }}>
+        {meta.label} Settings
+        </div>
+        <div style={{ ...helperStyle, marginTop: 0, marginBottom: "0.85rem" }}>
+        {meta.description}
+        </div>
+
+        {provider === "gemini" && (
+            <>
+            <SettingsInput
+            label="Gemini API Key"
+            type="password"
+            value={settings.geminiApiKey ?? ""}
+            onChange={(value) => onSettingChange("geminiApiKey", value)}
+            placeholder="Paste Gemini API key"
+            helperText="Stored only in this browser."
+            />
+            <SettingsInput
+            label="Model"
+            value={settings.geminiModel ?? ""}
+            onChange={(value) => onSettingChange("geminiModel", value)}
+            placeholder="gemini-3.1-flash-lite-preview"
+            helperText="Leave blank to use the built-in Gemini default."
+            />
+            </>
+        )}
+
+        {provider === "openai" && (
+            <>
+            <SettingsInput
+            label="OpenAI API Key"
+            type="password"
+            value={settings.openaiApiKey ?? ""}
+            onChange={(value) => onSettingChange("openaiApiKey", value)}
+            placeholder="Paste OpenAI API key"
+            helperText="Stored only in this browser."
+            />
+            <SettingsInput
+            label="Model"
+            value={settings.openaiModel ?? ""}
+            onChange={(value) => onSettingChange("openaiModel", value)}
+            placeholder="gpt-..."
+            helperText={
+                supportsModelDiscovery
+                    ? "Leave blank to auto-pick a chat-capable model from /v1/models."
+                    : "Enter the exact model id."
+            }
+            />
+            </>
+        )}
+
+        {provider === "anthropic" && (
+            <>
+            <SettingsInput
+            label="Anthropic API Key"
+            type="password"
+            value={settings.anthropicApiKey ?? ""}
+            onChange={(value) => onSettingChange("anthropicApiKey", value)}
+            placeholder="Paste Anthropic API key"
+            helperText="Stored only in this browser."
+            />
+            <SettingsInput
+            label="Model"
+            value={settings.anthropicModel ?? ""}
+            onChange={(value) => onSettingChange("anthropicModel", value)}
+            placeholder="claude-haiku-4-5"
+            helperText="Claude model ids are manual here. Leave blank to use the built-in default."
+            />
+            </>
+        )}
+
+        {provider === "openai-compatible" && (
+            <>
+            <SettingsInput
+            label="API Endpoint"
+            value={settings.openaiCompatibleEndpoint ?? ""}
+            onChange={(value) => onSettingChange("openaiCompatibleEndpoint", value)}
+            placeholder="http://localhost:11434/v1"
+            helperText="Base URL that exposes /chat/completions and /models."
+            />
+            <SettingsInput
+            label="API Key (optional)"
+            type="password"
+            value={settings.openaiCompatibleApiKey ?? ""}
+            onChange={(value) => onSettingChange("openaiCompatibleApiKey", value)}
+            placeholder="Leave empty for local Ollama"
+            helperText="Use a bearer token if your gateway requires authentication."
+            />
+            <SettingsInput
+            label="Model"
+            value={settings.openaiCompatibleModel ?? ""}
+            onChange={(value) => onSettingChange("openaiCompatibleModel", value)}
+            placeholder="llama / qwen / gpt / mistral"
+            helperText="Leave blank to auto-pick a model from /models."
+            />
+            </>
+        )}
+        </div>
+    );
+};
 
 const SocialLinks = ({ discordUrl, githubUrl }) => (
     <div
@@ -177,21 +431,21 @@ const SocialLinks = ({ discordUrl, githubUrl }) => (
             padding: "0.5rem",
             borderRadius: "8px",
             border: "1px solid rgba(255,255,255,0.1)",
-                    backgroundColor: "rgba(88, 101, 242, 0.2)",
-                    color: "white",
-                    textDecoration: "none",
-                    fontSize: "0.8rem",
-                    fontWeight: 500,
-                    transition: "background-color 0.2s, border-color 0.2s",
-                    cursor: "pointer",
+            backgroundColor: "rgba(88, 101, 242, 0.2)",
+            color: "white",
+            textDecoration: "none",
+            fontSize: "0.8rem",
+            fontWeight: 500,
+            transition: "background-color 0.2s, border-color 0.2s",
+            cursor: "pointer",
         }}
-        onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = "rgba(88, 101, 242, 0.45)";
-            e.currentTarget.style.borderColor = "rgba(88, 101, 242, 0.6)";
+        onMouseEnter={(event) => {
+            event.currentTarget.style.backgroundColor = "rgba(88, 101, 242, 0.45)";
+            event.currentTarget.style.borderColor = "rgba(88, 101, 242, 0.6)";
         }}
-        onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = "rgba(88, 101, 242, 0.2)";
-            e.currentTarget.style.borderColor = "rgba(255,255,255,0.1)";
+        onMouseLeave={(event) => {
+            event.currentTarget.style.backgroundColor = "rgba(88, 101, 242, 0.2)";
+            event.currentTarget.style.borderColor = "rgba(255,255,255,0.1)";
         }}
         >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -215,21 +469,21 @@ const SocialLinks = ({ discordUrl, githubUrl }) => (
             padding: "0.5rem",
             borderRadius: "8px",
             border: "1px solid rgba(255,255,255,0.1)",
-                   backgroundColor: "rgba(255,255,255,0.07)",
-                   color: "white",
-                   textDecoration: "none",
-                   fontSize: "0.8rem",
-                   fontWeight: 500,
-                   transition: "background-color 0.2s, border-color 0.2s",
-                   cursor: "pointer",
+            backgroundColor: "rgba(255,255,255,0.07)",
+            color: "white",
+            textDecoration: "none",
+            fontSize: "0.8rem",
+            fontWeight: 500,
+            transition: "background-color 0.2s, border-color 0.2s",
+            cursor: "pointer",
         }}
-        onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = "rgba(255,255,255,0.15)";
-            e.currentTarget.style.borderColor = "rgba(255,255,255,0.3)";
+        onMouseEnter={(event) => {
+            event.currentTarget.style.backgroundColor = "rgba(255,255,255,0.15)";
+            event.currentTarget.style.borderColor = "rgba(255,255,255,0.3)";
         }}
-        onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = "rgba(255,255,255,0.07)";
-            e.currentTarget.style.borderColor = "rgba(255,255,255,0.1)";
+        onMouseLeave={(event) => {
+            event.currentTarget.style.backgroundColor = "rgba(255,255,255,0.07)";
+            event.currentTarget.style.borderColor = "rgba(255,255,255,0.1)";
         }}
         >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -265,35 +519,14 @@ const SettingsMenu = ({
     onToggleFullscreen,
     onToggleGlobe,
     onToggleTerrain,
-    geminiKey,
-    onGeminiKeyChange,
     apiProvider,
     onApiProviderChange,
-    customApiEndpoint,
-    onCustomApiEndpointChange,
+    providerSettings,
+    onProviderSettingChange,
     discordUrl,
     githubUrl,
 }) => {
-    useEffect(() => {
-        const savedGemini = localStorage.getItem("gemini_api_key");
-        if (savedGemini && !geminiKey) onGeminiKeyChange(savedGemini);
-
-        const savedEndpoint = localStorage.getItem("custom_api_endpoint");
-        if (savedEndpoint && !customApiEndpoint) onCustomApiEndpointChange?.(savedEndpoint);
-
-        const savedProvider = localStorage.getItem("api_provider");
-        if (savedProvider && !apiProvider) onApiProviderChange?.(savedProvider);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-    const handleProviderChange = (value) => {
-        onApiProviderChange?.(value);
-        localStorage.setItem("api_provider", value);
-    };
-
-    const handleGeminiKeyChange = (value) => {
-        onGeminiKeyChange(value);
-        localStorage.setItem("gemini_api_key", value);
-    };
+    const selectedProvider = apiProvider ?? DEFAULT_PROVIDER;
 
     return (
         <div
@@ -301,7 +534,10 @@ const SettingsMenu = ({
             ...baseStyle,
             top: "4.5rem",
             left: "0.5rem",
-            width: "18rem",
+            width: "22rem",
+            maxWidth: "calc(100vw - 1rem)",
+            maxHeight: "calc(100vh - 5rem)",
+            overflowY: "auto",
             padding: "1rem",
             flexDirection: "column",
             alignItems: "stretch",
@@ -309,36 +545,28 @@ const SettingsMenu = ({
             height: "auto",
         }}
         >
-        <h3 style={{
+        <h3
+        style={{
             margin: "0 -1rem 1rem -1rem",
             padding: "0 1rem 1rem 1rem",
             fontSize: "1.1rem",
             textAlign: "left",
-            borderBottom: "1px solid rgba(255,255,255,0.1)"
-        }}>
+            borderBottom: "1px solid rgba(255,255,255,0.1)",
+        }}
+        >
         Game Settings
         </h3>
 
         <ApiProviderSelector
-        provider={apiProvider ?? "gemini"}
-        onProviderChange={handleProviderChange}
+        provider={selectedProvider}
+        onProviderChange={onApiProviderChange ?? (() => {})}
         />
 
-        {(apiProvider ?? "gemini") === "gemini" && (
-            <ApiKeyInput
-            label="Gemini API Key"
-            storageKey="gemini_api_key"
-            value={geminiKey}
-            onChange={handleGeminiKeyChange}
-            />
-        )}
-
-        {apiProvider === "custom" && (
-            <CustomApiFields
-            endpoint={customApiEndpoint ?? ""}
-            onEndpointChange={onCustomApiEndpointChange ?? (() => {})}
-            />
-        )}
+        <ProviderSettingsPanel
+        provider={selectedProvider}
+        settings={providerSettings ?? {}}
+        onSettingChange={onProviderSettingChange ?? (() => {})}
+        />
 
         <Toggle label="Fullscreen" enabled={isFullscreenEnabled} onToggle={onToggleFullscreen} />
         <Toggle label="3D Globe" enabled={isGlobeEnabled} onToggle={onToggleGlobe} />
@@ -349,4 +577,4 @@ const SettingsMenu = ({
     );
 };
 
-export { Toggle, SettingsButton, SettingsMenu, ApiProviderSelector, ApiKeyInput, SocialLinks };
+export { Toggle, SettingsButton, SettingsMenu, ApiProviderSelector, SocialLinks };


### PR DESCRIPTION
ai provider api overhaul

gemini now catches 429 and tells you your balance is gone instead of a generic error

added openai, anthropic and openai compatible as providers. openai compatible is for anything that speaks the same api format like ollama, together, local stuff etc

you can plug in your own models now. by default it pulls the list from /v1/models (or whatever the provider exposes) but you can just override it and type in whatever model name you want