### PR TITLE
small ui fixes

### DIFF
--- a/src/Game/GameUI/actions.jsx
+++ b/src/Game/GameUI/actions.jsx
@@ -334,14 +334,12 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
     );
 };
 
-const Actions = ({ onOpenAdvisor, hovered, setHovered, isActive }) => {
-    const [actionsOpen, setActionsOpen] = React.useState(false);
-
+const Actions = ({ onOpenAdvisor, hovered, setHovered, isOpen, onToggle }) => {
     return (
         <>
         <ActionsPanel
-        isOpen={actionsOpen}
-        onClose={() => setActionsOpen(false)}
+        isOpen={isOpen}
+        onClose={onToggle}
         onOpenAdvisor={onOpenAdvisor}
         />
         <button
@@ -352,10 +350,10 @@ const Actions = ({ onOpenAdvisor, hovered, setHovered, isActive }) => {
             borderRadius: "10px",
             border: hovered
             ? "1px solid rgba(255,255,255,0.2)"
-            : actionsOpen
+            : isOpen
             ? "1px solid rgba(139,92,246,0.5)"
             : "1px solid rgba(255,255,255,0.1)",
-            background: actionsOpen
+            background: isOpen
             ? "linear-gradient(145deg, rgba(109,40,217,0.4), rgba(76,29,149,0.4))"
             : hovered
             ? "linear-gradient(145deg, rgba(40,55,80,0.95), rgba(20,30,50,0.95))"
@@ -376,7 +374,7 @@ const Actions = ({ onOpenAdvisor, hovered, setHovered, isActive }) => {
         }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onClick={() => setActionsOpen(o => !o)}
+        onClick={onToggle}
         >
         ⚡
         </button>

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -837,12 +837,13 @@ const ChatPanel = ({ isOpen, onClose }) => {
 
 // ── Chat toolbar button ───────────────────────────────────────────────────────
 
-const Chat = ({ hovered, setHovered }) => {
-    const [chatOpen, setChatOpen] = useState(false);
+const Chat = ({ hovered, setHovered, isOpen, onToggle }) => {
+    const chatOpen = isOpen;
+    const setChatOpen = () => { onToggle(); };
     return (
         <>
-        <ChatPanel isOpen={chatOpen} onClose={() => setChatOpen(false)} />
-        <button title="Chat" style={{ width: "3.3rem", height: "3.3rem", borderRadius: "10px", border: hovered ? "1px solid rgba(255,255,255,0.2)" : chatOpen ? "1px solid rgba(139,92,246,0.5)" : "1px solid rgba(255,255,255,0.1)", background: chatOpen ? "linear-gradient(145deg,rgba(109,40,217,0.4),rgba(76,29,149,0.4))" : hovered ? "linear-gradient(145deg,rgba(40,55,80,0.95),rgba(20,30,50,0.95))" : "linear-gradient(145deg,rgba(30,42,65,0.95),rgba(15,22,40,0.95))", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", transition: "all 0.12s ease", boxShadow: hovered ? "inset 0 1px 0 rgba(255,255,255,0.1),0 2px 8px rgba(0,0,0,0.4)" : "inset 0 1px 0 rgba(255,255,255,0.06),inset 0 -1px 0 rgba(0,0,0,0.3),0 2px 6px rgba(0,0,0,0.35)", fontSize: "1.2rem", outline: "none", transform: hovered ? "translateY(-1px)" : "translateY(0)", color: "white", fontFamily: "sans-serif", flexShrink: 0 }}
+        <ChatPanel isOpen={isOpen} onClose={onToggle} />
+        <button title="Chat" style={{ width: "3.3rem", height: "3.3rem", borderRadius: "10px", border: hovered ? "1px solid rgba(255,255,255,0.2)" : isOpen ? "1px solid rgba(139,92,246,0.5)" : "1px solid rgba(255,255,255,0.1)", background: isOpen ? "linear-gradient(145deg,rgba(109,40,217,0.4),rgba(76,29,149,0.4))" : hovered ? "linear-gradient(145deg,rgba(40,55,80,0.95),rgba(20,30,50,0.95))" : "linear-gradient(145deg,rgba(30,42,65,0.95),rgba(15,22,40,0.95))", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", transition: "all 0.12s ease", boxShadow: hovered ? "inset 0 1px 0 rgba(255,255,255,0.1),0 2px 8px rgba(0,0,0,0.4)" : "inset 0 1px 0 rgba(255,255,255,0.06),inset 0 -1px 0 rgba(0,0,0,0.3),0 2px 6px rgba(0,0,0,0.35)", fontSize: "1.2rem", outline: "none", transform: hovered ? "translateY(-1px)" : "translateY(0)", color: "white", fontFamily: "sans-serif", flexShrink: 0 }}
         onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
         onClick={() => setChatOpen(o => !o)}>💬</button>
         </>
@@ -851,13 +852,13 @@ const Chat = ({ hovered, setHovered }) => {
 
 // ── Toolbar ───────────────────────────────────────────────────────────────────
 
-const Toolbar = ({ onOpenAdvisor }) => {
+const Toolbar = ({ onOpenAdvisor, activePanel, onTogglePanel }) => {
     const [hoveredChat, setHoveredChat]       = useState(false);
     const [hoveredActions, setHoveredActions] = useState(false);
     return (
         <div style={{ position: "fixed", bottom: "0.5rem", left: "0.5rem", height: "4rem", width: "8.5rem", gap: "0.75rem", padding: "0 0.1rem", backgroundColor: "rgba(17,24,39,0.9)", backdropFilter: "blur(4px)", zIndex: 9999, display: "flex", alignItems: "center", justifyContent: "center", color: "white", fontFamily: "sans-serif", borderRadius: "14px", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 8px 24px rgba(0,0,0,0.5),inset 0 1px 0 rgba(255,255,255,0.05)" }}>
-        <Chat hovered={hoveredChat} setHovered={setHoveredChat} />
-        <Actions onOpenAdvisor={onOpenAdvisor} hovered={hoveredActions} setHovered={setHoveredActions} />
+        <Chat hovered={hoveredChat} setHovered={setHoveredChat} isOpen={activePanel === "chat"} onToggle={() => onTogglePanel("chat")} />
+        <Actions onOpenAdvisor={onOpenAdvisor} hovered={hoveredActions} setHovered={setHoveredActions} isOpen={activePanel === "actions"} onToggle={() => onTogglePanel("actions")} />
         </div>
     );
 };

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -58,6 +58,7 @@ const WebGLWarningPopup = ({ onDismiss }) => (
 const Main = ({ mapRef }) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isAdvisorOpen, setIsAdvisorOpen] = useState(false);
+  const [activeBottomPanel, setActiveBottomPanel] = useState(null);
   const [isFullscreenEnabled, setIsFullscreenEnabled] = useState(false);
   const [showWebGLWarning, setShowWebGLWarning] = useState(false);
 
@@ -112,12 +113,26 @@ const Main = ({ mapRef }) => {
     : { provider: "custom", apiKey: null, endpoint: customApiEndpoint };
 
     const rightShift = isAdvisorOpen ? `calc(${ADVISOR_PANEL_WIDTH} + 0.5rem)` : "0.5rem";
+    const toggleBottomPanel = (panelName) => {
+      setActiveBottomPanel((currentPanel) => (
+        currentPanel === panelName ? null : panelName
+      ));
+    };
 
     return (
       <>
       {showWebGLWarning && <WebGLWarningPopup />}
-      <DateWidget rightShift={rightShift} />
-      <Toolbar onOpenAdvisor={() => setIsAdvisorOpen(true)} />
+      <DateWidget
+      rightShift={rightShift}
+      isTimelineOpen={activeBottomPanel === "timeline"}
+      onToggleTimeline={() => toggleBottomPanel("timeline")}
+      onCloseTimeline={() => setActiveBottomPanel((panel) => (panel === "timeline" ? null : panel))}
+      />
+      <Toolbar
+      onOpenAdvisor={() => setIsAdvisorOpen(true)}
+      activePanel={activeBottomPanel}
+      onTogglePanel={toggleBottomPanel}
+      />
       <Other />
       <Search mapRef={mapRef} rightShift={rightShift} />
       <AdvisorButton

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
+
 dayjs.extend(advancedFormat);
 
 const baseStyle = {
@@ -36,31 +37,26 @@ const arrowButtonStyle = {
     lineHeight: 1,
 };
 
-/* ── Timeline Panel ── */
 const TimelinePanel = ({ isOpen, onClose, currentDate, onJump }) => {
     const jumpOptions = [
-        { label: "1 week",   sublabel: dayjs(currentDate).add(7,   "day").format("M/D/YYYY"),   days: 7   },
-        { label: "1 month",  sublabel: dayjs(currentDate).add(1,   "month").format("M/D/YYYY"), days: 30  },
-        { label: "3 months", sublabel: dayjs(currentDate).add(3,   "month").format("M/D/YYYY"), days: 90  },
-        { label: "6 months", sublabel: dayjs(currentDate).add(6,   "month").format("M/D/YYYY"), days: 180 },
-        { label: "1 year",   sublabel: dayjs(currentDate).add(1,   "year").format("M/D/YYYY"),  days: 365 },
+        { label: "1 week", sublabel: dayjs(currentDate).add(7, "day").format("M/D/YYYY"), days: 7 },
+        { label: "1 month", sublabel: dayjs(currentDate).add(1, "month").format("M/D/YYYY"), days: 30 },
+        { label: "3 months", sublabel: dayjs(currentDate).add(3, "month").format("M/D/YYYY"), days: 90 },
+        { label: "6 months", sublabel: dayjs(currentDate).add(6, "month").format("M/D/YYYY"), days: 180 },
+        { label: "1 year", sublabel: dayjs(currentDate).add(1, "year").format("M/D/YYYY"), days: 365 },
     ];
 
     return (
-        <div style={{
+        <div
+        style={{
             position: "fixed",
             bottom: isOpen ? "5.25rem" : "-30rem",
             left: "0.5rem",
-
             width: "26.25rem",
-            height: "calc(100vh - 33.25rem)",
-
+            maxWidth: "calc(100vw - 1rem)",
+            maxHeight: "calc(100vh - 7rem)",
             display: "flex",
             flexDirection: "column",
-            gap: "0.4rem",
-            overflowY: "auto",
-            scrollbarWidth: "none",
-
             backgroundColor: "rgba(17, 24, 39, 0.95)",
             backdropFilter: "blur(8px)",
             borderRadius: "16px",
@@ -73,15 +69,17 @@ const TimelinePanel = ({ isOpen, onClose, currentDate, onJump }) => {
             pointerEvents: isOpen ? "auto" : "none",
             fontFamily: "sans-serif",
             color: "white",
-        }}>
-        {/* Header */}
-        <div style={{
+        }}
+        >
+        <div
+        style={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
             padding: "1rem 1.25rem 0.75rem",
             borderBottom: "1px solid rgba(255,255,255,0.07)",
-        }}>
+        }}
+        >
         <div>
         <div style={{ fontWeight: 700, fontSize: "1rem" }}>Timeline</div>
         <div style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.45)", marginTop: "0.1rem" }}>
@@ -91,21 +89,42 @@ const TimelinePanel = ({ isOpen, onClose, currentDate, onJump }) => {
         <button
         onClick={onClose}
         style={{
-            background: "none", border: "none",
-            color: "rgba(255,255,255,0.5)", cursor: "pointer",
-            fontSize: "1.1rem", lineHeight: 1,
-            padding: "0.15rem 0.3rem", borderRadius: "6px",
+            background: "none",
+            border: "none",
+            color: "rgba(255,255,255,0.5)",
+            cursor: "pointer",
+            fontSize: "1.1rem",
+            lineHeight: 1,
+            padding: "0.15rem 0.3rem",
+            borderRadius: "6px",
             transition: "color 0.15s, background 0.15s",
         }}
-        onMouseEnter={e => { e.currentTarget.style.color = "white"; e.currentTarget.style.background = "rgba(255,255,255,0.08)"; }}
-        onMouseLeave={e => { e.currentTarget.style.color = "rgba(255,255,255,0.5)"; e.currentTarget.style.background = "none"; }}
-        >✕</button>
+        onMouseEnter={(e) => {
+            e.currentTarget.style.color = "white";
+            e.currentTarget.style.background = "rgba(255,255,255,0.08)";
+        }}
+        onMouseLeave={(e) => {
+            e.currentTarget.style.color = "rgba(255,255,255,0.5)";
+            e.currentTarget.style.background = "none";
+        }}
+        >
+        {"\u2715"}
+        </button>
         </div>
 
-        {/* Body */}
-        <div style={{ padding: "1rem 1.25rem 1.25rem", display: "flex", flexDirection: "column", alignItems: "center", gap: 0 }}>
-        {/* NOW node */}
-        <div style={{
+        <div
+        style={{
+            padding: "1rem 1.25rem 1.5rem",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 0,
+            overflowY: "auto",
+            scrollbarWidth: "none",
+        }}
+        >
+        <div
+        style={{
             width: "5.5rem",
             padding: "0.35rem 0",
             borderRadius: "999px",
@@ -116,7 +135,8 @@ const TimelinePanel = ({ isOpen, onClose, currentDate, onJump }) => {
             fontWeight: 700,
             color: "rgba(196,165,255,0.95)",
             letterSpacing: "0.04em",
-        }}>
+        }}
+        >
         <div>NOW</div>
         <div style={{ fontWeight: 400, color: "rgba(196,165,255,0.65)", fontSize: "0.65rem" }}>
         {dayjs(currentDate).format("M/D/YYYY")}
@@ -126,7 +146,7 @@ const TimelinePanel = ({ isOpen, onClose, currentDate, onJump }) => {
         {jumpOptions.map((opt) => (
             <React.Fragment key={opt.label}>
             <div style={{ width: "2px", height: "1.25rem", background: "rgba(139,92,246,0.4)" }} />
-            <JumpNode opt={opt} onJump={onJump} onClose={onClose} />
+            <JumpNode opt={opt} onJump={onJump} />
             </React.Fragment>
         ))}
         </div>
@@ -134,13 +154,16 @@ const TimelinePanel = ({ isOpen, onClose, currentDate, onJump }) => {
     );
 };
 
-const JumpNode = ({ opt, onJump, onClose }) => {
+const JumpNode = ({ opt, onJump }) => {
     const [hovered, setHovered] = useState(false);
+
     return (
         <button
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onClick={() => { onJump(opt.days); }}
+        onClick={() => {
+            onJump(opt.days);
+        }}
         style={{
             width: "12.5rem",
             padding: "0.38rem 0",
@@ -160,25 +183,30 @@ const JumpNode = ({ opt, onJump, onClose }) => {
     );
 };
 
-/* ── DateWidget ── */
-const DateWidget = ({ rightShift }) => {
+const DateWidget = ({
+    rightShift,
+    isTimelineOpen = false,
+    onToggleTimeline = () => {},
+    onCloseTimeline = () => {},
+}) => {
     const [gameData, setGameData] = useState(null);
-    const [timelineOpen, setTimelineOpen] = useState(false);
 
     useEffect(() => {
-        fetch('/saves/save0/game.json')
-        .then(res => res.json())
-        .then(data => setGameData(data));
+        fetch("/saves/save0/game.json")
+        .then((res) => res.json())
+        .then((data) => setGameData(data));
     }, []);
 
     const changeDate = async (days) => {
         if (!gameData || days == null) return;
-        const newDate = dayjs(gameData.gameDate).add(days, 'day').format("YYYY-MM-DD");
+
+        const newDate = dayjs(gameData.gameDate).add(days, "day").format("YYYY-MM-DD");
         const updated = { ...gameData, gameDate: newDate };
+
         try {
-            await fetch('/saves/save0/game.json', {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
+            await fetch("/saves/save0/game.json", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(updated, null, 2),
             });
             setGameData(updated);
@@ -194,8 +222,8 @@ const DateWidget = ({ rightShift }) => {
     return (
         <>
         <TimelinePanel
-        isOpen={timelineOpen}
-        onClose={() => setTimelineOpen(false)}
+        isOpen={isTimelineOpen}
+        onClose={onCloseTimeline}
         currentDate={gameData?.gameDate ?? dayjs().format("YYYY-MM-DD")}
         onJump={(days) => changeDate(days)}
         />
@@ -214,10 +242,12 @@ const DateWidget = ({ rightShift }) => {
         >
         <button
         style={arrowButtonStyle}
-        onMouseEnter={e => (e.currentTarget.style.color = "white")}
-        onMouseLeave={e => (e.currentTarget.style.color = "rgba(255,255,255,0.6)")}
+        onMouseEnter={(e) => (e.currentTarget.style.color = "white")}
+        onMouseLeave={(e) => (e.currentTarget.style.color = "rgba(255,255,255,0.6)")}
         title="Go back"
-        >{"«"}</button>
+        >
+        {"\u00AB"}
+        </button>
 
         <span style={{ flex: 1, textAlign: "center", fontSize: "0.95rem", letterSpacing: "0.02em" }}>
         {displayDate}
@@ -226,13 +256,17 @@ const DateWidget = ({ rightShift }) => {
         <button
         style={{
             ...arrowButtonStyle,
-            color: timelineOpen ? "rgba(196,165,255,0.9)" : "rgba(255,255,255,0.7)",
+            color: isTimelineOpen ? "rgba(196,165,255,0.9)" : "rgba(255,255,255,0.7)",
         }}
-        onClick={() => setTimelineOpen(o => !o)}
-        onMouseEnter={e => (e.currentTarget.style.color = "white")}
-        onMouseLeave={e => (e.currentTarget.style.color = timelineOpen ? "rgba(196,165,255,0.9)" : "rgba(255,255,255,0.7)")}
+        onClick={onToggleTimeline}
+        onMouseEnter={(e) => (e.currentTarget.style.color = "white")}
+        onMouseLeave={(e) => {
+            e.currentTarget.style.color = isTimelineOpen ? "rgba(196,165,255,0.9)" : "rgba(255,255,255,0.7)";
+        }}
         title="Jump forward"
-        >{"»"}</button>
+        >
+        {"\u00BB"}
+        </button>
         </div>
         </>
     );

--- a/src/Game/Selection/Regions.jsx
+++ b/src/Game/Selection/Regions.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useMap } from "react-map-gl/maplibre";
 
@@ -27,30 +27,67 @@ export const onOceanClicked = () => {
     if (_currentSelection) _dismiss?.();
 };
 
+const flagCache = {}; // GID_0 or country name -> { imageUrl, emoji } | null
 
-const flagCache = {}; // GID_0 → { png, svg } | null
+const createFlagState = (status = "idle", imageUrl = null, emoji = null) => ({
+    status,
+    imageUrl,
+    emoji,
+});
 
-const fetchFlagUrls = async (gid0) => {
-    if (!gid0) return null;
-    const key = gid0.toUpperCase();
-    if (key in flagCache) return flagCache[key];
+const normalizeFlagPayload = (payload) => {
+    const data = Array.isArray(payload) ? payload[0] : payload;
+    const imageUrl = data?.flags?.svg ?? data?.flags?.png ?? null;
+    const emoji = data?.flag ?? null;
+
+    if (!imageUrl && !emoji) return null;
+    return { imageUrl, emoji };
+};
+
+const fetchFlagPayload = async (url) => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return normalizeFlagPayload(await res.json());
+};
+
+const fetchFlagInfo = async (gid0, countryName) => {
+    const cacheKey = (gid0 || countryName || "").trim().toUpperCase();
+    if (!cacheKey) return null;
+    if (cacheKey in flagCache) return flagCache[cacheKey];
 
     try {
-        const res = await fetch(
-            `https://restcountries.com/v3.1/alpha/${key}?fields=flags`
-        );
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        flagCache[key] = data?.flags ?? null;
+        if (gid0) {
+            const alphaMatch = await fetchFlagPayload(
+                `https://restcountries.com/v3.1/alpha/${encodeURIComponent(gid0)}?fields=flags,flag`
+            );
+            if (alphaMatch) {
+                flagCache[cacheKey] = alphaMatch;
+                return alphaMatch;
+            }
+        }
     } catch {
-        flagCache[key] = null;
+        // Fall back to country name below.
     }
 
-    return flagCache[key];
+    try {
+        if (countryName) {
+            const nameMatch = await fetchFlagPayload(
+                `https://restcountries.com/v3.1/name/${encodeURIComponent(countryName)}?fullText=true&fields=flags,flag`
+            );
+            flagCache[cacheKey] = nameMatch;
+            return nameMatch;
+        }
+    } catch {
+        // Fall through to null cache below.
+    }
+
+    flagCache[cacheKey] = null;
+    return null;
 };
 
 const IconBtn = ({ children, title, onClick }) => {
     const [hovered, setHovered] = React.useState(false);
+
     return (
         <button
         title={title}
@@ -80,6 +117,7 @@ const IconBtn = ({ children, title, onClick }) => {
 };
 
 const ANIM_ID = "region-popup-anims";
+
 if (typeof document !== "undefined" && !document.getElementById(ANIM_ID)) {
     const style = document.createElement("style");
     style.id = ANIM_ID;
@@ -101,79 +139,107 @@ const RegionPopup = () => {
     const [screenPos, setScreenPos] = useState(null);
     const [animKey, setAnimKey] = useState(0);
     const [dismissing, setDismissing] = useState(false);
-    const [flagUrl, setFlagUrl] = useState(null);
+    const [flagState, setFlagState] = useState(() => createFlagState());
+    const [flagImageFailed, setFlagImageFailed] = useState(false);
     const { current: map } = useMap();
 
-    _setSelection = (val) => {
-        _currentSelection = val;
+    _setSelection = (value) => {
+        _currentSelection = value;
         setDismissing(false);
-        setFlagUrl(null);
-        setSelection(val);
-        if (val !== null) setAnimKey((k) => k + 1);
+        setFlagState(value ? createFlagState("loading") : createFlagState());
+        setFlagImageFailed(false);
+        setSelection(value);
+        if (value !== null) setAnimKey((key) => key + 1);
     };
 
-        _dismiss = () => setDismissing(true);
+    _dismiss = () => setDismissing(true);
 
-        const handleAnimationEnd = (e) => {
-            if (e.animationName === "regionPopupFadeOut") {
-                _currentSelection = null;
-                setSelection(null);
-                setFlagUrl(null);
-                setDismissing(false);
+    const handleAnimationEnd = (e) => {
+        if (e.animationName !== "regionPopupFadeOut") return;
+
+        _currentSelection = null;
+        setSelection(null);
+        setFlagState(createFlagState());
+        setFlagImageFailed(false);
+        setDismissing(false);
+    };
+
+    useEffect(() => {
+        if (!selection?.GID_0 && !selection?.COUNTRY) {
+            setFlagState(createFlagState());
+            return;
+        }
+
+        let cancelled = false;
+        setFlagState(createFlagState("loading"));
+        setFlagImageFailed(false);
+
+        fetchFlagInfo(selection.GID_0, selection.COUNTRY).then((flagInfo) => {
+            if (cancelled) return;
+
+            if (!flagInfo) {
+                setFlagState(createFlagState("error"));
+                return;
+            }
+
+            setFlagState(createFlagState("ready", flagInfo.imageUrl, flagInfo.emoji));
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [selection?.COUNTRY, selection?.GID_0]);
+
+    useEffect(() => {
+        if (!map) return;
+
+        const handleMapClick = (e) => {
+            const features = map.queryRenderedFeatures(e.point);
+            if ((!features || features.length === 0) && _currentSelection) {
+                _dismiss?.();
             }
         };
 
-        // Fetch flag whenever GID_0 changes
-        useEffect(() => {
-            if (!selection?.GID_0) { setFlagUrl(null); return; }
-            let cancelled = false;
-            fetchFlagUrls(selection.GID_0).then((flags) => {
-                if (!cancelled) setFlagUrl(flags?.svg ?? null);
-            });
-                return () => { cancelled = true; };
-        }, [selection?.GID_0]);
+        map.on("click", handleMapClick);
+        return () => map.off("click", handleMapClick);
+    }, [map]);
 
-        // ocean click
-        useEffect(() => {
-            if (!map) return;
-            const handleMapClick = (e) => {
-                const features = map.queryRenderedFeatures(e.point);
-                if ((!features || features.length === 0) && _currentSelection) {
-                    _dismiss?.();
-                }
-            };
-            map.on("click", handleMapClick);
-            return () => map.off("click", handleMapClick);
-        }, [map]);
+    useEffect(() => {
+        if (!map || !selection) {
+            setScreenPos(null);
+            return;
+        }
 
-        useEffect(() => {
-            if (!map || !selection) { setScreenPos(null); return; }
+        const update = () => {
+            const center = map.getCenter();
+            const toRad = (deg) => (deg * Math.PI) / 180;
+            const lat1 = toRad(center.lat);
+            const lat2 = toRad(selection.lngLat.lat);
+            const dLng = toRad(selection.lngLat.lng - center.lng);
+            const cosAngle =
+            Math.sin(lat1) * Math.sin(lat2) +
+            Math.cos(lat1) * Math.cos(lat2) * Math.cos(dLng);
 
-            const update = () => {
-                const center = map.getCenter();
-                const toRad = (d) => (d * Math.PI) / 180;
-                const lat1 = toRad(center.lat);
-                const lat2 = toRad(selection.lngLat.lat);
-                const dLng  = toRad(selection.lngLat.lng - center.lng);
-                const cosAngle =
-                Math.sin(lat1) * Math.sin(lat2) +
-                Math.cos(lat1) * Math.cos(lat2) * Math.cos(dLng);
+            if (cosAngle < 0) {
+                setScreenPos(null);
+                return;
+            }
 
-                if (cosAngle < 0) { setScreenPos(null); return; }
+            const point = map.project(selection.lngLat);
+            setScreenPos({ x: point.x, y: point.y });
+        };
 
-                const point = map.project(selection.lngLat);
-                setScreenPos({ x: point.x, y: point.y });
-            };
+        update();
+        map.on("move", update);
+        return () => map.off("move", update);
+    }, [map, selection]);
 
-            update();
-            map.on("move", update);
-            return () => map.off("move", update);
-        }, [map, selection]);
+    if (!selection || !screenPos) return null;
 
-        if (!selection || !screenPos) return null;
-
-        const { COUNTRY, NAME_1 } = selection;
+    const { COUNTRY, NAME_1 } = selection;
     const POPUP_WIDTH = 210;
+    const showFlagImage = Boolean(flagState.imageUrl && !flagImageFailed);
+    const showFlagEmoji = Boolean(!showFlagImage && flagState.emoji);
 
     return createPortal(
         <div
@@ -188,57 +254,85 @@ const RegionPopup = () => {
             pointerEvents: dismissing ? "none" : "auto",
             animation: dismissing
             ? "regionPopupFadeOut 0.18s cubic-bezier(0.4, 0, 1, 1) both"
-            : "regionPopupFadeIn  0.22s cubic-bezier(0.22, 1, 0.36, 1) both",
+            : "regionPopupFadeIn 0.22s cubic-bezier(0.22, 1, 0.36, 1) both",
         }}
         >
-        {/* Card */}
-        <div style={{
+        <div
+        style={{
             backgroundColor: "rgba(17, 24, 39, 0.95)",
-                        backdropFilter: "blur(4px)",
-                        WebkitBackdropFilter: "blur(4px)",
-                        borderRadius: "12px",
-                        overflow: "hidden",
-                        fontFamily: "sans-serif",
-                        boxShadow: "0 8px 32px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.3)",
-                        border: "1px solid rgba(255,255,255,0.12)",
-                        color: "white",
-        }}>
-        {/* Flag banner */}
+            backdropFilter: "blur(4px)",
+            WebkitBackdropFilter: "blur(4px)",
+            borderRadius: "12px",
+            overflow: "hidden",
+            fontFamily: "sans-serif",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.3)",
+            border: "1px solid rgba(255,255,255,0.12)",
+            color: "white",
+        }}
+        >
         <div style={{ position: "relative", width: "100%", height: "96px", background: "rgba(30,42,60,0.6)" }}>
-        {flagUrl ? (
+        {showFlagImage ? (
             <img
-            src={flagUrl}
+            src={flagState.imageUrl}
             alt={COUNTRY}
             style={{ width: "100%", height: "100%", objectFit: "cover", display: "block", opacity: 0.9 }}
-            onError={(e) => { e.target.style.display = "none"; }}
+            onError={() => setFlagImageFailed(true)}
             />
         ) : (
-            <div style={{
-                width: "100%", height: "100%", display: "flex",
-                alignItems: "center", justifyContent: "center",
-                color: "rgba(255,255,255,0.2)", fontSize: "11px",
-             letterSpacing: "0.05em",
-            }}>
-            {flagUrl === null && selection?.GID_0 ? "Loading…" : "No flag available"}
+            <div
+            style={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: showFlagEmoji ? "white" : "rgba(255,255,255,0.2)",
+                fontSize: showFlagEmoji ? "3rem" : "11px",
+                letterSpacing: showFlagEmoji ? 0 : "0.05em",
+                textShadow: showFlagEmoji ? "0 4px 18px rgba(0,0,0,0.35)" : "none",
+            }}
+            >
+            {showFlagEmoji
+            ? flagState.emoji
+            : flagState.status === "loading" && selection?.GID_0
+            ? "Loading..."
+            : "No flag available"}
             </div>
         )}
         <button
         onClick={() => _dismiss?.()}
         style={{
-            position: "absolute", top: "7px", right: "7px",
-            background: "rgba(17,24,39,0.7)", backdropFilter: "blur(4px)",
-                        border: "1px solid rgba(255,255,255,0.12)", borderRadius: "6px",
-                        width: "22px", height: "22px", cursor: "pointer",
-                        color: "rgba(255,255,255,0.5)", fontSize: "11px", padding: 0,
-                        display: "flex", alignItems: "center", justifyContent: "center",
-                        transition: "color 0.2s, background 0.2s",
+            position: "absolute",
+            top: "7px",
+            right: "7px",
+            background: "rgba(17,24,39,0.7)",
+            backdropFilter: "blur(4px)",
+            border: "1px solid rgba(255,255,255,0.12)",
+            borderRadius: "6px",
+            width: "22px",
+            height: "22px",
+            cursor: "pointer",
+            color: "rgba(255,255,255,0.5)",
+            fontSize: "11px",
+            padding: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            transition: "color 0.2s, background 0.2s",
         }}
-        onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.9)"; e.currentTarget.style.background = "rgba(17,24,39,0.9)"; }}
-        onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.5)"; e.currentTarget.style.background = "rgba(17,24,39,0.7)"; }}
-        >✕</button>
+        onMouseEnter={(e) => {
+            e.currentTarget.style.color = "rgba(255,255,255,0.9)";
+            e.currentTarget.style.background = "rgba(17,24,39,0.9)";
+        }}
+        onMouseLeave={(e) => {
+            e.currentTarget.style.color = "rgba(255,255,255,0.5)";
+            e.currentTarget.style.background = "rgba(17,24,39,0.7)";
+        }}
+        >
+        {"\u2715"}
+        </button>
         </div>
 
-        {/* Info section */}
         <div style={{ padding: "8px 10px 10px" }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "6px", minHeight: "26px" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "7px", minWidth: 0 }}>
@@ -248,8 +342,8 @@ const RegionPopup = () => {
         </span>
         </div>
         <div style={{ display: "flex", gap: "4px", flexShrink: 0 }}>
-        <IconBtn title="Copy country name" onClick={() => navigator.clipboard?.writeText(COUNTRY)}>⧉</IconBtn>
-        <IconBtn title="Country info">ⓘ</IconBtn>
+        <IconBtn title="Copy country name" onClick={() => navigator.clipboard?.writeText(COUNTRY)}>{"\u29C9"}</IconBtn>
+        <IconBtn title="Country info">{"\u24D8"}</IconBtn>
         </div>
         </div>
 
@@ -260,21 +354,23 @@ const RegionPopup = () => {
         {NAME_1}
         </span>
         <div style={{ display: "flex", gap: "4px", flexShrink: 0 }}>
-        <IconBtn title="Copy region name" onClick={() => navigator.clipboard?.writeText(NAME_1)}>⧉</IconBtn>
-        <IconBtn title="Region info">ⓘ</IconBtn>
+        <IconBtn title="Copy region name" onClick={() => navigator.clipboard?.writeText(NAME_1)}>{"\u29C9"}</IconBtn>
+        <IconBtn title="Region info">{"\u24D8"}</IconBtn>
         </div>
         </div>
         </div>
         </div>
 
-        {/* Arrow */}
-        <div style={{
-            width: 0, height: 0,
+        <div
+        style={{
+            width: 0,
+            height: 0,
             borderLeft: "8px solid transparent",
             borderRight: "8px solid transparent",
             borderTop: "9px solid rgba(17,24,39,0.95)",
-                        margin: "0 auto",
-        }} />
+            margin: "0 auto",
+        }}
+        />
         </div>,
         document.body
     );


### PR DESCRIPTION
menus stack on top of each other and you cant close them

opening multiple panels at once turns the ui into a pile. they overlap, you cant click the close button because another panel is on top of it. now only one menu can be open at a time, opening a new one closes the previous.

flag image fallback

if the flag image fails to load for whatever reason it just showed a broken image icon. now it falls back to the country emoji flag instead.

timeline doesnt fit

the last year in the timeline scroll was clipped, like 50 pixels of it sticking out at the bottom. you could technically see it exists but couldnt click it. added proper overflow and padding so the full list is reachable.