### PR TITLE
Android: native-HTTP server probe (WebView blocks loopback fetch); advisor close button

### DIFF
--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -104,6 +104,28 @@
         return url.replace(/\/+$/, "");
       };
 
+      // Probe via NATIVE http when available: the WebView's fetch is subject
+      // to CORS and Chrome's Private Network Access rules for loopback
+      // targets ("TypeError: Failed to fetch" with the server running fine),
+      // while native requests are not. Navigation afterwards is unaffected by
+      // those policies, and the game then runs same-origin on the server.
+      const probe = async (url) => {
+        const native = window.Capacitor && window.Capacitor.Plugins && window.Capacitor.Plugins.CapacitorHttp;
+        if (native) {
+          const res = await native.request({
+            url: url + "/api/library",
+            method: "GET",
+            connectTimeout: 4000,
+            readTimeout: 4000,
+          });
+          if (!res || res.status < 100 || res.status >= 500) {
+            throw new Error("HTTP " + (res && res.status));
+          }
+          return;
+        }
+        await fetch(url + "/api/library", { signal: AbortSignal.timeout(4000) });
+      };
+
       // Probe the server first so a typo shows an error here instead of a
       // WebView error page the user can't navigate back from.
       const connect = async (raw) => {
@@ -111,7 +133,7 @@
         if (!url) return;
         errorBox.textContent = "";
         try {
-          await fetch(url + "/api/library", { signal: AbortSignal.timeout(4000) });
+          await probe(url);
           localStorage.setItem(KEY, url);
           window.location.replace(url);
         } catch (err) {
@@ -149,7 +171,7 @@
           setup.style.display = "none";
           connecting.style.display = "flex";
           document.getElementById("connectingTo").textContent = "Looking for a server on this phone…";
-          fetch(guess + "/api/library", { signal: AbortSignal.timeout(2500) })
+          probe(guess)
             .then(() => {
               localStorage.setItem(KEY, guess);
               window.location.replace(guess);

--- a/server/server.js
+++ b/server/server.js
@@ -57,6 +57,9 @@ app.use((req, res, next) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  // Chrome's Private Network Access preflights loopback/LAN targets and
+  // requires this opt-in on top of regular CORS.
+  res.setHeader("Access-Control-Allow-Private-Network", "true");
   if (req.method === "OPTIONS") {
     return res.sendStatus(204);
   }

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -159,7 +159,7 @@ const loadMessages = async () => {
     } catch { return []; }
 };
 
-const AdvisorPanel = ({ isAdvisorOpen }) => {
+const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
     const [messages, setMessages]   = useState([]);
     const [input, setInput]         = useState("");
     const [isLoading, setIsLoading] = useState(false);
@@ -259,6 +259,15 @@ const AdvisorPanel = ({ isAdvisorOpen }) => {
         title="Clear chat"
         style={{ background: "none", border: "none", color: "rgba(255,255,255,0.4)", cursor: "pointer", fontSize: "1.5rem", lineHeight: 1, padding: 0, display: "flex", alignItems: "center" }}
         >🗑</button>
+        {/* On phones the panel slides over the 🧭 launcher, making it
+            untappable — this ✕ is the way out. */}
+        {onClose && (
+            <button
+            onClick={onClose}
+            title="Close advisor"
+            style={{ background: "none", border: "none", color: "rgba(255,255,255,0.55)", cursor: "pointer", fontSize: "1.35rem", lineHeight: 1, padding: "0 0 0 0.35rem", display: "flex", alignItems: "center" }}
+            >✕</button>
+        )}
         </div>
 
         {/* Messages */}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -213,7 +213,9 @@ const Main = ({
         onToggle={() => setIsAdvisorOpen(!isAdvisorOpen)}
       />
       <Suspense fallback={null}>
-        {shouldLoadAdvisor && <LazyAdvisorPanel isAdvisorOpen={isAdvisorOpen} />}
+        {shouldLoadAdvisor && (
+          <LazyAdvisorPanel isAdvisorOpen={isAdvisorOpen} onClose={() => setIsAdvisorOpen(false)} />
+        )}
       </Suspense>
       <SettingsButton
         topOffset={TOP_BAR_OFFSET}


### PR DESCRIPTION
Two fixes from continued phone testing.

## App: probe the server with native HTTP

Build 3 still failed with `TypeError: Failed to fetch` against a confirmed-healthy server. The connect screen's fetch runs inside the WebView, where requests to loopback targets are subject to CORS **and Chrome's Private Network Access rules** — policies the plain browser never hits, because there the page is served *from* `localhost:3000` and everything is same-origin. The probe now goes through Capacitor's **native HTTP** plugin (immune to browser policies), with the old fetch as a fallback outside the app. Navigation to the server — and the game itself, which then runs same-origin — was never subject to these rules. The server additionally answers PNA preflights with `Access-Control-Allow-Private-Network: true` for any browser-context loopback callers.

## Advisor drawer: close button

On phones the advisor drawer slides over its own 🧭 launcher button, so once open there was no way to close it. The panel header now has a ✕.

After merging, the auto-dispatch publishes this as **Build 4** — Build 2/3 installs will offer it via the update screen.