### PR TITLE
Relay AI calls through the game server — self-hosted endpoints (NIM, LM Studio, llama.cpp) work

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -368,6 +368,33 @@ const HUB_DOWNLOAD_HOSTS = new Set([
 ]);
 const HUB_MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
 
+// Browser AI calls to self-hosted OpenAI-compatible endpoints (llama.cpp,
+// LM Studio, NVIDIA NIM...) die on CORS — those servers rarely send the
+// headers. The game server relays them instead: same-origin for the browser,
+// plain server-to-server for the endpoint. The target is whatever the player
+// configured in Settings — them talking to their own AI through their own
+// game server.
+app.post("/api/ai/relay", largeJsonParser, async (req, res) => {
+  try {
+    const { url: targetUrl, method = "POST", headers = {}, payload } = req.body ?? {};
+    const target = new URL(String(targetUrl ?? ""));
+    if (target.protocol !== "http:" && target.protocol !== "https:") {
+      return sendError(res, 400, new Error("Only http(s) AI endpoints can be relayed."));
+    }
+    const upstream = await fetch(target, {
+      method: method === "GET" ? "GET" : "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: method === "GET" ? undefined : JSON.stringify(payload ?? {}),
+    });
+    const text = await upstream.text();
+    res.status(upstream.status);
+    res.type(upstream.headers.get("content-type") || "application/json");
+    res.send(text);
+  } catch (error) {
+    sendError(res, 502, error);
+  }
+});
+
 // Shut the server down from the UI (the ⏻ button in the top bar) — handy on
 // phones/Termux and headless installs where no terminal is in sight. Responds
 // first so the client can show its "server stopped" screen, then exits.

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -141,6 +141,18 @@ function getGeminiUrl(model, apiKey) {
     return `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${apiKey}`;
 }
 
+// OpenAI-style calls go through the game server's relay instead of straight to
+// the endpoint: self-hosted endpoints (llama.cpp, LM Studio, NVIDIA NIM...)
+// rarely send CORS headers, so the browser can't call them directly. The relay
+// is same-origin for us and plain server-to-server for the endpoint. Gemini and
+// Anthropic stay direct — both support browser calls explicitly.
+const relayFetch = (url, { method = "POST", headers = {}, payload } = {}) =>
+    fetch("/api/ai/relay", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, method, headers, payload }),
+    });
+
 function toOpenAIMessages(systemPrompt, history) {
     const messages = [{ role: "system", content: systemPrompt }];
 
@@ -187,7 +199,7 @@ async function resolveModel(provider, { endpoint = "", headers = {}, fallbackMod
     }
 
     try {
-        const response = await fetch(`${normalizedEndpoint}/models`, { headers });
+        const response = await relayFetch(`${normalizedEndpoint}/models`, { method: "GET", headers });
 
         if (!response.ok) {
             const payload = await readErrorPayload(response);
@@ -280,17 +292,16 @@ async function callOpenAIStyleChatCompletions({
     retryDelay = 15000,
 }) {
     for (let attempt = 1; attempt <= retries; attempt++) {
-        const response = await fetch(`${normalizeEndpoint(endpoint)}/chat/completions`, {
-            method: "POST",
+        const response = await relayFetch(`${normalizeEndpoint(endpoint)}/chat/completions`, {
             headers,
-            body: JSON.stringify({
+            payload: {
                 model,
                 messages: toOpenAIMessages(systemPrompt, history),
                 // Reasoning toggle (settings) — honored by o-series/gpt-5 models and
                 // most OpenAI-compatible gateways; models that reject it surface a
                 // clear API error so the user knows to pick a reasoning model.
                 ...(getReasoningEnabled() ? { reasoning_effort: "medium" } : {}),
-            }),
+            },
         });
 
         if (response.status === 429 || response.status === 503) {


### PR DESCRIPTION
Fixes AI calls dying with CORS errors when the provider is a self-hosted OpenAI-compatible endpoint (llama.cpp, LM Studio, NVIDIA NIM, ...).

**Root cause:** the browser called AI providers directly. The big cloud APIs explicitly allow browser CORS, but self-hosted endpoints almost never send those headers — so every `/models` and `/chat/completions` request was blocked by the browser itself (console: "No 'Access-Control-Allow-Origin' header is present").

**Fix:** OpenAI-style calls now go through a small relay on the game server (`POST /api/ai/relay`): same-origin for the browser, plain server-to-server for the endpoint. The provider's status code and body pass through untouched, so retry/error handling behaves exactly as before. Gemini and Anthropic stay direct — both support browser calls explicitly. The relay only accepts http(s) targets; the endpoint is whatever the player configured in Settings, i.e. their own AI through their own server.

Bonus: endpoints reachable only from the server's machine (e.g. `127.0.0.1`-bound local models on the host) now work from any device playing over the LAN.

Verified: relayed GET/POST mirror upstream status + body; non-http(s) schemes rejected with a clear 400.