### PR TITLE
Fix Android app connection: CORS headers on the API + http app scheme

### DIFF
--- a/mobile/capacitor.config.json
+++ b/mobile/capacitor.config.json
@@ -3,6 +3,7 @@
   "appName": "Pax Historia",
   "webDir": "www",
   "server": {
+    "androidScheme": "http",
     "cleartext": true,
     "allowNavigation": ["*"]
   },

--- a/server/server.js
+++ b/server/server.js
@@ -48,6 +48,21 @@ const jsonParser = express.json({ limit: "64mb" });
 const largeJsonParser = express.json({ limit: "2048mb" });
 const uploadParser = express.raw({ type: () => true, limit: "2048mb" });
 
+// The Android app's connect screen lives on the WebView's own origin, so its
+// probe of this server is a cross-origin request — without these headers the
+// phone blocks it (CORS) and the app can never connect. This is a personal
+// game server whose whole API is open to whoever can reach it, so a blanket
+// allow changes nothing security-wise.
+app.use((req, res, next) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
 ensureScenarioStore();
 ensureGameStore();
 ensureMapEditorStore();


### PR DESCRIPTION
Fixes the Android app failing with "Could not reach http://localhost:3000 — is the server running?" while Termux is serving right there.

**Root cause:** the app's connect screen runs on the WebView's own internal origin, so its probe of the game server is a **cross-origin** request. The server sent no CORS headers, so Android blocked the response — the reported "CORS blocked" — and the probe failed. A second hurdle: the app's internal origin was `https`, making calls to a plain-`http` server mixed content.

**Fixes:**
- The API now answers with `Access-Control-Allow-Origin: *` (+ preflight handling). A personal game server's API is already open to whoever can reach it, so this changes nothing security-wise. Verified: OPTIONS preflight returns 204 with the allow headers; GETs carry the origin header.
- The app's internal origin switches to `http` (`androidScheme`), removing the mixed-content hurdle.

**Rollout:** the server fix alone unblocks already-installed apps (Build 1 allows mixed content). After merging, update + restart the Termux server, and run **Build Android APK** once so the release carries the hardened app — installed copies self-update to it on next launch.