### PR TITLE
Mobile support: touch-friendly UI and Termux hosting

### DIFF
--- a/Launch Pax Historia.sh
+++ b/Launch Pax Historia.sh
@@ -52,7 +52,10 @@ if ! command -v node >/dev/null 2>&1; then
             ;;
         *)
             PKG_CMD=""
-            if command -v apt-get >/dev/null 2>&1; then PKG_CMD="sudo apt-get install -y nodejs npm"
+            # Termux (Android) has its own package manager and no sudo.
+            if [ -n "$TERMUX_VERSION" ] || { [ -n "$PREFIX" ] && [ "${PREFIX#*com.termux}" != "$PREFIX" ]; }; then
+                PKG_CMD="pkg install -y nodejs"
+            elif command -v apt-get >/dev/null 2>&1; then PKG_CMD="sudo apt-get install -y nodejs npm"
             elif command -v dnf >/dev/null 2>&1; then PKG_CMD="sudo dnf install -y nodejs npm"
             elif command -v pacman >/dev/null 2>&1; then PKG_CMD="sudo pacman -S --noconfirm nodejs npm"
             elif command -v zypper >/dev/null 2>&1; then PKG_CMD="sudo zypper install -y nodejs npm"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ and opens the game. To update an existing install later, run the matching
 **`Update Pax Historia`** script for your platform — it fetches the latest version
 while preserving your saves, scenarios, and map data.
 
+### Android (Termux)
+
+The game runs and hosts fine on a phone. In [Termux](https://termux.dev):
+
+```bash
+pkg install nodejs git git-lfs rsync
+git clone https://github.com/Tommi-K/pax-historia.git && cd pax-historia
+git lfs install && git lfs pull
+npm install && npm run build
+node server/server.js
+```
+
+Then open **http://localhost:3000** in your phone's browser — the UI adapts to
+small touch screens. Other devices on the same Wi-Fi can play too, at
+`http://<phone-ip>:3000`. (`./"Launch Pax Historia.sh"` and the update script
+also work on Termux.)
+
 ### Manual
 
 Prerequisites: [Git](https://git-scm.com/) (with [Git LFS](https://git-lfs.com/)) and [Node.js](https://nodejs.org/en).

--- a/Update Pax Historia.sh
+++ b/Update Pax Historia.sh
@@ -79,7 +79,8 @@ main() {
     fi
     if ! command -v rsync >/dev/null 2>&1; then
         echo "[ERROR] rsync was not found. It ships with macOS; on Linux install it"
-        echo "        with your package manager (e.g. sudo apt-get install rsync)."
+        echo "        with your package manager (e.g. sudo apt-get install rsync;"
+        echo "        on Termux: pkg install rsync)."
         exit 1
     fi
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/jpeg" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b1020" />
     <title>Pax Historia</title>
 
     <!-- Primary Meta -->

--- a/src/Editor/BottomBar.jsx
+++ b/src/Editor/BottomBar.jsx
@@ -58,6 +58,7 @@ const BottomBar = ({
   saveStatus,
   openPanel,
   onOpenPanel,
+  search,
 }) => {
   const save = SAVE[saveStatus] || SAVE.saved;
   return (
@@ -76,6 +77,7 @@ const BottomBar = ({
         flexWrap: "wrap",
       }}
     >
+      {search}
       <Chip icon="list" label={`Regions: ${counts.regions}`} active={openPanel === "regions"} onClick={() => onOpenPanel("regions")} />
       <Chip icon="pin" label={`Features: ${counts.features}`} active={openPanel === "features"} onClick={() => onOpenPanel("features")} />
       <Chip icon="types" label={`Types: ${counts.types}`} active={openPanel === "types"} onClick={() => onOpenPanel("types")} />

--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -340,30 +340,6 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
         setSelection={d.setSelection}
       />
 
-      <SearchBar
-        api={api}
-        features={d.features}
-        onAddCity={(c) => {
-          const id = newId("feat");
-          d.setFeatures((list) => [
-            ...list,
-            {
-              id,
-              name: c.name,
-              type: "Coordinate",
-              symbol: "square",
-              coord: c.coord,
-              country: c.country || "",
-              owner: null,
-              regionId: null,
-              population: c.population || 0,
-              tags: c.capital ? ["city", "capital"] : ["city"],
-            },
-          ]);
-          api?.locateFeature(c.coord);
-        }}
-      />
-
       {cityPopup && (
         <CityPopup
           feature={d.features.find((f) => f.id === cityPopup.id)}
@@ -390,6 +366,31 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
         saveStatus={d.saveStatus}
         openPanel={openPanel}
         onOpenPanel={togglePanel}
+        search={
+          <SearchBar
+            api={api}
+            features={d.features}
+            onAddCity={(c) => {
+              const id = newId("feat");
+              d.setFeatures((list) => [
+                ...list,
+                {
+                  id,
+                  name: c.name,
+                  type: "Coordinate",
+                  symbol: "square",
+                  coord: c.coord,
+                  country: c.country || "",
+                  owner: null,
+                  regionId: null,
+                  population: c.population || 0,
+                  tags: c.capital ? ["city", "capital"] : ["city"],
+                },
+              ]);
+              api?.locateFeature(c.coord);
+            }}
+          />
+        }
       />
     </div>
   );

--- a/src/Editor/Panel.jsx
+++ b/src/Editor/Panel.jsx
@@ -15,7 +15,8 @@ const Panel = ({ title, icon, onClose, side = "left", width = 340, footer, child
       position: "fixed",
       top: 64,
       [side]: 12,
-      width,
+      // Never wider than the screen (phones).
+      width: `min(${width}px, calc(100vw - 24px))`,
       maxHeight: "calc(100vh - 150px)",
       display: "flex",
       flexDirection: "column",

--- a/src/Editor/SearchBar.jsx
+++ b/src/Editor/SearchBar.jsx
@@ -7,7 +7,8 @@
 // this map (point features), this map's regions, and the modern world place
 // index (~70k cities/POIs the original app ships). Clicking a result flies the
 // view there; world places offer one-click "+ Add" to drop them onto the map
-// as a custom city.
+// as a custom city. Lives INSIDE the bottom bar (results open upward) so it
+// never covers the tool buttons — floating it top-left did, on phones.
 
 import { useEffect, useRef, useState } from "react";
 import Icon from "./Icon.jsx";
@@ -92,9 +93,9 @@ const SearchBar = ({ api, features, onAddCity }) => {
   const hasResults = results.custom.length || results.regions.length || results.world.length;
 
   return (
-    <div ref={boxRef} style={{ position: "fixed", top: 60, left: 12, zIndex: 36, width: 272 }}>
-      <div style={{ ...panelSurface, display: "flex", alignItems: "center", gap: 6, padding: "6px 9px" }}>
-        <Icon name="search" size={15} style={{ opacity: 0.6 }} />
+    <div ref={boxRef} style={{ position: "relative", flex: "1 1 170px", maxWidth: 300, minWidth: 140 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 8px", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 8 }}>
+        <Icon name="search" size={14} style={{ opacity: 0.6, flexShrink: 0 }} />
         <input
           value={query}
           onChange={(e) => {
@@ -106,7 +107,7 @@ const SearchBar = ({ api, features, onAddCity }) => {
             if (e.key === "Escape") setOpen(false);
           }}
           placeholder="Search places…"
-          style={{ ...inputStyle, border: "none", background: "transparent", padding: "2px 0" }}
+          style={{ ...inputStyle, border: "none", background: "transparent", padding: "2px 0", fontSize: 12 }}
         />
         {query && (
           <button
@@ -114,7 +115,7 @@ const SearchBar = ({ api, features, onAddCity }) => {
               setQuery("");
               setOpen(false);
             }}
-            style={{ background: "transparent", border: "none", color: "rgba(255,255,255,0.6)", cursor: "pointer", fontSize: 13 }}
+            style={{ background: "transparent", border: "none", color: "rgba(255,255,255,0.6)", cursor: "pointer", fontSize: 13, flexShrink: 0 }}
             title="Clear"
           >
             ✕
@@ -126,13 +127,17 @@ const SearchBar = ({ api, features, onAddCity }) => {
         <div
           style={{
             ...panelSurface,
-            marginTop: 6,
+            position: "absolute",
+            bottom: "calc(100% + 10px)",
+            left: 0,
+            width: "min(320px, calc(100vw - 40px))",
             padding: 6,
-            maxHeight: "55vh",
+            maxHeight: "50vh",
             overflowY: "auto",
             display: "flex",
             flexDirection: "column",
             gap: 2,
+            zIndex: 40,
           }}
         >
           {!hasResults && (

--- a/src/Editor/Toolbar.jsx
+++ b/src/Editor/Toolbar.jsx
@@ -41,6 +41,10 @@ const Toolbar = ({ activeTool, onToolChange, onFit, onUndo, onRedo, canUndo, can
       transform: "translateX(-50%)",
       display: "flex",
       alignItems: "center",
+      // Wraps into extra rows on narrow (phone) screens instead of overflowing.
+      flexWrap: "wrap",
+      justifyContent: "center",
+      maxWidth: "calc(100vw - 12px)",
       gap: 4,
       padding: "6px 8px",
       zIndex: 30,

--- a/src/Game/GameUI/actions.jsx
+++ b/src/Game/GameUI/actions.jsx
@@ -372,7 +372,9 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
             display: "flex",
             flexDirection: "column",
             fontFamily: "sans-serif",
-            height: "calc(100vh - 33rem)",
+            // Tall desktops keep the old size; laptops/phones get a usable 30rem
+            // instead of the sliver calc(100vh - 33rem) left them.
+            height: "min(calc(100vh - 9rem), max(calc(100vh - 33rem), 30rem))",
             minHeight: "10rem",
             left: "0rem",
             maxWidth: "calc(100vw - 1rem)",

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -6,7 +6,7 @@ import { JSON_URLS, readJson, writeJson } from "../../runtime/assets.js";
 
 Chart.register(...registerables);
 
-const ADVISOR_PANEL_WIDTH = "20rem";
+const ADVISOR_PANEL_WIDTH = "min(20rem, calc(100vw - 1rem))";
 
 const baseStyle = {
     position: "fixed",

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -766,7 +766,7 @@ const ChatPanel = ({ isOpen, onClose, requestedCountry, onConsumeRequest }) => {
         return (
             <>
             <MarkdownStyleInjector />
-            <div style={{ position: "fixed", bottom: isOpen ? "4.25rem" : "-40rem", left: "0rem", width: "26.25rem", maxWidth: "calc(100vw - 1rem)", height: "calc(100vh - 33rem)", minHeight: "10rem", backgroundColor: "rgba(17,24,39,0.95)", backdropFilter: "blur(8px)", borderRadius: "16px", border: "1px solid rgba(255,255,255,0.1)", boxShadow: "-4px 0 24px rgba(0,0,0,0.4),inset 0 1px 0 rgba(255,255,255,0.06)", zIndex: 9998, overflow: "hidden", transition: "bottom 0.35s cubic-bezier(0.4,0,0.2,1),opacity 0.35s ease", opacity: isOpen ? 1 : 0, pointerEvents: isOpen ? "auto" : "none", fontFamily: "sans-serif", color: "white", display: "flex", flexDirection: "column" }}>
+            <div style={{ position: "fixed", bottom: isOpen ? "4.25rem" : "-40rem", left: "0rem", width: "26.25rem", maxWidth: "calc(100vw - 1rem)", height: "max(calc(100vh - 33rem), min(22rem, calc(100vh - 9rem)))", minHeight: "10rem", backgroundColor: "rgba(17,24,39,0.95)", backdropFilter: "blur(8px)", borderRadius: "16px", border: "1px solid rgba(255,255,255,0.1)", boxShadow: "-4px 0 24px rgba(0,0,0,0.4),inset 0 1px 0 rgba(255,255,255,0.06)", zIndex: 9998, overflow: "hidden", transition: "bottom 0.35s cubic-bezier(0.4,0,0.2,1),opacity 0.35s ease", opacity: isOpen ? 1 : 0, pointerEvents: isOpen ? "auto" : "none", fontFamily: "sans-serif", color: "white", display: "flex", flexDirection: "column" }}>
 
             {showSelector && <CountrySelectorModal countries={availableCountries} loading={loadingCountries} onStart={handleStartChat} onCancel={() => setShowSelector(false)} />}
 

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -766,7 +766,7 @@ const ChatPanel = ({ isOpen, onClose, requestedCountry, onConsumeRequest }) => {
         return (
             <>
             <MarkdownStyleInjector />
-            <div style={{ position: "fixed", bottom: isOpen ? "4.25rem" : "-40rem", left: "0rem", width: "26.25rem", maxWidth: "calc(100vw - 1rem)", height: "max(calc(100vh - 33rem), min(22rem, calc(100vh - 9rem)))", minHeight: "10rem", backgroundColor: "rgba(17,24,39,0.95)", backdropFilter: "blur(8px)", borderRadius: "16px", border: "1px solid rgba(255,255,255,0.1)", boxShadow: "-4px 0 24px rgba(0,0,0,0.4),inset 0 1px 0 rgba(255,255,255,0.06)", zIndex: 9998, overflow: "hidden", transition: "bottom 0.35s cubic-bezier(0.4,0,0.2,1),opacity 0.35s ease", opacity: isOpen ? 1 : 0, pointerEvents: isOpen ? "auto" : "none", fontFamily: "sans-serif", color: "white", display: "flex", flexDirection: "column" }}>
+            <div style={{ position: "fixed", bottom: isOpen ? "4.25rem" : "-40rem", left: "0rem", width: "26.25rem", maxWidth: "calc(100vw - 1rem)", height: "min(calc(100vh - 9rem), max(calc(100vh - 33rem), 30rem))", minHeight: "10rem", backgroundColor: "rgba(17,24,39,0.95)", backdropFilter: "blur(8px)", borderRadius: "16px", border: "1px solid rgba(255,255,255,0.1)", boxShadow: "-4px 0 24px rgba(0,0,0,0.4),inset 0 1px 0 rgba(255,255,255,0.06)", zIndex: 9998, overflow: "hidden", transition: "bottom 0.35s cubic-bezier(0.4,0,0.2,1),opacity 0.35s ease", opacity: isOpen ? 1 : 0, pointerEvents: isOpen ? "auto" : "none", fontFamily: "sans-serif", color: "white", display: "flex", flexDirection: "column" }}>
 
             {showSelector && <CountrySelectorModal countries={availableCountries} loading={loadingCountries} onStart={handleStartChat} onCancel={() => setShowSelector(false)} />}
 

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -29,6 +29,7 @@ import {
 } from "../../runtime/library.js";
 import { loadCountryNames } from "../../runtime/assets.js";
 import { UNIT_TYPES } from "../../runtime/gameState.js";
+import { useIsMobile } from "../../runtime/useIsMobile.js";
 
 const UNIT_TYPE_LABELS = {
   infantry: "Infantry",
@@ -1389,6 +1390,7 @@ const LibraryTopBar = () => {
     setIsPanelOpen(true);
   };
 
+  const isMobile = useIsMobile();
   const [isMapEditorOpen, setIsMapEditorOpen] = useState(false);
   const [mapEditorScenario, setMapEditorScenario] = useState(null);
   const [mapEditorSeed, setMapEditorSeed] = useState(null); // the scenario's current map, loaded async
@@ -1524,11 +1526,11 @@ const LibraryTopBar = () => {
           borderRight: "none",
           borderTop: "none",
           display: "grid",
-          gap: "0.9rem",
+          gap: isMobile ? "0.4rem" : "0.9rem",
           gridTemplateColumns: "minmax(0, 1fr) auto minmax(0, 1fr)",
           height: `${BAR_HEIGHT}px`,
           left: 0,
-          padding: "0 1rem",
+          padding: isMobile ? "0 0.5rem" : "0 1rem",
           position: "fixed",
           right: 0,
           top: 0,
@@ -1536,17 +1538,20 @@ const LibraryTopBar = () => {
         }}
       >
         <div style={{ alignItems: "center", display: "flex", gap: "0.8rem", minWidth: 0 }}>
-          <div style={{ alignItems: "center", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "999px", display: "flex", height: "2.65rem", justifyContent: "center", overflow: "hidden", width: "2.65rem" }}>
+          <div style={{ alignItems: "center", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "999px", display: "flex", flexShrink: 0, height: "2.65rem", justifyContent: "center", overflow: "hidden", width: "2.65rem" }}>
             <img alt="Pax Historia" src="/logo.png" style={{ height: "1.7rem", width: "1.7rem" }} />
           </div>
-          <div style={{ minWidth: 0 }}>
-            <div style={{ color: "#fff", fontSize: "1rem", fontWeight: 800, letterSpacing: "-0.03em" }}>
-              Pax Historia
+          {/* Phones keep the logo only — the title/summary would crowd out the tabs. */}
+          {!isMobile && (
+            <div style={{ minWidth: 0 }}>
+              <div style={{ color: "#fff", fontSize: "1rem", fontWeight: 800, letterSpacing: "-0.03em" }}>
+                Pax Historia
+              </div>
+              <div style={{ color: "rgba(255,255,255,0.48)", fontSize: "0.72rem", marginTop: "0.08rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", width: "min(28rem, 46vw)" }}>
+                {summaryText}
+              </div>
             </div>
-            <div style={{ color: "rgba(255,255,255,0.48)", fontSize: "0.72rem", marginTop: "0.08rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", width: "min(28rem, 46vw)" }}>
-              {summaryText}
-            </div>
-          </div>
+          )}
         </div>
 
         <div style={{ alignItems: "center", display: "flex", gap: "0.55rem", justifyContent: "center", justifySelf: "center" }}>
@@ -1558,7 +1563,8 @@ const LibraryTopBar = () => {
                 ...actionButtonStyle,
                 background: activeTab === tab ? "rgba(124,58,237,0.24)" : "rgba(255,255,255,0.05)",
                 borderColor: activeTab === tab ? "rgba(124,58,237,0.38)" : "rgba(255,255,255,0.08)",
-                minWidth: "6.6rem",
+                minWidth: isMobile ? "0" : "6.6rem",
+                padding: isMobile ? "0.55rem 0.7rem" : undefined,
               }}
               type="button"
             >

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -13,7 +13,7 @@ import {
   persistProviderSetting,
 } from "../AI/providerConfig.js";
 
-const ADVISOR_PANEL_WIDTH = "20rem";
+const ADVISOR_PANEL_WIDTH = "min(20rem, calc(100vw - 1rem))";
 const baseStyle = {
   position: "fixed",
   backgroundColor: "rgba(17, 24, 39, 0.9)",

--- a/src/Game/GameUI/search.jsx
+++ b/src/Game/GameUI/search.jsx
@@ -1,4 +1,5 @@
 import React, { memo, useEffect, useRef, useState } from "react";
+import { useIsMobile } from "../../runtime/useIsMobile.js";
 
 const SEARCH_HEADERS = { "Accept-Language": "en, *;q=0.5" };
 const SEARCH_RESULT_CACHE = new Map();
@@ -140,6 +141,7 @@ const getIcon = (suggestion) => {
 };
 
 const Search = memo(({ mapRef }) => {
+  const isMobile = useIsMobile();
   const [expanded, setExpanded] = useState(false);
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState(null);
@@ -270,11 +272,14 @@ const Search = memo(({ mapRef }) => {
     <div
       style={{
         position: "fixed",
-        bottom: "1rem",
+        // Desktop: sits right of the bottom toolbar and expands rightward.
+        // Phones: the expanded box wouldn't fit there, so it opens as a
+        // full-width bar just above the toolbar instead.
+        bottom: expanded && isMobile ? "5rem" : "1rem",
         // Clear of the bottom toolbar (0.5rem + 12.5rem wide, now incl. Forces).
-        left: "13.5rem",
+        left: expanded && isMobile ? "0.5rem" : "13.5rem",
         height: "3rem",
-        width: expanded ? "17rem" : "3rem",
+        width: expanded ? (isMobile ? "calc(100vw - 1rem)" : "17rem") : "3rem",
         overflow: "visible",
         transition: "width 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
         cursor: expanded ? "default" : "pointer",

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -559,7 +559,9 @@ const SettingsMenu = ({
             left: "0.5rem",
             width: "22rem",
             maxWidth: "calc(100vw - 1rem)",
-            maxHeight: "calc(100vh - 5rem)",
+            // Never taller than the space below the panel's own top edge — the old
+            // 100vh-5rem pushed the bottom (Discord/GitHub links) off short screens.
+            maxHeight: `calc(100vh - ${topOffset} - 5.25rem)`,
             overflowY: "auto",
             padding: "1rem",
             flexDirection: "column",

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -21,7 +21,8 @@ import {
 dayjs.extend(advancedFormat);
 
 const TIMELINE_STYLE_ID = "timeline-ui-style";
-const PANEL_WIDTH = "26.25rem";
+// Clamped so the timeline panel and widget always fit phone screens.
+const PANEL_WIDTH = "min(26.25rem, calc(100vw - 0.9rem))";
 
 const ensureTimelineStyles = () => {
     if (typeof document === "undefined" || document.getElementById(TIMELINE_STYLE_ID)) {
@@ -158,7 +159,7 @@ const widgetSurface = {
     padding: "0 0.5rem",
     position: "fixed",
     transition: "right 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
-    width: "18rem",
+    width: "min(18rem, calc(100vw - 0.9rem))",
     zIndex: 9999,
 };
 

--- a/src/runtime/useIsMobile.js
+++ b/src/runtime/useIsMobile.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+// Small-screen detection for the HUD. Components use this to swap desktop
+// offsets/widths for phone-friendly ones (full-width panels, compact bars).
+// Pure-CSS min()/max() clamps are preferred where they suffice; this hook is
+// for layout decisions CSS can't express in inline styles.
+const MOBILE_QUERY = "(max-width: 700px)";
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(MOBILE_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_QUERY);
+    const onChange = () => setIsMobile(mq.matches);
+    if (mq.addEventListener) mq.addEventListener("change", onChange);
+    else mq.addListener(onChange);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener("change", onChange);
+      else mq.removeListener(onChange);
+    };
+  }, []);
+
+  return isMobile;
+};


### PR DESCRIPTION
Makes the game playable on phones and hostable from one.

## Mobile UI

- **Top bar**: logo-only branding and compact tabs on small screens — Games / Scenarios / Community all fit at 375px.
- **Panels clamp to the viewport**: timeline widget and panel, chat/actions panel, advisor panels, settings — nothing runs off-screen.
- **Chat/actions panel height**: the desktop formula left ~280px on a phone; small screens now get up to 22rem of usable panel (desktop unchanged).
- **Map search**: expanding it rightward ran off a phone's edge — on small screens it now opens as a full-width bar just above the bottom toolbar.
- **Map editor**: the tool toolbar wraps into centered rows on narrow screens, and side panels never exceed the viewport.
- Touch itself already works — MapLibre and OpenLayers handle pan/pinch/tap natively; a new `useIsMobile` hook powers the layout switches and pure-CSS `min()`/`max()` clamps cover the rest. Browser chrome is themed via `theme-color`.

Verified at 375×812: no fixed element overflows the viewport, the chat panel opens at 359×352 above the toolbar, search expands full-width, and the editor toolbar wraps cleanly.

## Termux hosting (Android)

- The Linux launcher detects Termux and offers `pkg install nodejs` (Termux has no sudo); the updater's rsync hint covers `pkg install rsync`.
- README gains an Android/Termux quick-start. The server already binds all interfaces, so other devices on the same Wi-Fi can join at `http://<phone-ip>:3000`.