### PR TITLE
Fix country flags: restcountries API is deprecated

### DIFF
--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -11,6 +11,7 @@ import {
     readJson,
     writeJson,
 } from "../../runtime/assets.js";
+import { flagEmojiFromGid } from "../../runtime/countryFlags.js";
 
 // ── Storage ───────────────────────────────────────────────────────────────────
 
@@ -32,101 +33,26 @@ const loadCountryNames = async () => {
     return loadCachedCountryNames();
 };
 
-// ── Flag cache ────────────────────────────────────────────────────────────────
+// ── Flags ─────────────────────────────────────────────────────────────────────
+// Flag emoji are derived locally from each nation's GID_0 country code. (The
+// previous source, restcountries.com, deprecated its public API and no longer
+// returns flag data.)
 
-const flagCache = new Map();
+const FALLBACK_FLAG = "🏳";
 
-const fetchFlagByCode = async (code) => {
-    const res = await fetch(`https://restcountries.com/v3.1/alpha/${encodeURIComponent(code)}?fields=flag`);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    return (Array.isArray(data) ? data[0] : data)?.flag ?? "🏳";
-};
+const getCountryFlag = ({ code } = {}) => flagEmojiFromGid(code) ?? FALLBACK_FLAG;
 
-const fetchFlagByName = async (name) => {
-    const res = await fetch(`https://restcountries.com/v3.1/name/${encodeURIComponent(name)}?fullText=true&fields=flag`);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    return data?.[0]?.flag ?? "🏳";
-};
-
-const getCountryFlag = async ({ code, name } = {}) => {
-    const key = code || name;
-    if (!key) return "🏳";
-    if (flagCache.has(key) && flagCache.get(key) !== "🏳") return flagCache.get(key);
-    if (!flagCache.has(key)) flagCache.set(key, "🏳");
-    try {
-        const emoji = code ? await fetchFlagByCode(code) : await fetchFlagByName(name);
-        flagCache.set(key, emoji);
-        return emoji;
-    } catch {
-        if (code && name) {
-            try {
-                const emoji = await fetchFlagByName(name);
-                flagCache.set(key, emoji);
-                return emoji;
-            } catch { /* fall through */ }
-        }
-        flagCache.set(key, "🏳");
-        return "🏳";
-    }
-};
-
-const useCountryFlag = ({ code, name } = {}) => {
-    const key = code || name;
-    const [flag, setFlag] = useState(() => (key && flagCache.has(key)) ? flagCache.get(key) : "🏳");
-    useEffect(() => {
-        if (!key) return;
-        if (flagCache.has(key) && flagCache.get(key) !== "🏳") { setFlag(flagCache.get(key)); return; }
-        let cancelled = false;
-        getCountryFlag({ code, name }).then(emoji => { if (!cancelled) setFlag(emoji); });
-        return () => { cancelled = true; };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [key]);
-    return flag;
-};
+const useCountryFlag = ({ code } = {}) =>
+    useMemo(() => getCountryFlag({ code }), [code]);
 
 const useCountryFlags = (countries) => {
-    const depsKey = countries.map(c => c.code || c.name).join(",");
-
-    const [flags, setFlags] = useState(() => {
-        const initial = {};
-        for (const { name, code } of countries) {
-            const key = code || name;
-            initial[name] = (key && flagCache.has(key) && flagCache.get(key) !== "🏳")
-            ? flagCache.get(key)
-            : "🏳";
-        }
-        return initial;
-    });
-
-    useEffect(() => {
-        if (!countries.length) return;
-        let cancelled = false;
-
-        setFlags(prev => {
-            const next = { ...prev };
-            for (const { name, code } of countries) {
-                const key = code || name;
-                if (key && flagCache.has(key)) next[name] = flagCache.get(key);
-                else next[name] = prev[name] ?? "🏳";
-            }
-            return next;
-        });
-
-        for (const { name, code } of countries) {
-            const key = code || name;
-            if (flagCache.has(key) && flagCache.get(key) !== "🏳") continue;
-            getCountryFlag({ code, name }).then(emoji => {
-                if (!cancelled) setFlags(prev => ({ ...prev, [name]: emoji }));
-            });
-        }
-
-        return () => { cancelled = true; };
+    const depsKey = countries.map(c => `${c.name}:${c.code ?? ""}`).join(",");
+    return useMemo(() => {
+        const flags = {};
+        for (const { name, code } of countries) flags[name] = getCountryFlag({ code });
+        return flags;
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [depsKey]);
-
-    return flags;
 };
 
 // ── Nation colors (from colors.json, same source as WorldMap) ─────────────────

--- a/src/Game/Selection/Regions.jsx
+++ b/src/Game/Selection/Regions.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useMap } from "react-map-gl/maplibre";
 import { resolveCountryDisplayName } from "../../runtime/assets.js";
+import { flagImageUrlFromGid, flagEmojiFromGid } from "../../runtime/countryFlags.js";
 
 let _setSelection = null;
 let _currentSelection = null;
@@ -28,62 +29,17 @@ export const onOceanClicked = () => {
     if (_currentSelection) _dismiss?.();
 };
 
-const flagCache = {}; // GID_0 or country name -> { imageUrl, emoji } | null
-
 const createFlagState = (status = "idle", imageUrl = null, emoji = null) => ({
     status,
     imageUrl,
     emoji,
 });
 
-const normalizeFlagPayload = (payload) => {
-    const data = Array.isArray(payload) ? payload[0] : payload;
-    const imageUrl = data?.flags?.svg ?? data?.flags?.png ?? null;
-    const emoji = data?.flag ?? null;
-
-    if (!imageUrl && !emoji) return null;
-    return { imageUrl, emoji };
-};
-
-const fetchFlagPayload = async (url) => {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return normalizeFlagPayload(await res.json());
-};
-
-const fetchFlagInfo = async (gid0, countryName) => {
-    const cacheKey = (gid0 || countryName || "").trim().toUpperCase();
-    if (!cacheKey) return null;
-    if (cacheKey in flagCache) return flagCache[cacheKey];
-
-    try {
-        if (gid0) {
-            const alphaMatch = await fetchFlagPayload(
-                `https://restcountries.com/v3.1/alpha/${encodeURIComponent(gid0)}?fields=flags,flag`
-            );
-            if (alphaMatch) {
-                flagCache[cacheKey] = alphaMatch;
-                return alphaMatch;
-            }
-        }
-    } catch {
-        // Fall back to country name below.
-    }
-
-    try {
-        if (countryName) {
-            const nameMatch = await fetchFlagPayload(
-                `https://restcountries.com/v3.1/name/${encodeURIComponent(countryName)}?fullText=true&fields=flags,flag`
-            );
-            flagCache[cacheKey] = nameMatch;
-            return nameMatch;
-        }
-    } catch {
-        // Fall through to null cache below.
-    }
-
-    flagCache[cacheKey] = null;
-    return null;
+// Flag image (with an emoji fallback) for a selected region's GID_0 country code.
+const resolveFlagInfo = (gid0) => {
+    const imageUrl = flagImageUrlFromGid(gid0);
+    if (!imageUrl) return null;
+    return { imageUrl, emoji: flagEmojiFromGid(gid0) };
 };
 
 const IconBtn = ({ children, title, onClick }) => {
@@ -171,24 +127,14 @@ const RegionPopup = () => {
             return;
         }
 
-        let cancelled = false;
-        setFlagState(createFlagState("loading"));
         setFlagImageFailed(false);
 
-        fetchFlagInfo(selection.GID_0, selection.COUNTRY).then((flagInfo) => {
-            if (cancelled) return;
-
-            if (!flagInfo) {
-                setFlagState(createFlagState("error"));
-                return;
-            }
-
-            setFlagState(createFlagState("ready", flagInfo.imageUrl, flagInfo.emoji));
-        });
-
-        return () => {
-            cancelled = true;
-        };
+        const flagInfo = resolveFlagInfo(selection.GID_0);
+        setFlagState(
+            flagInfo
+                ? createFlagState("ready", flagInfo.imageUrl, flagInfo.emoji)
+                : createFlagState("error"),
+        );
     }, [selection?.COUNTRY, selection?.GID_0]);
 
     useEffect(() => {

--- a/src/runtime/countryFlags.js
+++ b/src/runtime/countryFlags.js
@@ -1,0 +1,72 @@
+// Shared country-flag helpers.
+//
+// The map layers (GADM) identify countries by GID_0, an ISO 3166-1 alpha-3 code.
+// Flag images are served by flagcdn.com keyed on the alpha-2 code, and flag
+// emoji are built from that alpha-2 code's regional-indicator letters. These
+// replace restcountries.com, whose public API was deprecated and no longer
+// returns flag data.
+
+// ISO 3166-1 alpha-3 -> alpha-2.
+const ISO3_TO_ISO2 = {
+    ABW: "AW", AFG: "AF", AGO: "AO", ALA: "AX", ALB: "AL", AND: "AD", ARE: "AE", ARG: "AR",
+    ARM: "AM", ASM: "AS", ATA: "AQ", ATF: "TF", ATG: "AG", AUS: "AU", AUT: "AT", AZE: "AZ",
+    BDI: "BI", BEL: "BE", BEN: "BJ", BES: "BQ", BFA: "BF", BGD: "BD", BGR: "BG", BHR: "BH",
+    BHS: "BS", BIH: "BA", BLR: "BY", BLZ: "BZ", BMU: "BM", BOL: "BO", BRA: "BR", BRB: "BB",
+    BRN: "BN", BTN: "BT", BVT: "BV", BWA: "BW", CAF: "CF", CAN: "CA", CHE: "CH", CHL: "CL",
+    CHN: "CN", CIV: "CI", CMR: "CM", COD: "CD", COG: "CG", COK: "CK", COL: "CO", COM: "KM",
+    CPV: "CV", CRI: "CR", CUB: "CU", CUW: "CW", CYM: "KY", CYP: "CY", CZE: "CZ", DEU: "DE",
+    DJI: "DJ", DMA: "DM", DNK: "DK", DOM: "DO", DZA: "DZ", ECU: "EC", EGY: "EG", ERI: "ER",
+    ESH: "EH", ESP: "ES", EST: "EE", ETH: "ET", FIN: "FI", FJI: "FJ", FLK: "FK", FRA: "FR",
+    FRO: "FO", FSM: "FM", GAB: "GA", GBR: "GB", GEO: "GE", GGY: "GG", GHA: "GH", GIN: "GN",
+    GLP: "GP", GMB: "GM", GNB: "GW", GNQ: "GQ", GRC: "GR", GRD: "GD", GRL: "GL", GTM: "GT",
+    GUF: "GF", GUM: "GU", GUY: "GY", HKG: "HK", HMD: "HM", HND: "HN", HRV: "HR", HTI: "HT",
+    HUN: "HU", IDN: "ID", IMN: "IM", IND: "IN", IRL: "IE", IRN: "IR", IRQ: "IQ", ISL: "IS",
+    ISR: "IL", ITA: "IT", JAM: "JM", JEY: "JE", JOR: "JO", JPN: "JP", KAZ: "KZ", KEN: "KE",
+    KGZ: "KG", KHM: "KH", KIR: "KI", KNA: "KN", KOR: "KR", KWT: "KW", LAO: "LA", LBN: "LB",
+    LBR: "LR", LBY: "LY", LCA: "LC", LIE: "LI", LKA: "LK", LSO: "LS", LTU: "LT", LUX: "LU",
+    LVA: "LV", MAC: "MO", MAR: "MA", MCO: "MC", MDA: "MD", MDG: "MG", MDV: "MV", MEX: "MX",
+    MHL: "MH", MKD: "MK", MLI: "ML", MLT: "MT", MMR: "MM", MNE: "ME", MNG: "MN", MNP: "MP",
+    MOZ: "MZ", MRT: "MR", MTQ: "MQ", MUS: "MU", MWI: "MW", MYS: "MY", MYT: "YT", NAM: "NA",
+    NCL: "NC", NER: "NE", NGA: "NG", NIC: "NI", NLD: "NL", NOR: "NO", NPL: "NP", NRU: "NR",
+    NZL: "NZ", OMN: "OM", PAK: "PK", PAN: "PA", PER: "PE", PHL: "PH", PLW: "PW", PNG: "PG",
+    POL: "PL", PRI: "PR", PRK: "KP", PRT: "PT", PRY: "PY", PSE: "PS", PYF: "PF", QAT: "QA",
+    REU: "RE", ROU: "RO", RUS: "RU", RWA: "RW", SAU: "SA", SDN: "SD", SEN: "SN", SGP: "SG",
+    SGS: "GS", SHN: "SH", SJM: "SJ", SLB: "SB", SLE: "SL", SLV: "SV", SMR: "SM", SOM: "SO",
+    SPM: "PM", SRB: "RS", SSD: "SS", STP: "ST", SUR: "SR", SVK: "SK", SVN: "SI", SWE: "SE",
+    SWZ: "SZ", SYC: "SC", SYR: "SY", TCA: "TC", TCD: "TD", TGO: "TG", THA: "TH", TJK: "TJ",
+    TKL: "TK", TKM: "TM", TLS: "TL", TON: "TO", TTO: "TT", TUN: "TN", TUR: "TR", TWN: "TW",
+    TZA: "TZ", UGA: "UG", UKR: "UA", URY: "UY", USA: "US", UZB: "UZ", VAT: "VA", VCT: "VC",
+    VEN: "VE", VGB: "VG", VIR: "VI", VNM: "VN", VUT: "VU", WLF: "WF", WSM: "WS", XKO: "XK",
+    YEM: "YE", ZAF: "ZA", ZMB: "ZM", ZWE: "ZW",
+};
+
+// GADM assigns placeholder codes (Z01..Z09) to disputed border areas; show the
+// flag of the administering / claiming country instead.
+const DISPUTED_TERRITORY_PARENT = {
+    Z01: "IND", Z02: "CHN", Z03: "CHN", Z04: "IND", Z05: "IND",
+    Z06: "PAK", Z07: "IND", Z08: "CHN", Z09: "IND",
+};
+
+// Resolve a GID_0 (ISO3) code to a lowercase ISO 3166-1 alpha-2 code, or null.
+export const gidToAlpha2 = (gid0) => {
+    if (!gid0) return null;
+    const code = String(gid0).trim().toUpperCase();
+    const iso3 = DISPUTED_TERRITORY_PARENT[code] ?? code;
+    const alpha2 = ISO3_TO_ISO2[iso3];
+    return alpha2 ? alpha2.toLowerCase() : null;
+};
+
+// flagcdn.com SVG flag URL for a GID_0 code, or null if unknown.
+export const flagImageUrlFromGid = (gid0) => {
+    const alpha2 = gidToAlpha2(gid0);
+    return alpha2 ? `https://flagcdn.com/${alpha2}.svg` : null;
+};
+
+// Regional-indicator flag emoji (e.g. "us" -> 🇺🇸) for a GID_0 code, or null.
+export const flagEmojiFromGid = (gid0) => {
+    const alpha2 = gidToAlpha2(gid0);
+    if (!alpha2) return null;
+    return alpha2
+        .toUpperCase()
+        .replace(/./g, (ch) => String.fromCodePoint(0x1f1e6 + ch.charCodeAt(0) - 65));
+};


### PR DESCRIPTION
restcountries.com's v3.1 API now 301-redirects to a legacy endpoint that returns a deprecation error with no flag data

Replace it with flagcdn.com for flag images