### PR TITLE
Era-accurate scenario cities, editor city tool & place search, Linux/macOS launchers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Shell scripts must stay LF - CRLF breaks bash on Linux/macOS
+*.sh text eol=lf
+*.command text eol=lf
 *.pmtiles filter=lfs diff=lfs merge=lfs -text
 public/assets/regions-seed.geojson filter=lfs diff=lfs merge=lfs -text
 public/assets/cities-seed.json filter=lfs diff=lfs merge=lfs -text

--- a/Launch Pax Historia.command
+++ b/Launch Pax Historia.command
@@ -1,0 +1,4 @@
+#!/bin/bash
+# macOS double-click wrapper - opens Terminal and runs the launcher.
+# (First run: right-click > Open if macOS blocks a downloaded file.)
+cd "$(dirname "$0")" && exec bash "./Launch Pax Historia.sh"

--- a/Launch Pax Historia.sh
+++ b/Launch Pax Historia.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# ============================================================
+#  Pax Historia - one-click setup and launch (Linux / macOS)
+#  ----------------------------------------------------------
+#   1. Verifies Node.js is installed
+#   2. Downloads the world map data (Git LFS assets) if missing
+#   3. Installs npm dependencies
+#   4. Builds the client
+#   5. Starts the server and opens your browser
+#
+#  Run from a terminal:   ./"Launch Pax Historia.sh"
+#  macOS: double-click "Launch Pax Historia.command" instead.
+#  Keep the terminal open while playing; press Ctrl+C to stop.
+# ============================================================
+
+# Work from the folder this script lives in (the project root)
+cd "$(dirname "$0")" || exit 1
+
+echo ""
+echo "==================================================="
+echo "            PAX HISTORIA  -  LAUNCHER"
+echo "==================================================="
+echo ""
+
+# Download helper: curl preferred, wget as fallback.
+fetch() { # fetch <url> <outfile>
+    if command -v curl >/dev/null 2>&1; then
+        curl -L -f --retry 3 -o "$2" "$1"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -O "$2" "$1"
+    else
+        echo "  [ERROR] Neither curl nor wget was found."
+        return 1
+    fi
+}
+
+# ---- 1. Check Node.js -------------------------------------
+if ! command -v node >/dev/null 2>&1; then
+    echo "[ERROR] Node.js was not found on this computer."
+    echo "Pax Historia needs Node.js to run."
+    echo ""
+    case "$(uname -s)" in
+        Darwin)
+            if command -v brew >/dev/null 2>&1; then
+                read -r -p "Install Node.js now via Homebrew? [y/N] " answer
+                if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+                    brew install node
+                fi
+            else
+                echo "Install it with Homebrew (https://brew.sh):  brew install node"
+            fi
+            ;;
+        *)
+            PKG_CMD=""
+            if command -v apt-get >/dev/null 2>&1; then PKG_CMD="sudo apt-get install -y nodejs npm"
+            elif command -v dnf >/dev/null 2>&1; then PKG_CMD="sudo dnf install -y nodejs npm"
+            elif command -v pacman >/dev/null 2>&1; then PKG_CMD="sudo pacman -S --noconfirm nodejs npm"
+            elif command -v zypper >/dev/null 2>&1; then PKG_CMD="sudo zypper install -y nodejs npm"
+            fi
+            if [ -n "$PKG_CMD" ]; then
+                read -r -p "Install Node.js now with \"$PKG_CMD\"? [y/N] " answer
+                if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+                    $PKG_CMD
+                fi
+            fi
+            ;;
+    esac
+    if ! command -v node >/dev/null 2>&1; then
+        echo ""
+        echo "Download and install Node.js (LTS) from: https://nodejs.org/"
+        echo "Then run this launcher again."
+        echo ""
+        exit 1
+    fi
+fi
+
+echo "[OK] Node.js $(node --version 2>/dev/null) detected."
+echo ""
+
+# ---- 2. Ensure world map data (Git LFS assets) -----------
+#  The big map files ship as tiny Git LFS pointer stubs in a
+#  ZIP download. Pull the real binaries from GitHub's media CDN.
+#  Real files are several MB; LFS pointer stubs are ~150 B.
+ASSET_BASE="https://media.githubusercontent.com/media/Arkniem/pax-historia-2/main"
+
+ensure_asset() { # ensure_asset <local path == repo path>
+    local target="$1" size=0
+    [ -f "$target" ] && size=$(wc -c < "$target" | tr -d '[:space:]')
+    if [ "${size:-0}" -ge 100000 ]; then
+        echo "  [OK] $(basename "$target") already present."
+        return 0
+    fi
+    echo "  Downloading $(basename "$target") ..."
+    mkdir -p "$(dirname "$target")"
+    if fetch "$ASSET_BASE/$target" "$target.download"; then
+        mv -f "$target.download" "$target"
+        echo "  [OK] $(basename "$target") downloaded."
+    else
+        rm -f "$target.download"
+        echo "  [WARN] Could not download $(basename "$target") - the map may not display."
+    fi
+}
+
+echo "Checking world map data..."
+ensure_asset "public/assets/cities.pmtiles"
+ensure_asset "public/assets/countries.pmtiles"
+ensure_asset "public/assets/regions.pmtiles"
+# Map-editor seeds + the built-in Modern Day world map (also LFS)
+ensure_asset "public/assets/regions-seed.geojson"
+ensure_asset "public/assets/cities-seed.json"
+ensure_asset "server/data/scenarios/default/regions.geojson"
+echo ""
+
+# ---- 3. Install dependencies -----------------------------
+if [ ! -d "node_modules" ]; then
+    echo "Installing dependencies (first run - this can take a few minutes)..."
+    npm install || { echo ""; echo "[ERROR] Setup failed - see the messages above for details."; exit 1; }
+else
+    echo "[OK] Dependencies already installed."
+    echo "     (Delete the \"node_modules\" folder to force a clean reinstall.)"
+fi
+echo ""
+
+# ---- 4. Build the client ---------------------------------
+# Give Node extra heap so the production build doesn't run out of memory
+# on machines that are low on free RAM.
+export NODE_OPTIONS="--max-old-space-size=4096"
+if [ ! -f "dist/index.html" ]; then
+    echo "Building the app..."
+    npm run build || { echo ""; echo "[ERROR] Setup failed - see the messages above for details."; exit 1; }
+else
+    echo "[OK] Build already present."
+    echo "     (Delete the \"dist\" folder to force a rebuild.)"
+fi
+echo ""
+
+# ---- 5. Launch -------------------------------------------
+echo "==================================================="
+echo "  Starting server at http://localhost:3000"
+echo "  Your browser will open automatically."
+echo "  Keep this terminal open while playing."
+echo "  Press Ctrl+C to stop."
+echo "==================================================="
+echo ""
+
+# Open the browser a few seconds after the server boots
+case "$(uname -s)" in
+    Darwin) OPEN_CMD="open" ;;
+    *) command -v xdg-open >/dev/null 2>&1 && OPEN_CMD="xdg-open" || OPEN_CMD="" ;;
+esac
+if [ -n "$OPEN_CMD" ]; then
+    ( sleep 4; "$OPEN_CMD" "http://localhost:3000" >/dev/null 2>&1 ) &
+fi
+
+node server/server.js
+
+echo ""
+echo "Server stopped."
+exit 0

--- a/README.md
+++ b/README.md
@@ -50,10 +50,16 @@
 
 ## 🚀 Installation
 
-### Easiest (Windows)
+### Easiest
 
-Double-click **`Launch Pax Historia.bat`** — it checks Node.js, downloads the map data,
-installs dependencies, builds, and opens the game.
+- **Windows:** double-click **`Launch Pax Historia.bat`**
+- **macOS:** double-click **`Launch Pax Historia.command`** (first run: right-click → *Open*)
+- **Linux:** run `./"Launch Pax Historia.sh"` in a terminal
+
+The launcher checks Node.js, downloads the map data, installs dependencies, builds,
+and opens the game. To update an existing install later, run the matching
+**`Update Pax Historia`** script for your platform — it fetches the latest version
+while preserving your saves, scenarios, and map data.
 
 ### Manual
 
@@ -73,7 +79,7 @@ Then open **http://localhost:3000** in your browser.
 
 > **Note:** the large map assets (`*.pmtiles`, `public/assets/*-seed.*`, and
 > `server/data/scenarios/default/regions.geojson`) live in Git LFS. If you downloaded a
-> ZIP instead of cloning, run the launcher `.bat` — it fetches them automatically.
+> ZIP instead of cloning, run the launcher script for your platform — it fetches them automatically.
 
 ---
 

--- a/Update Pax Historia.command
+++ b/Update Pax Historia.command
@@ -1,0 +1,4 @@
+#!/bin/bash
+# macOS double-click wrapper - opens Terminal and runs the updater.
+# (First run: right-click > Open if macOS blocks a downloaded file.)
+cd "$(dirname "$0")" && exec bash "./Update Pax Historia.sh"

--- a/Update Pax Historia.sh
+++ b/Update Pax Historia.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# ============================================================
+#  Pax Historia - one-click updater (Linux / macOS)
+#  ----------------------------------------------------------
+#  Replaces this install's files with the latest ones from
+#  GitHub, without touching your saved games or settings.
+#
+#   - Git installs (folder has .git):  git pull + LFS
+#   - ZIP installs:                    downloads the latest
+#     code and copies it over this folder (needs rsync)
+#
+#  What is protected:
+#   * server/data/games        (your save games)
+#   * server/data/*.json       (your library state)
+#   * existing scenario files  (new ones are added, yours
+#                               are never overwritten)
+#   * public/assets/*.pmtiles  (real map data is never
+#                               replaced by LFS pointer stubs)
+#
+#  After updating, run "Launch Pax Historia.sh" as usual -
+#  it reinstalls dependencies and rebuilds automatically.
+#
+#  Run from a terminal:   ./"Update Pax Historia.sh"
+#  macOS: double-click "Update Pax Historia.command" instead.
+# ============================================================
+
+# Which repository to update from.
+REPO_OWNER="Tommi-K"
+REPO_NAME="pax-historia"
+REPO_BRANCH="main"
+
+fail_copy() {
+    echo ""
+    echo "[ERROR] Copying the update failed - see messages above."
+    echo "Your existing install was not fully modified; re-run to retry."
+    exit 1
+}
+
+# The whole update runs inside main() so bash parses this entire file
+# before any of it executes - the update overwriting this very script
+# mid-run can then never corrupt the running process.
+main() {
+    # Work from the folder this script lives in (the project root)
+    cd "$(dirname "$0")" || exit 1
+
+    echo ""
+    echo "==================================================="
+    echo "            PAX HISTORIA  -  UPDATER"
+    echo "   source: $REPO_OWNER/$REPO_NAME ($REPO_BRANCH)"
+    echo "==================================================="
+    echo ""
+
+    # ---- Git installs: a proper pull is the cleanest update ----
+    if [ -d ".git" ]; then
+        if ! command -v git >/dev/null 2>&1; then
+            echo "[ERROR] This is a git install but git is not on PATH."
+            echo "Install Git (https://git-scm.com/) and run this again."
+            exit 1
+        fi
+        echo "This is a git install - updating with git pull..."
+        if ! git pull --ff-only; then
+            echo ""
+            echo "[WARN] git pull could not fast-forward (local changes?)."
+            echo "Commit/stash your changes, or resolve manually, then retry."
+            exit 1
+        fi
+        git lfs pull 2>/dev/null
+        finish
+    fi
+
+    # ---- ZIP installs: download the latest code and overlay ----
+    if command -v curl >/dev/null 2>&1; then
+        DOWNLOAD="curl -L -f --retry 3 -o"
+    elif command -v wget >/dev/null 2>&1; then
+        DOWNLOAD="wget -O"
+    else
+        echo "[ERROR] Neither curl nor wget was found - install one and re-run."
+        exit 1
+    fi
+    if ! command -v rsync >/dev/null 2>&1; then
+        echo "[ERROR] rsync was not found. It ships with macOS; on Linux install it"
+        echo "        with your package manager (e.g. sudo apt-get install rsync)."
+        exit 1
+    fi
+
+    WORKDIR="${TMPDIR:-/tmp}/pax-historia-update"
+    ZIPFILE="$WORKDIR/latest.zip"
+    rm -rf "$WORKDIR"
+    mkdir -p "$WORKDIR"
+
+    echo "Downloading the latest version..."
+    if ! $DOWNLOAD "$ZIPFILE" "https://codeload.github.com/$REPO_OWNER/$REPO_NAME/zip/refs/heads/$REPO_BRANCH"; then
+        echo "[ERROR] Download failed - check your internet connection."
+        exit 1
+    fi
+
+    echo "Extracting..."
+    if command -v unzip >/dev/null 2>&1; then
+        unzip -q "$ZIPFILE" -d "$WORKDIR"
+    else
+        tar -xf "$ZIPFILE" -C "$WORKDIR"
+    fi
+    if [ $? -ne 0 ]; then
+        echo "[ERROR] Could not extract the update."
+        exit 1
+    fi
+
+    SRC="$WORKDIR/$REPO_NAME-$REPO_BRANCH"
+    if [ ! -f "$SRC/package.json" ]; then
+        echo "[ERROR] The downloaded update looks incomplete."
+        exit 1
+    fi
+
+    echo "Updating files (saves and map data are preserved)..."
+
+    # Big map files ship as tiny LFS pointer stubs inside GitHub ZIPs. They must
+    # never overwrite (or trigger deletion of) the real local data. rsync never
+    # deletes excluded files, so these are safe under --delete too.
+    KEEP=(--exclude='*.pmtiles' --exclude='regions-seed.geojson' --exclude='cities-seed.json')
+
+    # 1) Repo-owned code directories are MIRRORED: new files added, changed files
+    #    updated, and files the update removed are deleted locally too.
+    for d in src scripts public; do
+        if [ -d "$SRC/$d" ]; then
+            rsync -a --delete "${KEEP[@]}" "$SRC/$d/" "./$d/" || fail_copy
+        fi
+    done
+
+    #    server code is mirrored as well, but server/data (saves, scenarios,
+    #    library state) is fully protected from both copying and deletion.
+    if [ -d "$SRC/server" ]; then
+        rsync -a --delete --exclude='/data/' "${KEEP[@]}" "$SRC/server/" "./server/" || fail_copy
+    fi
+
+    # 2) Root-level files (package.json, launcher, README, configs...) are
+    #    copied without purging - the root also holds node_modules, dist etc.
+    rsync -a --exclude='*/' "${KEEP[@]}" "$SRC/" "./" || fail_copy
+
+    # 3) Scenario content: ADD new files only - never overwrite the player's
+    #    existing scenario data.
+    if [ -d "$SRC/server/data/scenarios" ]; then
+        mkdir -p "./server/data/scenarios"
+        rsync -a --ignore-existing "$SRC/server/data/scenarios/" "./server/data/scenarios/" || fail_copy
+    fi
+
+    rm -rf "$WORKDIR"
+
+    # Force a rebuild on next launch so the update actually takes effect.
+    rm -rf "dist"
+
+    finish
+}
+
+finish() {
+    # ZIP extraction can lose the executable bit - restore it.
+    chmod +x "Launch Pax Historia.sh" "Update Pax Historia.sh" \
+             "Launch Pax Historia.command" "Update Pax Historia.command" 2>/dev/null
+    echo ""
+    echo "==================================================="
+    echo "  Update complete."
+    echo "  Run \"Launch Pax Historia.sh\" to play - it will"
+    echo "  reinstall dependencies and rebuild automatically."
+    echo "==================================================="
+    echo ""
+    exit 0
+}
+
+main "$@"

--- a/scripts/presets/build-preset.mjs
+++ b/scripts/presets/build-preset.mjs
@@ -49,6 +49,62 @@ const die = (msg) => {
   process.exit(1);
 };
 
+// ── Era cities ────────────────────────────────────────────────────────────────
+// spec.cities: [[name, at, tier, population], ...] where `at` is either the
+// MODERN name of the place in cities-seed.json (coords resolved from the seed,
+// e.g. ["Constantinople", "Istanbul", 4, 200000]) or explicit [lng, lat] for
+// places with no modern successor (Karakorum, Cahokia...). tier drives when the
+// city appears on the game map (4 = great-power capital ★, 3 = major city ◆,
+// 2 = city, 1 = town); population is the historical estimate.
+const CITIES_SEED_PATH = path.join(PROJECT_ROOT, "public", "assets", "cities-seed.json");
+
+const buildCityLookup = () => {
+  const seed = JSON.parse(readFileSync(CITIES_SEED_PATH, "utf8"));
+  const byName = new Map();
+  for (const c of seed) {
+    if (!Array.isArray(c.coord) || c.coord[0] == null || c.coord[1] == null) continue;
+    const key = String(c.name || "").toLowerCase();
+    if (!key) continue;
+    const prev = byName.get(key);
+    // Same-named places (Paris, Texas...) resolve to the most populous one.
+    if (!prev || (c.population || 0) > (prev.population || 0)) byName.set(key, c);
+  }
+  return byName;
+};
+
+const compileCities = (spec) => {
+  if (!Array.isArray(spec.cities) || !spec.cities.length) return null;
+  const lookup = buildCityLookup();
+  const features = [];
+  const cityErrors = [];
+  for (const entry of spec.cities) {
+    const [name, at, tier = 2, population = 0] = entry;
+    let coord = null;
+    if (Array.isArray(at)) {
+      coord = [Number(at[0]), Number(at[1])];
+    } else {
+      const hit = lookup.get(String(at).toLowerCase());
+      if (!hit) {
+        cityErrors.push(`city "${name}": modern place "${at}" not found in cities-seed.json`);
+        continue;
+      }
+      coord = [hit.coord[0], hit.coord[1]];
+    }
+    features.push({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: coord },
+      properties: {
+        city: String(name),
+        population: Number(population) || 0,
+        capital: tier >= 4 ? "primary" : "",
+        tier: Number(tier) || 2,
+      },
+    });
+  }
+  if (cityErrors.length) die(`spec city validation failed:\n  - ${cityErrors.join("\n  - ")}`);
+  return { type: "FeatureCollection", features };
+};
+
 const specArg = process.argv[2];
 if (!specArg) die("usage: node scripts/presets/build-preset.mjs <spec.mjs>");
 const specPath = path.resolve(process.cwd(), specArg);
@@ -128,6 +184,8 @@ const scenarioDir = path.join(SCENARIOS_DIR, spec.id);
 mkdirSync(path.join(scenarioDir, "storage"), { recursive: true });
 const now = new Date().toISOString();
 
+const cityCollection = compileCities(spec);
+
 const world = {
   regionOwnershipOverrides: overrides,
   polityOverrides,
@@ -135,6 +193,9 @@ const world = {
   // so the map shows accurate per-region ownership — the stock pmtiles only fill
   // whole countries by GID_0 and cannot depict era borders inside a country.
   customRegions: true,
+  // Era-accurate cities (cities.geojson) replace the modern city labels — no
+  // St. Petersburg in 117 AD, no Istanbul in 1200.
+  ...(cityCollection ? { customCities: true } : {}),
   // Era-appropriate deployable troop types (e.g. no Air Force in 1200).
   ...(Array.isArray(spec.allowedUnitTypes) ? { allowedUnitTypes: spec.allowedUnitTypes } : {}),
   simulationRules: spec.simulationRules ?? "",
@@ -200,6 +261,10 @@ writeFileSync(
   "utf8",
 );
 
+if (cityCollection) {
+  writeJson(path.join(scenarioDir, "cities.geojson"), cityCollection);
+}
+
 writeJson(path.join(scenarioDir, "game.json"), {
   country: spec.game?.country ?? "",
   startDate: spec.game?.startDate ?? "",
@@ -260,6 +325,9 @@ const assigned = Object.keys(overrides).length;
 console.log(`\n[build-preset] "${spec.id}" written to ${path.relative(PROJECT_ROOT, scenarioDir)}`);
 console.log(`  regions assigned: ${assigned}/${catalog.length} (${catalog.length - assigned} keep modern owner)`);
 console.log(`  regions.geojson: ${regionFeatures.length} features (customRegions=true, tier-2 render)`);
+if (cityCollection) {
+  console.log(`  cities.geojson: ${cityCollection.features.length} era cities (customCities=true)`);
+}
 console.log(`  polities: ${Object.keys(polityOverrides).length}`);
 console.log("  per-polity region counts:");
 for (const [code, n] of Object.entries(perPolity).sort((a, b) => b[1] - a[1])) {

--- a/scripts/presets/colonial-1650.spec.mjs
+++ b/scripts/presets/colonial-1650.spec.mjs
@@ -184,6 +184,103 @@ export default {
     "CHL.6_1": "MAPU", "CHL.3_1": "MAPU", "CHL.10_1": "MAPU", "CHL.9_1": "MAPU",
   },
 
+  // Era cities: [name, modern-seed-name | [lng,lat], tier, population].
+  // tier 4 = great-power capital ★, 3 = major city ◆, 2 = city, 1 = town.
+  // Cape Town is deliberately absent — the VOC station is founded in 1652.
+  cities: [
+    // — English, Dutch, French and Swedish North America —
+    ["Boston", "Boston", 2, 3000],
+    ["Plymouth", [-70.67, 41.96], 1, 1000],
+    ["New Amsterdam", "New York", 2, 1000], // capital of New Netherland
+    ["Fort Orange", [-73.75, 42.65], 1, 500], // Albany — the fur trade post
+    ["Jamestown", [-76.78, 37.21], 1, 1000],
+    ["St. Mary's City", [-76.43, 38.19], 1, 500],
+    ["Fort Christina", [-75.55, 39.74], 1, 400], // capital of New Sweden
+    ["Québec", "Quebec City", 2, 1500], // capital of New France
+    ["Ville-Marie", "Montréal", 1, 300], // the new mission at Montréal
+    ["St. Augustine", "St. Augustine", 1, 1500],
+    ["Santa Fe", [-105.94, 35.69], 1, 1500],
+    // — Native nations —
+    ["Onondaga", [-76.15, 43.05], 2, 2000], // Haudenosaunee council fire
+    ["Chota", [-84.13, 35.56], 1, 1000], // Cherokee mother town
+    // — New Spain and the Caribbean —
+    ["Mexico City", "Mexico City", 4, 100000], // capital of New Spain
+    ["Puebla", "Puebla", 2, 30000],
+    ["Veracruz", "Veracruz", 2, 8000],
+    ["Acapulco", "Acapulco de Juárez", 1, 4000], // the Manila galleon port
+    ["Mérida", "Mérida", 1, 6000],
+    ["Santiago de Guatemala", "Antigua Guatemala", 2, 25000],
+    ["Havana", "Havana", 2, 30000],
+    ["Santo Domingo", "Santo Domingo", 2, 15000],
+    ["San Juan", "San Juan", 1, 5000],
+    ["Cartagena", "Cartagena", 2, 20000],
+    ["Portobelo", [-79.65, 9.55], 1, 3000], // the silver fleet's Atlantic port
+    ["Panamá", "Panama City", 2, 8000],
+    ["Bridgetown", "Bridgetown", 2, 10000], // Barbados sugar boom
+    // — Spanish South America —
+    ["Bogotá", "Bogotá", 2, 15000],
+    ["Quito", "Quito", 2, 25000],
+    ["Lima", "Lima", 4, 60000], // capital of the Viceroyalty of Peru
+    ["Cusco", "Cusco", 2, 20000],
+    ["Potosí", "Potosí", 3, 150000], // the silver mountain — biggest city in the Americas
+    ["La Paz", "La Paz", 1, 5000],
+    ["Asunción", "Asunción", 1, 4000],
+    ["Buenos Aires", "Buenos Aires", 1, 4000],
+    ["Santiago", "Santiago", 1, 5000],
+    // — Portuguese and Dutch Brazil —
+    ["Salvador", "Salvador", 3, 25000], // capital of Portuguese Brazil
+    ["Mauritsstad", "Recife", 2, 15000], // capital of Dutch Brazil
+    ["Rio de Janeiro", "Rio de Janeiro", 2, 8000],
+    ["São Paulo", "São Paulo", 1, 2000],
+    ["Belém", "Belém", 1, 2000],
+    // — Europe: the metropoles —
+    ["London", "London", 4, 400000],
+    ["Paris", "Paris", 4, 450000],
+    ["Madrid", "Madrid", 3, 130000],
+    ["Seville", [-5.99, 37.39], 3, 120000], // the Indies trade monopoly
+    ["Lisbon", "Lisbon", 3, 150000],
+    ["Amsterdam", "Amsterdam", 4, 175000], // the warehouse of the world
+    ["The Hague", "The Hague", 2, 20000],
+    ["Rome", "Rome", 2, 120000],
+    ["Vienna", "Vienna", 2, 60000],
+    ["Berlin", "Berlin", 1, 12000], // small after the Thirty Years' War
+    ["Stockholm", "Stockholm", 2, 35000],
+    ["Copenhagen", "Copenhagen", 2, 30000],
+    ["Warsaw", "Warsaw", 2, 20000],
+    ["Moscow", "Moscow", 3, 150000],
+    ["Constantinople", "Istanbul", 3, 700000], // the Ottoman capital
+    // — Africa —
+    ["Luanda", "Luanda", 2, 6000], // just retaken from the Dutch, 1648
+    ["Elmina", [-1.35, 5.08], 2, 4000], // Dutch Gold Coast castle
+    ["Fez", "Fès", 2, 80000],
+    ["Algiers", "Algiers", 2, 60000],
+    ["Tunis", "Tunis", 2, 70000],
+    ["Cairo", "Cairo", 3, 300000],
+    ["Mombasa", "Mombasa", 1, 6000],
+    ["Mozambique Island", [40.74, -15.03], 1, 5000],
+    // — Asia: the factories and the empires —
+    ["Goa", "Panaji", 3, 60000], // capital of the Portuguese Estado da Índia
+    ["Batavia", "Jakarta", 3, 30000], // VOC headquarters
+    ["Manila", "Manila", 3, 40000],
+    ["Macau", "Macau", 2, 20000],
+    ["Malacca", "Melaka", 2, 10000], // Dutch since 1641
+    ["Colombo", "Colombo", 1, 8000],
+    ["Fort St. George", "Chennai", 1, 5000], // Madras, founded 1639
+    ["Surat", [72.83, 21.17], 3, 100000], // the Mughal port
+    ["Nagasaki", "Nagasaki", 2, 30000], // Dejima — Japan's one window
+    ["Edo", "Tokyo", 4, 400000], // seat of the Tokugawa shoguns
+    ["Kyoto", [135.77, 35.01], 3, 350000],
+    ["Osaka", "Ōsaka", 3, 300000],
+    ["Beijing", "Beijing", 4, 600000], // the new Qing capital
+    ["Nanjing", "Nanjing", 3, 300000],
+    ["Canton", "Guangzhou", 3, 200000],
+    ["Shahjahanabad", "Delhi", 4, 400000], // Shah Jahan's new Mughal capital
+    ["Agra", [78.01, 27.18], 3, 500000],
+    ["Isfahan", [51.67, 32.65], 4, 400000], // Safavid capital — "half the world"
+    ["Ayutthaya", [100.57, 14.35], 3, 150000], // Siamese capital
+    ["Thang Long", "Hanoi", 2, 60000],
+  ],
+
   simulationRules:
     "It is 1650, the height of the first colonial age. Warfare is pike-and-shot: matchlock " +
     "muskets, pikes, siege cannon and ships of the line; armies are small and oceans are " +

--- a/scripts/presets/medieval-1200.spec.mjs
+++ b/scripts/presets/medieval-1200.spec.mjs
@@ -213,6 +213,101 @@ export default {
     "CHN.29_1": "TIBET", "CHN.21_1": "TIBET",
   },
 
+  // Era cities: [name, modern-seed-name | [lng,lat], tier, population].
+  // tier 4 = great-power capital ★, 3 = major city ◆, 2 = city, 1 = town.
+  // Populations are c. 1200 estimates — a medieval "great city" held 50-200k.
+  cities: [
+    // — Christendom —
+    ["Constantinople", "Istanbul", 4, 200000],
+    ["Paris", "Paris", 4, 110000],
+    ["London", "London", 3, 25000],
+    ["Rome", "Rome", 3, 35000],
+    ["Venice", "Venice", 3, 80000],
+    ["Genoa", "Genoa", 2, 50000],
+    ["Pisa", "Pisa", 2, 30000],
+    ["Florence", "Florence", 2, 50000],
+    ["Milan", "Milan", 2, 70000],
+    ["Palermo", [13.36, 38.12], 3, 100000],
+    ["Naples", "Naples", 2, 40000],
+    ["Cologne", "Cologne", 2, 40000],
+    ["Lübeck", "Lübeck", 1, 10000],
+    ["Aachen", [6.08, 50.78], 1, 10000],
+    ["Prague", "Prague", 2, 30000],
+    ["Vienna", "Vienna", 2, 20000],
+    ["Esztergom", "Esztergom", 2, 12000], // Hungarian royal seat
+    ["Kraków", "Kraków", 2, 15000],
+    ["Kiev", "Kyiv", 3, 45000],
+    ["Novgorod", [31.27, 58.52], 3, 30000],
+    ["Vladimir", "Vladimir", 2, 20000],
+    ["Smolensk", "Smolensk", 1, 15000],
+    ["Uppsala", "Uppsala", 1, 5000],
+    ["Nidaros", "Trondheim", 1, 5000],
+    ["Roskilde", "Roskilde", 1, 6000],
+    ["Tarnovo", [25.62, 43.08], 2, 15000], // Bulgarian capital
+    ["Thessalonica", [22.94, 40.64], 2, 40000],
+    ["Toledo", [-4.02, 39.86], 2, 35000], // Castilian royal city
+    ["Lisbon", "Lisbon", 2, 20000],
+    ["Barcelona", "Barcelona", 2, 25000],
+    // — Dar al-Islam —
+    ["Seville", [-5.99, 37.39], 3, 80000], // Almohad seat in al-Andalus
+    ["Córdoba", [-4.78, 37.89], 3, 60000],
+    ["Granada", "Granada", 2, 30000],
+    ["Marrakesh", "Marrakech", 3, 100000], // Almohad capital
+    ["Fez", "Fès", 3, 80000],
+    ["Tunis", "Tunis", 2, 40000],
+    ["Cairo", "Cairo", 4, 200000], // Ayyubid capital
+    ["Alexandria", "Alexandria", 2, 60000],
+    ["Damascus", "Damascus", 3, 80000],
+    ["Aleppo", "Aleppo", 2, 60000],
+    ["Jerusalem", "Jerusalem", 2, 20000],
+    ["Acre", [35.07, 32.93], 2, 40000], // Crusader capital
+    ["Baghdad", "Baghdad", 4, 300000], // Abbasid caliphal seat
+    ["Mosul", "Mosul", 2, 40000],
+    ["Konya", "Konya", 2, 30000], // Seljuk Rum capital
+    ["Mecca", "Mecca", 2, 15000],
+    ["Tabriz", [46.29, 38.08], 2, 40000],
+    ["Isfahan", [51.67, 32.65], 2, 60000],
+    ["Nishapur", [58.8, 36.21], 2, 70000],
+    ["Merv", [62.19, 37.66], 3, 100000],
+    ["Bukhara", "Bukhara", 2, 60000],
+    ["Samarkand", "Samarkand", 3, 80000],
+    ["Gurganj", [59.15, 42.33], 3, 90000], // Khwarazmian capital
+    ["Ghazni", "Ghaznī", 2, 40000], // Ghurid twin capital
+    ["Herat", [62.2, 34.35], 2, 40000],
+    // — India and Ceylon —
+    ["Delhi", "Delhi", 2, 50000], // seat of the new Ghurid conquest
+    ["Lahore", "Lahore", 2, 40000],
+    ["Varanasi", [83.01, 25.32], 2, 50000],
+    ["Thanjavur", [79.14, 10.79], 2, 60000], // Chola capital
+    ["Polonnaruwa", [81.0, 7.94], 2, 30000], // Lankan capital
+    // — East and Southeast Asia —
+    ["Hangzhou", "Hangzhou", 4, 500000], // Lin'an, Southern Song capital
+    ["Zhongdu", "Beijing", 3, 250000], // Jin capital
+    ["Kaifeng", [114.31, 34.8], 3, 300000],
+    ["Chengdu", "Chengdu", 2, 150000],
+    ["Guangzhou", "Guangzhou", 2, 150000],
+    ["Quanzhou", "Quanzhou", 2, 150000],
+    ["Chang'an", [108.94, 34.34], 2, 80000],
+    ["Kyoto", [135.77, 35.01], 3, 150000], // Heian-kyō
+    ["Kamakura", [139.55, 35.32], 2, 50000], // seat of the new shogunate
+    ["Kaesong", [126.55, 37.97], 2, 60000], // Goryeo capital
+    ["Pagan", [94.86, 21.17], 3, 60000], // Burmese capital
+    ["Angkor", [103.86, 13.44], 4, 400000], // Khmer capital — largest city on earth by area
+    ["Thang Long", "Hanoi", 2, 50000], // Đại Việt capital
+    // — Africa beyond Islam —
+    ["Koumbi Saleh", [-7.68, 15.77], 2, 20000], // Ghana Empire
+    ["Timbuktu", "Timbuktu", 1, 8000],
+    ["Lalibela", [39.04, 12.03], 2, 15000], // Zagwe capital
+    ["Kilwa", [39.51, -8.96], 2, 12000],
+    ["Mogadishu", "Mogadishu", 2, 15000],
+    ["Great Zimbabwe", [30.93, -20.27], 2, 10000],
+    // — The Americas —
+    ["Cahokia", [-90.06, 38.66], 2, 15000],
+    ["Chan Chan", [-79.07, -8.1], 2, 30000], // Chimor capital
+    ["Cusco", "Cusco", 1, 5000],
+    ["Mayapan", [-89.46, 20.63], 1, 10000],
+  ],
+
   simulationRules:
     "It is the year 1200, the height of the Middle Ages. Warfare is feudal: mounted knights, " +
     "levied infantry, castles and sieges; there is NO gunpowder and NO standing professional " +

--- a/scripts/presets/mongol-1300.spec.mjs
+++ b/scripts/presets/mongol-1300.spec.mjs
@@ -223,6 +223,94 @@ export default {
     "IND.31_1": "PAND", "IND.27_1": "PAND",
   },
 
+  // Era cities: [name, modern-seed-name | [lng,lat], tier, population].
+  // tier 4 = great-power capital ★, 3 = major city ◆, 2 = city, 1 = town.
+  cities: [
+    // — The Mongol khanates —
+    ["Khanbaliq", "Beijing", 4, 400000], // Dadu, the Yuan capital
+    ["Karakorum", [102.85, 47.2], 2, 25000], // the old imperial capital
+    ["Shangdu", [116.18, 42.36], 2, 30000], // Xanadu, the summer court
+    ["Sarai", [47.98, 46.63], 4, 100000], // Golden Horde capital
+    ["Bolghar", [49.06, 54.98], 2, 30000],
+    ["Tabriz", [46.29, 38.08], 4, 150000], // Ilkhanate capital
+    ["Baghdad", "Baghdad", 2, 100000], // never recovered from 1258
+    ["Isfahan", [51.67, 32.65], 2, 60000],
+    ["Shiraz", [52.54, 29.61], 2, 50000],
+    ["Herat", [62.2, 34.35], 2, 50000],
+    ["Samarkand", "Samarkand", 2, 70000],
+    ["Bukhara", "Bukhara", 2, 50000],
+    ["Urgench", [59.15, 42.33], 3, 90000],
+    ["Almaliq", [80.42, 44.16], 2, 20000], // Chagatai seat
+    ["Kashgar", "Kashgar", 1, 20000],
+    // — Yuan China beyond the capital —
+    ["Hangzhou", "Hangzhou", 3, 800000], // Quinsai — Marco Polo's greatest city
+    ["Quanzhou", "Quanzhou", 3, 200000], // Zayton, the great port
+    ["Guangzhou", "Guangzhou", 2, 150000],
+    ["Chengdu", "Chengdu", 2, 100000],
+    ["Kaifeng", [114.31, 34.8], 2, 100000],
+    // — Tributaries and neighbours —
+    ["Kaesong", [126.55, 37.97], 2, 60000], // Goryeo, Yuan son-in-law state
+    ["Kyoto", [135.77, 35.01], 3, 150000],
+    ["Kamakura", [139.55, 35.32], 3, 80000], // the shogunate that beat the Mongols
+    ["Pagan", [94.86, 21.17], 1, 20000], // sacked 1287, in decline
+    ["Sukhothai", [99.82, 17.01], 2, 25000],
+    ["Angkor", [103.86, 13.44], 3, 300000],
+    ["Thang Long", "Hanoi", 2, 60000], // repelled three invasions
+    ["Delhi", "Delhi", 4, 200000], // Delhi Sultanate — the Mongols' wall
+    ["Multan", "Multan", 2, 40000],
+    ["Devagiri", [75.23, 19.94], 2, 50000], // Yadava capital
+    ["Madurai", "Madurai", 2, 50000], // Pandya capital
+    // — The Mamluks and Islam beyond the Ilkhans —
+    ["Cairo", "Cairo", 4, 450000], // Mamluk capital, greatest city of Islam
+    ["Damascus", "Damascus", 3, 80000],
+    ["Aleppo", "Aleppo", 2, 50000],
+    ["Mecca", "Mecca", 2, 15000],
+    ["Fez", "Fès", 3, 120000], // Marinid capital
+    ["Tunis", "Tunis", 2, 50000], // Hafsid capital
+    ["Tlemcen", [-1.31, 34.88], 2, 40000],
+    ["Granada", "Granada", 3, 50000], // Nasrid capital
+    // — Christendom —
+    ["Constantinople", "Istanbul", 3, 60000], // restored but diminished
+    ["Paris", "Paris", 4, 200000],
+    ["London", "London", 3, 80000],
+    ["Venice", "Venice", 3, 100000],
+    ["Genoa", "Genoa", 3, 90000],
+    ["Florence", "Florence", 3, 90000],
+    ["Milan", "Milan", 2, 100000],
+    ["Rome", "Rome", 2, 30000],
+    ["Naples", "Naples", 2, 50000],
+    ["Palermo", [13.36, 38.12], 2, 50000],
+    ["Bruges", "Bruges", 2, 40000],
+    ["Ghent", [3.72, 51.05], 2, 55000],
+    ["Cologne", "Cologne", 2, 40000],
+    ["Lübeck", "Lübeck", 2, 20000],
+    ["Prague", "Prague", 2, 35000],
+    ["Vienna", "Vienna", 2, 25000],
+    ["Buda", "Budapest", 2, 15000],
+    ["Kraków", "Kraków", 2, 20000],
+    ["Seville", [-5.99, 37.39], 2, 40000],
+    ["Barcelona", "Barcelona", 2, 40000],
+    ["Lisbon", "Lisbon", 2, 30000],
+    // — The Rus' under the Horde —
+    ["Novgorod", [31.27, 58.52], 3, 30000],
+    ["Moscow", "Moscow", 1, 10000], // a minor fort, for now
+    ["Tver", "Tver", 2, 15000],
+    ["Vladimir", "Vladimir", 2, 15000],
+    ["Kiev", "Kyiv", 1, 10000], // devastated, 1240
+    // — Africa and the Indian Ocean —
+    ["Niani", [-9.6, 11.38], 3, 30000], // Mali imperial capital
+    ["Timbuktu", "Timbuktu", 2, 20000],
+    ["Kilwa", [39.51, -8.96], 2, 15000],
+    ["Mogadishu", "Mogadishu", 2, 20000],
+    ["Great Zimbabwe", [30.93, -20.27], 2, 15000],
+    // — The Americas —
+    ["Cahokia", [-90.06, 38.66], 1, 8000], // in decline
+    ["Mayapan", [-89.46, 20.63], 2, 15000],
+    ["Azcapotzalco", [-99.18, 19.48], 1, 10000], // Tepanec seat in the Valley of Mexico
+    ["Cusco", "Cusco", 2, 10000], // the young Inca seat
+    ["Chan Chan", [-79.07, -8.1], 3, 40000], // Chimor at its height
+  ],
+
   simulationRules:
     "It is 1300 AD. The Mongol Empire is the largest land empire in history but is no longer " +
     "one state: the Yuan Great Khan (Temur, Kublai's grandson) reigns in Khanbaliq and is " +

--- a/scripts/presets/roman-117.spec.mjs
+++ b/scripts/presets/roman-117.spec.mjs
@@ -83,6 +83,83 @@ export default {
     "GBR.3_1": "CALE",
   },
 
+  // Era cities: [name, modern-seed-name | [lng,lat], tier, population].
+  // tier 4 = imperial capital ★, 3 = great city ◆, 2 = city, 1 = town.
+  // Populations are the usual scholarly estimates for the early 2nd century.
+  cities: [
+    // — The Roman Empire —
+    ["Roma", "Rome", 4, 1000000],
+    ["Alexandria", "Alexandria", 3, 500000],
+    ["Antiochia", [36.16, 36.2], 3, 250000],
+    ["Carthago", [10.32, 36.85], 3, 150000],
+    ["Ephesus", [27.34, 37.94], 2, 150000],
+    ["Pergamum", [27.18, 39.13], 2, 120000],
+    ["Smyrna", [27.14, 38.43], 2, 90000],
+    ["Corinthus", [22.93, 37.94], 2, 80000],
+    ["Athenae", "Athens", 2, 75000],
+    ["Thessalonica", [22.94, 40.64], 2, 65000],
+    ["Byzantium", "Istanbul", 2, 40000],
+    ["Nicomedia", [29.92, 40.77], 2, 60000],
+    ["Ancyra", "Ankara", 1, 25000],
+    ["Londinium", "London", 2, 30000],
+    ["Eboracum", [-1.08, 53.96], 1, 5000],
+    ["Lutetia", "Paris", 1, 8000],
+    ["Lugdunum", "Lyon", 2, 50000],
+    ["Massilia", "Marseille", 2, 40000],
+    ["Burdigala", "Bordeaux", 1, 20000],
+    ["Colonia Agrippina", "Cologne", 2, 30000],
+    ["Mediolanum", "Milan", 2, 40000],
+    ["Ravenna", "Ravenna", 2, 20000],
+    ["Aquileia", [13.37, 45.77], 2, 30000],
+    ["Syracusae", [15.29, 37.07], 2, 60000],
+    ["Tarraco", "Tarragona", 2, 30000],
+    ["Corduba", [-4.78, 37.89], 2, 50000],
+    ["Gades", [-6.29, 36.53], 2, 50000],
+    ["Emerita Augusta", [-6.34, 38.92], 1, 25000],
+    ["Tingis", "Tangier", 1, 15000],
+    ["Volubilis", [-5.55, 34.07], 1, 12000],
+    ["Leptis Magna", [14.29, 32.64], 2, 80000],
+    ["Cyrene", [21.86, 32.82], 2, 50000],
+    ["Memphis", [31.25, 29.85], 2, 60000],
+    ["Hierosolyma", "Jerusalem", 1, 10000],
+    ["Caesarea", [34.89, 32.5], 2, 45000],
+    ["Damascus", "Damascus", 2, 45000],
+    ["Palmyra", [38.28, 34.55], 2, 30000],
+    ["Petra", [35.44, 30.32], 2, 20000],
+    ["Sarmizegetusa", [22.79, 45.52], 2, 15000],
+    ["Artaxata", [44.55, 39.88], 2, 30000],
+    ["Ctesiphon", [44.58, 33.09], 3, 250000], // taken by Trajan, 116
+    // — Parthia and the Iranian east —
+    ["Ecbatana", [48.52, 34.8], 2, 60000],
+    ["Susa", [48.26, 32.19], 1, 25000],
+    ["Merv", [62.19, 37.66], 2, 50000],
+    // — The Kushan realm and India —
+    ["Purushapura", "Peshawar", 3, 100000],
+    ["Taxila", [72.79, 33.74], 2, 40000],
+    ["Mathura", "Mathura", 2, 60000],
+    ["Pataliputra", "Patna", 3, 150000],
+    ["Ujjain", "Ujjain", 2, 80000],
+    ["Madurai", "Madurai", 2, 50000],
+    ["Anuradhapura", "Anuradhapura", 3, 60000],
+    // — Han China and East Asia —
+    ["Luoyang", "Luoyang", 4, 500000],
+    ["Chang'an", [108.94, 34.34], 3, 250000],
+    ["Chengdu", "Chengdu", 2, 100000],
+    ["Panyu", "Guangzhou", 2, 50000],
+    ["Longbian", "Hanoi", 1, 20000],
+    ["Gungnae", [126.19, 41.16], 2, 20000], // Goguryeo capital
+    // — Africa, Arabia, the Caucasus —
+    ["Meroe", [33.75, 16.94], 3, 25000],
+    ["Aksum", [38.72, 14.13], 3, 20000],
+    ["Zafar", [44.4, 14.21], 2, 15000], // Himyarite capital
+    ["Mtskheta", [44.72, 41.84], 2, 15000], // Iberian capital
+    // — Funan and the Americas —
+    ["Vyadhapura", [105.15, 10.25], 2, 20000], // Funan (Oc Eo)
+    ["Teotihuacan", [-98.84, 19.69], 3, 125000],
+    ["Tikal", [-89.62, 17.22], 2, 40000],
+    ["Monte Alban", [-96.77, 17.04], 1, 17000],
+  ],
+
   simulationRules:
     "It is 117 AD, the high-water mark of Rome. Warfare is classical: legions and auxilia, " +
     "disciplined heavy infantry, cataphract and horse-archer cavalry, siege engines, war " +

--- a/scripts/presets/wwii-1939.spec.mjs
+++ b/scripts/presets/wwii-1939.spec.mjs
@@ -159,6 +159,136 @@ export default {
     "YEM.7_1": "GBR",   // Al Mahrah
   },
 
+  // Era cities: [name, modern-seed-name | [lng,lat], tier, population].
+  // tier 4 = great-power capital ★, 3 = major city ◆, 2 = city, 1 = town.
+  // Names and populations as of 1939 (Danzig, Königsberg, Leningrad, Batavia...).
+  cities: [
+    // — Europe —
+    ["Berlin", "Berlin", 4, 4339000],
+    ["Hamburg", "Hamburg", 3, 1712000],
+    ["Munich", "Munich", 2, 829000],
+    ["Cologne", "Cologne", 2, 772000],
+    ["Vienna", "Vienna", 3, 1918000], // annexed, 1938
+    ["Prague", "Prague", 2, 962000], // Protectorate of Bohemia-Moravia
+    ["Danzig", "Gdańsk", 2, 400000], // the Free City — the war's first prize
+    ["Königsberg", "Kaliningrad", 2, 372000],
+    ["Breslau", "Wrocław", 2, 630000],
+    ["Warsaw", "Warsaw", 3, 1289000],
+    ["London", "London", 4, 8615000],
+    ["Manchester", "Manchester", 2, 736000],
+    ["Glasgow", [-4.25, 55.86], 2, 1128000],
+    ["Paris", "Paris", 4, 2830000],
+    ["Marseille", "Marseille", 2, 914000],
+    ["Rome", "Rome", 4, 1284000],
+    ["Milan", "Milan", 3, 1116000],
+    ["Naples", "Naples", 2, 866000],
+    ["Madrid", "Madrid", 3, 1048000], // Franco's Spain, war just ended
+    ["Barcelona", "Barcelona", 2, 1081000],
+    ["Lisbon", "Lisbon", 2, 594000],
+    ["Amsterdam", "Amsterdam", 2, 800000],
+    ["Brussels", [4.35, 50.85], 2, 913000],
+    ["Bern", [7.45, 46.95], 1, 122000],
+    ["Copenhagen", "Copenhagen", 2, 700000],
+    ["Oslo", "Oslo", 2, 276000],
+    ["Stockholm", "Stockholm", 2, 570000],
+    ["Helsinki", "Helsinki", 2, 291000],
+    ["Tallinn", "Tallinn", 1, 145000],
+    ["Riga", "Riga", 2, 385000],
+    ["Kaunas", "Kaunas", 1, 152000], // interwar Lithuanian capital
+    ["Budapest", "Budapest", 3, 1163000],
+    ["Bucharest", "Bucharest", 2, 870000],
+    ["Belgrade", "Belgrade", 2, 320000],
+    ["Sofia", "Sofia", 2, 401000],
+    ["Athens", "Athens", 2, 481000],
+    ["Dublin", "Dublin", 1, 472000],
+    // — Soviet Union —
+    ["Moscow", "Moscow", 4, 4137000],
+    ["Leningrad", [30.32, 59.94], 3, 3191000],
+    ["Stalingrad", "Volgograd", 2, 445000],
+    ["Kiev", "Kyiv", 2, 847000],
+    ["Kharkov", "Kharkiv", 2, 833000],
+    ["Minsk", "Minsk", 2, 239000],
+    ["Odessa", "Odesa", 2, 604000],
+    ["Baku", "Baku", 2, 809000], // the oil fields
+    ["Tbilisi", "Tbilisi", 1, 519000],
+    ["Tashkent", "Tashkent", 2, 585000],
+    ["Novosibirsk", "Novosibirsk", 1, 404000],
+    ["Vladivostok", "Vladivostok", 1, 206000],
+    // — Middle East and Africa —
+    ["Istanbul", "Istanbul", 3, 793000],
+    ["Ankara", "Ankara", 2, 157000],
+    ["Tehran", "Tehran", 2, 540000],
+    ["Baghdad", "Baghdad", 2, 400000],
+    ["Jerusalem", "Jerusalem", 1, 132000], // British Mandate
+    ["Cairo", "Cairo", 3, 1312000],
+    ["Alexandria", "Alexandria", 2, 686000],
+    ["Tripoli", "Tripoli", 1, 111000], // Italian Libya
+    ["Algiers", "Algiers", 2, 252000],
+    ["Casablanca", "Casablanca", 2, 257000],
+    ["Dakar", "Dakar", 1, 92000],
+    ["Lagos", "Lagos", 1, 167000],
+    ["Léopoldville", "Kinshasa", 1, 46000], // Belgian Congo
+    ["Nairobi", "Nairobi", 1, 61000],
+    ["Addis Ababa", "Addis Ababa", 2, 300000], // occupied Italian East Africa
+    ["Johannesburg", "Johannesburg", 2, 500000],
+    ["Cape Town", "Cape Town", 2, 344000],
+    // — Asia —
+    ["Tokyo", "Tokyo", 4, 6779000],
+    ["Osaka", "Ōsaka", 3, 3252000],
+    ["Kyoto", [135.77, 35.01], 2, 1090000],
+    ["Hiroshima", "Hiroshima", 1, 344000],
+    ["Keijo", "Seoul", 2, 774000], // colonial Seoul
+    ["Hsinking", [125.32, 43.88], 2, 415000], // capital of Manchukuo
+    ["Mukden", "Shenyang", 2, 863000],
+    ["Peiping", "Beijing", 3, 1556000], // occupied
+    ["Tientsin", "Tianjin", 3, 1210000], // occupied
+    ["Shanghai", "Shanghai", 4, 3727000], // occupied — the foreign concessions remain
+    ["Nanking", "Nanjing", 2, 700000], // occupied
+    ["Chungking", "Chongqing", 3, 635000], // Free China's wartime capital
+    ["Canton", "Guangzhou", 2, 1122000], // occupied
+    ["Hong Kong", "Hong Kong", 2, 1050000],
+    ["Hanoi", "Hanoi", 2, 149000], // French Indochina
+    ["Saigon", "Ho Chi Minh City", 2, 256000],
+    ["Bangkok", "Bangkok", 2, 681000],
+    ["Rangoon", [96.16, 16.87], 2, 400000], // British Burma
+    ["Singapore", "Singapore", 2, 728000], // the fortress
+    ["Batavia", "Jakarta", 2, 533000], // Dutch East Indies capital
+    ["Manila", "Manila", 2, 623000], // U.S. Commonwealth
+    ["Delhi", "Delhi", 3, 522000], // capital of the British Raj
+    ["Bombay", "Mumbai", 3, 1490000],
+    ["Calcutta", [88.36, 22.57], 3, 2109000],
+    ["Karachi", "Karachi", 2, 387000],
+    ["Colombo", "Colombo", 1, 362000],
+    // — The Americas —
+    ["New York", "New York", 4, 7455000],
+    ["Washington", [-77.04, 38.91], 3, 663000],
+    ["Chicago", "Chicago", 3, 3397000],
+    ["Detroit", "Detroit", 2, 1623000],
+    ["Los Angeles", "Los Angeles", 3, 1504000],
+    ["San Francisco", "San Francisco", 2, 635000],
+    ["Honolulu", "Honolulu", 1, 179000],
+    ["Ottawa", "Ottawa", 2, 155000],
+    ["Toronto", "Toronto", 2, 667000],
+    ["Montreal", "Montréal", 2, 903000],
+    ["Vancouver", "Vancouver", 1, 275000],
+    ["Mexico City", "Mexico City", 3, 1560000],
+    ["Havana", "Havana", 2, 570000],
+    ["Caracas", "Caracas", 1, 269000],
+    ["Bogotá", "Bogotá", 1, 330000],
+    ["Lima", "Lima", 2, 533000],
+    ["Santiago", "Santiago", 2, 952000],
+    ["Buenos Aires", "Buenos Aires", 3, 2400000],
+    ["Montevideo", "Montevideo", 2, 700000],
+    ["Rio de Janeiro", "Rio de Janeiro", 3, 1764000],
+    ["São Paulo", "São Paulo", 3, 1258000],
+    // — Oceania —
+    ["Sydney", "Sydney", 2, 1302000],
+    ["Melbourne", "Melbourne", 2, 1046000],
+    ["Canberra", "Canberra", 1, 11000],
+    ["Wellington", "Wellington", 1, 158000],
+    ["Auckland", "Auckland", 1, 221000],
+  ],
+
   simulationRules:
     "It is 1 September 1939. Germany has just invaded Poland; Britain and France will " +
     "declare war within 48 hours, beginning the Second World War. The Molotov–Ribbentrop " +

--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -76,6 +76,9 @@ const PMTILES_ASSET_FILES = {
 // without it fall back to the stock pmtiles rendering (full backward-compat).
 const SCENARIO_GEOJSON_ASSET_FILES = {
   regionsGeojson: "regions.geojson",
+  // Era-accurate custom cities (points). When world.customCities is set the game
+  // renders these instead of the modern cities.pmtiles labels.
+  citiesGeojson: "cities.geojson",
 };
 
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
@@ -115,6 +118,7 @@ const JSON_ASSET_DEFAULTS = {
 const TEMPLATE_WORLD_OVERRIDE_KEYS = [
   "allowedUnitTypes",
 "author",
+"customCities",
 "customRegions",
 "difficulty",
 "language",
@@ -1722,12 +1726,12 @@ const getActiveRuntimeScenarioSummary = () => {
 const readRuntimeJsonAsset = (assetKey) => {
   ensureGameStore();
 
-  // Custom region geometry is scenario-scoped (static map data). Resolve it from
-  // the active game's scenario, mirroring how pmtiles overrides resolve. Absent
-  // => empty collection, so the game keeps its stock pmtiles rendering.
-  if (assetKey === "regionsGeojson") {
+  // Custom region/city geometry is scenario-scoped (static map data). Resolve it
+  // from the active game's scenario, mirroring how pmtiles overrides resolve.
+  // Absent => empty collection, so the game keeps its stock pmtiles rendering.
+  if (assetKey in SCENARIO_GEOJSON_ASSET_FILES) {
     const scenario = getActiveRuntimeScenarioSummary();
-    const overridePath = getScenarioUploadPath(scenario.id, "regionsGeojson");
+    const overridePath = getScenarioUploadPath(scenario.id, assetKey);
     const hasOverride = fs.existsSync(overridePath);
     return {
       contentType: "application/json; charset=utf-8",
@@ -1914,6 +1918,7 @@ const exportScenarioBundle = (scenarioId, { mode = "light" } = {}) => {
       countries: buildScenarioBundleAsset(scenarioId, "countries", mode),
       regions: buildScenarioBundleAsset(scenarioId, "regions", mode),
       regionsGeojson: buildScenarioBundleAsset(scenarioId, "regionsGeojson", mode),
+      citiesGeojson: buildScenarioBundleAsset(scenarioId, "citiesGeojson", mode),
     },
     data: {
       actions: cloneJson(details.data.actions),

--- a/src/Editor/CityPopup.jsx
+++ b/src/Editor/CityPopup.jsx
@@ -1,0 +1,110 @@
+/*!
+ * Pax Historia Map Editor
+ * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
+ */
+
+// Inline city editor, anchored where the map was clicked. Opens when the city
+// tool places a new city (name pre-selected — just type) or when an existing
+// city is clicked with the tool. Size sets the population/prominence tier that
+// drives when the city appears on the exported game map.
+
+import { useEffect, useRef } from "react";
+import { panelSurface, inputStyle, pillButton } from "./editorStyles.js";
+
+const SIZES = [
+  { value: "town", label: "Town", population: 20000 },
+  { value: "city", label: "City", population: 250000 },
+  { value: "major", label: "Major city", population: 1500000 },
+];
+
+const sizeOf = (population = 0) => (population >= 1000000 ? "major" : population >= 100000 ? "city" : "town");
+
+const CityPopup = ({ feature, x, y, isNew, onChange, onDelete, onClose }) => {
+  const nameRef = useRef(null);
+
+  // New city: focus the name and select the placeholder so typing replaces it.
+  useEffect(() => {
+    if (!nameRef.current) return;
+    nameRef.current.focus();
+    if (isNew) nameRef.current.select();
+  }, [isNew]);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape" || e.key === "Enter") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  if (!feature) return null;
+  const tags = feature.tags || [];
+  const isCapital = tags.includes("capital");
+
+  const left = Math.max(8, Math.min(x - 20, (window.innerWidth || 1200) - 268));
+  const top = Math.max(8, Math.min(y + 14, (window.innerHeight || 800) - 190));
+
+  return (
+    <div
+      style={{
+        ...panelSurface,
+        position: "fixed",
+        left,
+        top,
+        zIndex: 45,
+        width: 250,
+        padding: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        fontSize: 12,
+      }}
+    >
+      <input
+        ref={nameRef}
+        value={feature.name || ""}
+        onChange={(e) => onChange({ name: e.target.value })}
+        placeholder="City name"
+        style={{ ...inputStyle, padding: "6px 8px", fontSize: 13, fontWeight: 600 }}
+      />
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <select
+          value={sizeOf(feature.population)}
+          onChange={(e) => {
+            const size = SIZES.find((s) => s.value === e.target.value);
+            if (size) onChange({ population: size.population });
+          }}
+          style={{ ...inputStyle, padding: "5px 6px", flex: 1 }}
+        >
+          {SIZES.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+        <label style={{ display: "flex", alignItems: "center", gap: 5, cursor: "pointer", whiteSpace: "nowrap" }}>
+          <input
+            type="checkbox"
+            checked={isCapital}
+            onChange={(e) =>
+              onChange({
+                tags: e.target.checked ? [...tags.filter((t) => t !== "capital"), "capital"] : tags.filter((t) => t !== "capital"),
+              })
+            }
+          />
+          ★ Capital
+        </label>
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+        <button onClick={onDelete} style={{ ...pillButton(false), color: "#f87171" }}>
+          Delete
+        </button>
+        <button onClick={onClose} style={{ ...pillButton(true) }}>
+          Done
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CityPopup;

--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -20,6 +20,8 @@ import LayersPanel from "./LayersPanel.jsx";
 import FeatureManager from "./FeatureManager.jsx";
 import SelectionInspector from "./SelectionInspector.jsx";
 import DocumentsMenu from "./DocumentsMenu.jsx";
+import CityPopup from "./CityPopup.jsx";
+import SearchBar from "./SearchBar.jsx";
 import { useMapDocument, createDocument, newId } from "./useMapDocument.js";
 import { saveDocument, loadDocument, downloadJson } from "./documentIO.js";
 import { buildGameSeed } from "./exportPreset.js";
@@ -33,6 +35,7 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario } = {}) => {
   const [docId, setDocId] = useState(null); // server document id (null until first save)
   const [history, setHistory] = useState({ canUndo: false, canRedo: false });
   const [applying, setApplying] = useState(false); // writing the map into the scenario
+  const [cityPopup, setCityPopup] = useState(null); // {id, x, y, isNew} — inline city editor
 
   const togglePanel = (name) => setOpenPanel((cur) => (cur === name ? null : name));
 
@@ -109,6 +112,15 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario } = {}) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, d.saveStatus, docId, d.name, d.types, d.features, d.metadata]);
 
+  // The city popup is anchored to a screen position; panning/zooming would leave
+  // it floating over the wrong spot, so any map movement closes it.
+  useEffect(() => {
+    if (!api?.map) return undefined;
+    const close = () => setCityPopup(null);
+    api.map.on("movestart", close);
+    return () => api.map.un("movestart", close);
+  }, [api]);
+
   // Region-count-per-type for the Type Manager (recomputed on relevant changes).
   const typeUsage = useMemo(
     () => (api ? api.countByType() : {}),
@@ -143,19 +155,29 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario } = {}) => {
           d.setRegionCount(count);
           d.setSaveStatus("dirty");
         }}
-        onFeatureCreate={(partial) => {
+        onFeatureCreate={({ pixel, ...partial }) => {
+          const id = newId("feat");
           d.setFeatures((list) => [
             ...list,
             {
-              id: newId("feat"),
+              id,
               name: "New City",
               type: "Coordinate",
               symbol: "square",
-              tags: [],
+              tags: ["city"],
+              population: 250000,
               ...partial,
             },
           ]);
           d.setSaveStatus("dirty");
+          // Open the inline editor right where the city was dropped.
+          setCityPopup({ id, x: pixel?.[0] ?? 80, y: pixel?.[1] ?? 80, isNew: true });
+        }}
+        onFeatureEdit={({ id, pixel }) => setCityPopup({ id, x: pixel[0], y: pixel[1], isNew: false })}
+        onFeatureRemove={(id) => {
+          d.setFeatures((list) => list.filter((f) => f.id !== id));
+          d.setSaveStatus("dirty");
+          setCityPopup((p) => (p?.id === id ? null : p));
         }}
         onHistory={setHistory}
         onReady={setApi}
@@ -282,6 +304,47 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario } = {}) => {
         colors={d.colors}
         setSelection={d.setSelection}
       />
+
+      <SearchBar
+        api={api}
+        features={d.features}
+        onAddCity={(c) => {
+          const id = newId("feat");
+          d.setFeatures((list) => [
+            ...list,
+            {
+              id,
+              name: c.name,
+              type: "Coordinate",
+              symbol: "square",
+              coord: c.coord,
+              country: c.country || "",
+              owner: null,
+              regionId: null,
+              population: c.population || 0,
+              tags: c.capital ? ["city", "capital"] : ["city"],
+            },
+          ]);
+          api?.locateFeature(c.coord);
+        }}
+      />
+
+      {cityPopup && (
+        <CityPopup
+          feature={d.features.find((f) => f.id === cityPopup.id)}
+          x={cityPopup.x}
+          y={cityPopup.y}
+          isNew={cityPopup.isNew}
+          onChange={(patch) =>
+            d.setFeatures((list) => list.map((f) => (f.id === cityPopup.id ? { ...f, ...patch } : f)))
+          }
+          onDelete={() => {
+            d.setFeatures((list) => list.filter((f) => f.id !== cityPopup.id));
+            setCityPopup(null);
+          }}
+          onClose={() => setCityPopup(null)}
+        />
+      )}
 
       <BottomBar
         counts={d.counts}

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -82,6 +82,8 @@ const OlMap = ({
   onRegionCount,
   onRegionsChanged,
   onFeatureCreate,
+  onFeatureEdit,
+  onFeatureRemove,
   onHistory,
   onReady,
 }) => {
@@ -98,6 +100,10 @@ const OlMap = ({
   const redoStackRef = useRef([]);
   const onFeatureCreateRef = useRef(onFeatureCreate);
   onFeatureCreateRef.current = onFeatureCreate;
+  const onFeatureEditRef = useRef(onFeatureEdit);
+  onFeatureEditRef.current = onFeatureEdit;
+  const onFeatureRemoveRef = useRef(onFeatureRemove);
+  onFeatureRemoveRef.current = onFeatureRemove;
   const onHistoryRef = useRef(onHistory);
   onHistoryRef.current = onHistory;
 
@@ -252,6 +258,21 @@ const OlMap = ({
       });
     };
 
+    // City/point feature under the cursor (generous tolerance — point markers
+    // are small).
+    const pointAtPixel = (pixel, tolerance = 8) => {
+      let point = null;
+      map.forEachFeatureAtPixel(
+        pixel,
+        (feature) => {
+          point = feature;
+          return true;
+        },
+        { layerFilter: (l) => l === pointLayerRef.current, hitTolerance: tolerance },
+      );
+      return point;
+    };
+
     map.on("singleclick", (evt) => {
       const tool = activeToolRef.current;
       if (tool !== "select" && tool !== "delete" && tool !== "paint" && tool !== "feature" && tool !== "dissolve") return;
@@ -265,6 +286,12 @@ const OlMap = ({
         { layerFilter: (l) => l === regionLayerRef.current, hitTolerance: 2 },
       );
       if (tool === "delete") {
+        // Deleting works on cities too — a point hit wins over the region under it.
+        const point = pointAtPixel(evt.pixel);
+        if (point) {
+          onFeatureRemoveRef.current?.(point.getId());
+          return;
+        }
         deleteFeature(hit);
         return;
       }
@@ -281,12 +308,20 @@ const OlMap = ({
         return;
       }
       if (tool === "feature") {
+        // Clicking an existing city edits it (rename/resize/delete popup);
+        // clicking empty map adds a new one right there.
+        const point = pointAtPixel(evt.pixel);
+        if (point) {
+          onFeatureEditRef.current?.({ id: point.getId(), pixel: [...evt.pixel] });
+          return;
+        }
         const [lng, lat] = toLonLat(evt.coordinate);
         onFeatureCreateRef.current?.({
           coord: [Number(lng.toFixed(5)), Number(lat.toFixed(5))],
           regionId: hit ? hit.getId() : null,
           owner: hit ? hit.get("owner") || null : null,
           country: hit ? hit.get("country") || "" : "",
+          pixel: [...evt.pixel],
         });
         return;
       }
@@ -341,9 +376,17 @@ const OlMap = ({
       const tool = activeToolRef.current;
       if (tool === "lasso" || tool === "split" || tool === "draw") {
         map.getTargetElement().style.cursor = "crosshair";
+      } else if (tool === "feature" || tool === "delete") {
+        // City-aware tools: pointer over an existing city (edit/remove target).
+        const pointHit = map.hasFeatureAtPixel(evt.pixel, {
+          layerFilter: (l) => l === pointLayerRef.current,
+          hitTolerance: 8,
+        });
+        map.getTargetElement().style.cursor =
+          pointHit || (hit && tool === "delete") ? "pointer" : tool === "feature" ? "crosshair" : "";
       } else {
         map.getTargetElement().style.cursor =
-          hit && (tool === "select" || tool === "delete" || tool === "paint" || tool === "dissolve") ? "pointer" : "";
+          hit && (tool === "select" || tool === "paint" || tool === "dissolve") ? "pointer" : "";
       }
     });
 

--- a/src/Editor/SearchBar.jsx
+++ b/src/Editor/SearchBar.jsx
@@ -1,0 +1,216 @@
+/*!
+ * Pax Historia Map Editor
+ * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
+ */
+
+// Editor place search. One box finds everything: the custom places added to
+// this map (point features), this map's regions, and the modern world place
+// index (~70k cities/POIs the original app ships). Clicking a result flies the
+// view there; world places offer one-click "+ Add" to drop them onto the map
+// as a custom city.
+
+import { useEffect, useRef, useState } from "react";
+import Icon from "./Icon.jsx";
+import { panelSurface, inputStyle } from "./editorStyles.js";
+import { searchSeedCities } from "./citiesImport.js";
+
+const rowStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: 7,
+  padding: "5px 7px",
+  borderRadius: 7,
+  cursor: "pointer",
+  background: "transparent",
+  border: "none",
+  color: "white",
+  width: "100%",
+  textAlign: "left",
+};
+
+const badge = (text, color) => (
+  <span
+    style={{
+      fontSize: 9,
+      fontWeight: 700,
+      letterSpacing: 0.4,
+      color,
+      border: `1px solid ${color}44`,
+      borderRadius: 4,
+      padding: "1px 4px",
+      whiteSpace: "nowrap",
+    }}
+  >
+    {text}
+  </span>
+);
+
+const formatPop = (n) => {
+  if (!n) return "";
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${Math.round(n / 1000)}k`;
+  return String(n);
+};
+
+const SearchBar = ({ api, features, onAddCity }) => {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [results, setResults] = useState({ custom: [], regions: [], world: [] });
+  const boxRef = useRef(null);
+
+  // Debounced search across the three indexes.
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    if (q.length < 2) {
+      setResults({ custom: [], regions: [], world: [] });
+      return undefined;
+    }
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      const custom = (features || [])
+        .filter((f) => Array.isArray(f.coord) && String(f.name || "").toLowerCase().includes(q))
+        .slice(0, 6);
+      const regions = api ? api.queryRegions(q, 5) : [];
+      const world = await searchSeedCities(q, 8);
+      if (!cancelled) setResults({ custom, regions, world });
+    }, 180);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [query, features, api]);
+
+  // Close when clicking anywhere outside the search box.
+  useEffect(() => {
+    const onDown = (e) => {
+      if (boxRef.current && !boxRef.current.contains(e.target)) setOpen(false);
+    };
+    window.addEventListener("pointerdown", onDown);
+    return () => window.removeEventListener("pointerdown", onDown);
+  }, []);
+
+  const hasResults = results.custom.length || results.regions.length || results.world.length;
+
+  return (
+    <div ref={boxRef} style={{ position: "fixed", top: 60, left: 12, zIndex: 36, width: 272 }}>
+      <div style={{ ...panelSurface, display: "flex", alignItems: "center", gap: 6, padding: "6px 9px" }}>
+        <Icon name="search" size={15} style={{ opacity: 0.6 }} />
+        <input
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setOpen(false);
+          }}
+          placeholder="Search places…"
+          style={{ ...inputStyle, border: "none", background: "transparent", padding: "2px 0" }}
+        />
+        {query && (
+          <button
+            onClick={() => {
+              setQuery("");
+              setOpen(false);
+            }}
+            style={{ background: "transparent", border: "none", color: "rgba(255,255,255,0.6)", cursor: "pointer", fontSize: 13 }}
+            title="Clear"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {open && query.trim().length >= 2 && (
+        <div
+          style={{
+            ...panelSurface,
+            marginTop: 6,
+            padding: 6,
+            maxHeight: "55vh",
+            overflowY: "auto",
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+          }}
+        >
+          {!hasResults && (
+            <div style={{ padding: "6px 8px", fontSize: 12, color: "rgba(255,255,255,0.5)" }}>No places found.</div>
+          )}
+
+          {results.custom.map((f) => (
+            <button
+              key={`c-${f.id}`}
+              style={rowStyle}
+              onClick={() => api?.locateFeature(f.coord)}
+              onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.08)")}
+              onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+            >
+              {badge("THIS MAP", "#a5b4fc")}
+              <span style={{ fontSize: 12.5, fontWeight: 600, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {f.name}
+              </span>
+              <span style={{ fontSize: 10.5, color: "rgba(255,255,255,0.45)" }}>{formatPop(f.population)}</span>
+            </button>
+          ))}
+
+          {results.regions.map((r) => (
+            <button
+              key={`r-${r.id}`}
+              style={rowStyle}
+              onClick={() => api?.zoomToRegion(r.id)}
+              onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.08)")}
+              onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+            >
+              {badge("REGION", "#86efac")}
+              <span style={{ fontSize: 12.5, fontWeight: 600, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {r.name || r.id}
+              </span>
+              <span style={{ fontSize: 10.5, color: "rgba(255,255,255,0.45)" }}>{r.country || r.owner || ""}</span>
+            </button>
+          ))}
+
+          {results.world.map((c, i) => (
+            <div key={`w-${c.name}-${i}`} style={{ display: "flex", alignItems: "center" }}>
+              <button
+                style={{ ...rowStyle, flex: 1 }}
+                onClick={() => api?.locateFeature(c.coord)}
+                onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(255,255,255,0.08)")}
+                onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+              >
+                {badge("WORLD", "#fcd34d")}
+                <span style={{ fontSize: 12.5, fontWeight: 600, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {c.name}
+                </span>
+                <span style={{ fontSize: 10.5, color: "rgba(255,255,255,0.45)" }}>
+                  {c.capital ? "★ " : ""}
+                  {formatPop(c.population)}
+                </span>
+              </button>
+              <button
+                title="Add to this map as a city"
+                onClick={() => onAddCity?.(c)}
+                style={{
+                  background: "transparent",
+                  border: "1px solid rgba(255,255,255,0.2)",
+                  borderRadius: 6,
+                  color: "#93c5fd",
+                  cursor: "pointer",
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: "3px 7px",
+                  marginLeft: 4,
+                }}
+              >
+                ＋
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/src/Editor/Toolbar.jsx
+++ b/src/Editor/Toolbar.jsx
@@ -24,7 +24,7 @@ const TOOLS = [
   { id: "split", icon: "split", label: "Split (drag across a region to cut it)", enabled: true },
   { id: "dissolve", icon: "eraser", label: "Delete border (merge two regions)", enabled: true },
   { id: "paint", icon: "paint", label: "Paint owner (click regions)", enabled: true },
-  { id: "feature", icon: "feature", label: "Add feature (click map)", enabled: true },
+  { id: "feature", icon: "feature", label: "City tool (click map to add a city, click a city to edit it)", enabled: true },
 ];
 
 const Separator = () => (

--- a/src/Editor/citiesImport.js
+++ b/src/Editor/citiesImport.js
@@ -48,3 +48,26 @@ export const importMajorCities = async ({ minPopulation = 500000 } = {}) =>
   (await loadSeed())
     .filter((c) => c.capital || (c.population || 0) >= minPopulation)
     .map(toFeature);
+
+// Name search over the modern world place index (for the editor search bar).
+// Prefix matches rank above substring matches; within each, capitals and larger
+// cities first. Entries without coordinates can't be located, so they're skipped.
+export const searchSeedCities = async (query, limit = 8) => {
+  const q = String(query || "").trim().toLowerCase();
+  if (q.length < 2) return [];
+  const seed = await loadSeed();
+  const starts = [];
+  const contains = [];
+  for (const c of seed) {
+    if (!Array.isArray(c.coord) || c.coord[0] == null || c.coord[1] == null) continue;
+    const name = String(c.name || "").toLowerCase();
+    if (!name) continue;
+    if (name.startsWith(q)) starts.push(c);
+    else if (name.includes(q)) contains.push(c);
+  }
+  const rank = (a, b) =>
+    (b.capital === true) - (a.capital === true) || (b.population || 0) - (a.population || 0);
+  starts.sort(rank);
+  contains.sort(rank);
+  return [...starts, ...contains].slice(0, limit);
+};

--- a/src/Editor/exportPreset.js
+++ b/src/Editor/exportPreset.js
@@ -75,6 +75,33 @@ const detectCustomGeometry = (regionsFC, kind) => {
   return false;
 };
 
+// Prominence tier driving when a city appears on the game map (4 = capital,
+// 3 = major, 2 = city, 1 = town) — see src/Game/Map/Cities.jsx.
+const cityTier = (f) => {
+  if ((f.tags || []).includes("capital")) return 4;
+  const pop = f.population || 0;
+  if (pop >= 1000000) return 3;
+  if (pop >= 100000) return 2;
+  return 1;
+};
+
+// The document's point features (cities) as the game-ready cities.geojson.
+const buildCitiesForGame = (features) => ({
+  type: "FeatureCollection",
+  features: (features || [])
+    .filter((f) => Array.isArray(f.coord) && f.coord.length === 2 && f.coord[0] != null && f.coord[1] != null)
+    .map((f) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [Number(f.coord[0]), Number(f.coord[1])] },
+      properties: {
+        city: f.name ? String(f.name) : "",
+        population: f.population || 0,
+        capital: (f.tags || []).includes("capital") ? "primary" : "",
+        tier: cityTier(f),
+      },
+    })),
+});
+
 export const buildGameSeed = (doc, regionsFC, palette = {}, { playerCode } = {}) => {
   const regionOwnershipOverrides = {};
   const owners = new Set();
@@ -120,10 +147,15 @@ export const buildGameSeed = (doc, regionsFC, palette = {}, { playerCode } = {})
   }
 
   const author = (doc.metadata?.author || "").trim();
+  const gameCities = buildCitiesForGame(doc.features);
   const world = {
     regionOwnershipOverrides,
     polityOverrides,
     customRegions: hasCustomGeometry,
+    // Authored cities replace the modern city labels. A custom-geometry map with
+    // no cities still sets the flag — modern names over invented land would be
+    // wrong — while a pure re-ownership map without cities keeps the stock set.
+    customCities: gameCities.features.length > 0 || hasCustomGeometry,
     author,
     mapCredit: author ? `Made by ${author}` : "",
     simulationRules: doc.metadata?.simulationRules || "",
@@ -151,5 +183,7 @@ export const buildGameSeed = (doc, regionsFC, palette = {}, { playerCode } = {})
     // regions is the normalized, game-ready FeatureCollection. Only uploaded to the
     // scenario when hasCustomGeometry (tier 2); harmless in the downloaded JSON.
     regions: gameRegions,
+    // cities is the authored era city set (cities.geojson in the scenario).
+    cities: gameCities,
   };
 };

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -1421,6 +1421,7 @@ const LibraryTopBar = () => {
         // Playable factions for the start-country picker.
         ownerCodes: [...new Set(Object.values(seed.world?.regionOwnershipOverrides ?? {}))].sort(),
         customRegions: true,
+        customCities: seed.world?.customCities ?? false,
         author: seed.world?.author ?? "",
         mapCredit: seed.world?.mapCredit ?? "",
       },
@@ -1444,6 +1445,13 @@ const LibraryTopBar = () => {
       scenarioId,
       "regionsGeojson",
       new Blob([JSON.stringify(seed.regions ?? { type: "FeatureCollection", features: [] })], {
+        type: "application/json",
+      }),
+    );
+    await uploadScenarioAsset(
+      scenarioId,
+      "citiesGeojson",
+      new Blob([JSON.stringify(seed.cities ?? { type: "FeatureCollection", features: [] })], {
         type: "application/json",
       }),
     );

--- a/src/Game/Map/Cities.jsx
+++ b/src/Game/Map/Cities.jsx
@@ -1,8 +1,15 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Source, Layer } from "react-map-gl/maplibre";
-import { PMTILES_PROTOCOL_URLS, ensurePmtilesProtocol } from "../../runtime/assets.js";
+import {
+    PMTILES_PROTOCOL_URLS,
+    JSON_URLS,
+    ensurePmtilesProtocol,
+    readJson,
+} from "../../runtime/assets.js";
 
 ensurePmtilesProtocol();
+
+const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
 
 const populationFilter = [
     "any",
@@ -21,80 +28,203 @@ const populationFilter = [
     ],
 ];
 
-const Cities = () => {
-    const pmtilesUrl = PMTILES_PROTOCOL_URLS.cities;
+// Custom (scenario-authored) cities are a curated era set, not the 70k-strong
+// modern database, and their historical populations are far below modern
+// thresholds (Paris in 1200 held ~50k). Visibility is driven by the authored
+// prominence tier instead: 4 = capital, 3 = major city, 2 = city, 1 = town.
+const customTierFilter = [
+    "any",
+    [">=", ["get", "tier"], 3],
+    ["all", [">=", ["get", "tier"], 2], [">=", ["zoom"], 4.3]],
+    [">=", ["zoom"], 5.8],
+];
 
-    return (
-        <Source id="cities-source" type="vector" url={pmtilesUrl}>
-        <Layer
-        id="cities-shapes"
-        type="symbol"
-        source-layer="cities"
-        minzoom={3.4}
-        filter={populationFilter}
-        layout={{
-            "symbol-sort-key": ["-", ["get", "population"]],
-            "text-allow-overlap": true,
-            "text-field": [
-                "case",
-                ["==", ["get", "capital"], "primary"], "★",
-                [">=", ["get", "population"], 2500000], "◆",
-                "■",
-            ],
-            "text-padding": 0,
-            "text-size": [
-                "interpolate", ["linear"], ["zoom"],
-                3, [
-                    "*",
-                    [
-                        "interpolate", ["linear"], ["get", "population"],
-                        100000, 6,
-                        1000000, 10,
-                    ],
-                    [
-                        "case",
-                        ["==", ["get", "capital"], "primary"], 2.5,
-                        [">=", ["get", "population"], 2500000], 2,
-                        1,
-                    ],
+const customSortKey = ["-", ["+", ["*", ["get", "tier"], 1000000000], ["get", "population"]]];
+
+const StockCities = () => (
+    <Source id="cities-source" type="vector" url={PMTILES_PROTOCOL_URLS.cities}>
+    <Layer
+    id="cities-shapes"
+    type="symbol"
+    source-layer="cities"
+    minzoom={3.4}
+    filter={populationFilter}
+    layout={{
+        "symbol-sort-key": ["-", ["get", "population"]],
+        "text-allow-overlap": true,
+        "text-field": [
+            "case",
+            ["==", ["get", "capital"], "primary"], "★",
+            [">=", ["get", "population"], 2500000], "◆",
+            "■",
+        ],
+        "text-padding": 0,
+        "text-size": [
+            "interpolate", ["linear"], ["zoom"],
+            3, [
+                "*",
+                [
+                    "interpolate", ["linear"], ["get", "population"],
+                    100000, 6,
+                    1000000, 10,
                 ],
-                10, 22,
+                [
+                    "case",
+                    ["==", ["get", "capital"], "primary"], 2.5,
+                    [">=", ["get", "population"], 2500000], 2,
+                    1,
+                ],
             ],
-        }}
-        paint={{
-            "text-color": "rgba(0,0,0,0)",
-            "text-halo-color": "#ffffff",
-            "text-halo-width": 0.5,
-        }}
-        />
+            10, 22,
+        ],
+    }}
+    paint={{
+        "text-color": "rgba(0,0,0,0)",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 0.5,
+    }}
+    />
 
-        <Layer
-        id="cities-labels"
-        type="symbol"
-        source-layer="cities"
-        minzoom={3.4}
-        filter={populationFilter}
-        layout={{
-            "symbol-sort-key": ["-", ["get", "population"]],
-            "text-field": ["get", "city"],
-            "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
-            "text-padding": 5,
-            "text-radial-offset": 0.7,
-            "text-size": [
-                "interpolate", ["linear"], ["zoom"],
-                3, 8,
-                10, 10,
-            ],
-            "text-variable-anchor": ["top", "bottom", "left", "right"],
-        }}
-        paint={{
-            "text-color": "#ffffff",
-            "text-halo-color": "#333333",
-            "text-halo-width": 2,
-        }}
-        />
-        </Source>
-    );
+    <Layer
+    id="cities-labels"
+    type="symbol"
+    source-layer="cities"
+    minzoom={3.4}
+    filter={populationFilter}
+    layout={{
+        "symbol-sort-key": ["-", ["get", "population"]],
+        "text-field": ["get", "city"],
+        "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+        "text-padding": 5,
+        "text-radial-offset": 0.7,
+        "text-size": [
+            "interpolate", ["linear"], ["zoom"],
+            3, 8,
+            10, 10,
+        ],
+        "text-variable-anchor": ["top", "bottom", "left", "right"],
+    }}
+    paint={{
+        "text-color": "#ffffff",
+        "text-halo-color": "#333333",
+        "text-halo-width": 2,
+    }}
+    />
+    </Source>
+);
+
+// Same visual language as the stock layers (★/◆/■ markers, haloed labels), but
+// fed from the scenario's cities.geojson and gated by the authored tier.
+const CustomCities = ({ data }) => (
+    <Source id="cities-source" type="geojson" data={data}>
+    <Layer
+    id="cities-shapes"
+    type="symbol"
+    minzoom={3.4}
+    filter={customTierFilter}
+    layout={{
+        "symbol-sort-key": customSortKey,
+        "text-allow-overlap": true,
+        "text-field": [
+            "case",
+            ["==", ["get", "capital"], "primary"], "★",
+            [">=", ["get", "tier"], 3], "◆",
+            "■",
+        ],
+        "text-padding": 0,
+        "text-size": [
+            "interpolate", ["linear"], ["zoom"],
+            3, ["match", ["get", "tier"], 4, 15, 3, 12, 2, 8, 6],
+            10, 22,
+        ],
+    }}
+    paint={{
+        "text-color": "rgba(0,0,0,0)",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 0.5,
+    }}
+    />
+
+    <Layer
+    id="cities-labels"
+    type="symbol"
+    minzoom={3.4}
+    filter={customTierFilter}
+    layout={{
+        "symbol-sort-key": customSortKey,
+        "text-field": ["get", "city"],
+        "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+        "text-padding": 5,
+        "text-radial-offset": 0.7,
+        "text-size": [
+            "interpolate", ["linear"], ["zoom"],
+            3, ["match", ["get", "tier"], 4, 9.5, 3, 9, 8],
+            10, 10,
+        ],
+        "text-variable-anchor": ["top", "bottom", "left", "right"],
+    }}
+    paint={{
+        "text-color": "#ffffff",
+        "text-halo-color": "#333333",
+        "text-halo-width": 2,
+    }}
+    />
+    </Source>
+);
+
+const Cities = () => {
+    // world.customCities marks scenarios whose maps carry their own era-accurate
+    // city set (presets, editor maps). Polled like the world state in Nations so
+    // switching games/scenarios swaps the city layer within a few seconds.
+    const [customFlag, setCustomFlag] = useState(false);
+    const [customData, setCustomData] = useState(null);
+    const citiesGeojsonUrl = JSON_URLS.citiesGeojson;
+
+    useEffect(() => {
+        let cancelled = false;
+        const loadFlag = () => {
+            readJson(JSON_URLS.world, { defaultValue: {}, force: true })
+                .then((data) => {
+                    if (!cancelled) setCustomFlag(Boolean(data?.customCities));
+                })
+                .catch(() => {});
+        };
+        loadFlag();
+        const interval = setInterval(loadFlag, 5000);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, []);
+
+    // The city set itself is static per scenario — fetched once when the flag (or
+    // the runtime token behind the URL) changes.
+    useEffect(() => {
+        let cancelled = false;
+        if (!customFlag) {
+            setCustomData(null);
+            return undefined;
+        }
+        readJson(citiesGeojsonUrl, { defaultValue: EMPTY_FEATURE_COLLECTION, force: true })
+            .then((data) => {
+                if (cancelled) return;
+                setCustomData(data && Array.isArray(data.features) ? data : EMPTY_FEATURE_COLLECTION);
+            })
+            .catch(() => {
+                if (!cancelled) setCustomData(EMPTY_FEATURE_COLLECTION);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [customFlag, citiesGeojsonUrl]);
+
+    // Custom-city scenarios never show the modern database (anachronistic); while
+    // the custom set is still loading, show nothing rather than flash modern names.
+    if (customFlag) {
+        if (!customData || !customData.features.length) return null;
+        return <CustomCities data={customData} />;
+    }
+    return <StockCities />;
 };
 
 export default Cities;

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -42,6 +42,7 @@ export const JSON_URLS = {
   game: "",
   prompts: "",
   regionsGeojson: "",
+  citiesGeojson: "",
   world: "",
 };
 
@@ -93,6 +94,7 @@ export const setRuntimeAssetEndpoints = ({ token = "" } = {}) => {
   JSON_URLS.game = withRuntimeToken("/api/runtime/json/game");
   JSON_URLS.prompts = withRuntimeToken("/api/runtime/json/prompts");
   JSON_URLS.regionsGeojson = withRuntimeToken("/api/runtime/json/regionsGeojson");
+  JSON_URLS.citiesGeojson = withRuntimeToken("/api/runtime/json/citiesGeojson");
   JSON_URLS.world = withRuntimeToken("/api/runtime/json/world");
 
   PMTILES_ARCHIVES.cities = buildAbsoluteUrl("/api/runtime/pmtiles/cities");


### PR DESCRIPTION
## Era-accurate cities on every official scenario map

Scenario maps can now ship their own city set. A new per-scenario `cities.geojson` asset plus a `world.customCities` flag make the game hide the modern city labels and render the scenario's cities in the same visual language (★ capitals, ◆ major cities), with visibility driven by an authored prominence tier instead of modern population — medieval Paris never clears a 2.5M threshold.

All five official presets carry period-accurate city sets (65–118 each) with historical names and populations: Constantinople, Angkor and Cahokia in 1200; Khanbaliq, Sarai and Tabriz in 1300; Roma, Ctesiphon and Teotihuacan in 117 AD; New Amsterdam, Potosí and Edo in 1650; Danzig, Leningrad and Hsinking in 1939.

## Map editor: cities are first-class

- **City tool** — click the map to drop a city and edit it in an inline popup right there (name pre-selected, size tier, capital toggle, delete); click an existing city to reopen it; the delete tool removes cities too.
- **Place search** — one search box finds the map's custom places, its regions, and the ~70k-place modern world index; results fly the view there, and any world place can be added to the map as a city with one click.
- Maps built in the editor export their cities into the game via Apply & Play, downloads, and hub publishing.

## One-click launchers for Linux and macOS

`Launch Pax Historia.sh` / `Update Pax Historia.sh` (plus double-clickable `.command` wrappers for macOS) mirror the Windows `.bat` tooling: Node.js check with install offer, Git LFS map-data fetch for ZIP installs, build + serve, and an rsync-based updater with the same protections. Line endings are pinned to LF via `.gitattributes` and the exec bits are committed.

## Compatibility

Scenarios without `cities.geojson` are untouched — the stock modern city layer renders exactly as before. Older clients importing new hub bundles simply ignore the extra asset.