### PR TITLE
Fix advisor drawer never closing; stop discarding slow AI turns

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -520,7 +520,11 @@ const withTimeout = async (promise, timeoutMs, timeoutMessage) => {
   }
 };
 
-const runJsonTask = async (taskKey, { fallback, timeoutMs = 12000, userMessage, variables }) => {
+// Give the AI real time: local/self-hosted models (and reasoning modes) often
+// need well over a minute per turn. The old 12s default silently discarded
+// their answers and served the canned fallback instead — turns "completed"
+// with nothing to show. The UI has spinners; waiting beats silently wrong.
+const runJsonTask = async (taskKey, { fallback, timeoutMs = 120000, userMessage, variables }) => {
   const prompts = await loadPromptCatalog();
   const helperValues = resolveHelperValues(prompts.helpers, variables);
   const systemPrompt = renderTemplate(prompts.tasks[taskKey], {
@@ -538,8 +542,9 @@ const runJsonTask = async (taskKey, { fallback, timeoutMs = 12000, userMessage, 
     if (parsed) {
       return parsed;
     }
-  } catch {
-    // Fall through to deterministic fallback.
+    console.warn(`[ai] task "${taskKey}": response was not parseable JSON — using the deterministic fallback.`);
+  } catch (error) {
+    console.warn(`[ai] task "${taskKey}" failed (${error?.message || error}) — using the deterministic fallback.`);
   }
 
   return fallback();
@@ -1263,7 +1268,9 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
   const variables = await buildTemplateVariables(bundle, { targetDate });
   const payload = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {
     fallback: () => fallbackJumpSimulation({ bundle, days: safeDays, mode, targetDate }),
-    timeoutMs: safeDays >= 90 || mode === "auto" ? 9000 : 12000,
+    // The jump IS the game — let slow (local/reasoning) models finish instead
+    // of silently swapping in the canned fallback after a few seconds.
+    timeoutMs: 180000,
     userMessage:
       mode === "auto"
         ? "Simulate an auto-jump and stop at the next notable or player-relevant event. Return JSON only."

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -240,13 +240,16 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
         <>
         <MarkdownStyleInjector />
         <div style={{
-            position: "fixed", bottom: 0,
-            right: isAdvisorOpen ? 0 : `calc(-${ADVISOR_PANEL_WIDTH} - 1rem)`,
+            position: "fixed", bottom: 0, right: 0,
+            // Slide via transform: the old right: calc(-min(...) - 1rem) was
+            // INVALID CSS (a min() can't be negated like that), so the closed
+            // position was silently dropped and the drawer never slid away.
+            transform: isAdvisorOpen ? "translateX(0)" : "translateX(calc(100% + 2rem))",
             width: ADVISOR_PANEL_WIDTH, height: "calc(100vh - 64px)",
             backgroundColor: "rgba(17, 24, 39, 0.95)", backdropFilter: "blur(8px)",
             zIndex: 9998, borderLeft: "1px solid rgba(255,255,255,0.1)",
             boxShadow: "-4px 0 24px rgba(0,0,0,0.4)",
-            transition: "right 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
+            transition: "transform 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
             display: "flex", flexDirection: "column",
             color: "white", fontFamily: "sans-serif", overflow: "hidden",
         }}>


### PR DESCRIPTION
Two cross-platform gameplay bugs.

## Advisor drawer never closed (all platforms)

Its closed position was `right: calc(-min(20rem, calc(100vw - 1rem)) - 1rem)` — a `min()` can't be negated like that, so the whole declaration was invalid CSS and silently dropped. The drawer opened fine (`right: 0` is valid) but never slid away, while the compass and clock — whose shift formula doesn't negate — kept moving back and forth. It now slides with a `transform`, valid everywhere, and keeps the ✕ close button.

## Timeline jumps "did nothing" with slow AI providers

Every AI task raced the model against a **9–12 second timeout** and, on loss, silently served a canned deterministic fallback (an empty `catch {}` hid it). With a local or reasoning model — anything that takes more than a few seconds — a jump would spin, "complete", and show none of what the AI actually decided: the real answer was discarded every single time. Jumps now allow 3 minutes and other tasks 2 (the UI has spinners; waiting beats silently wrong), and any fallback logs a console warning naming the task and the reason.

No APK rebuild needed — the app is a thin client, so these reach phones as soon as the server updates.