### PR TITLE
Empty AI turns take the fallback; app hostname no longer collides with the server

### DIFF
--- a/mobile/capacitor.config.json
+++ b/mobile/capacitor.config.json
@@ -4,6 +4,7 @@
   "webDir": "www",
   "server": {
     "androidScheme": "http",
+    "hostname": "app.paxhistoria",
     "cleartext": true,
     "allowNavigation": ["*"]
   },

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1266,7 +1266,7 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
   const safeDays = Math.max(1, Math.trunc(Number(days) || 0));
   const targetDate = dayjs(bundle.game.gameDate).add(safeDays, "day").format("YYYY-MM-DD");
   const variables = await buildTemplateVariables(bundle, { targetDate });
-  const payload = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {
+  let payload = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {
     fallback: () => fallbackJumpSimulation({ bundle, days: safeDays, mode, targetDate }),
     // The jump IS the game — let slow (local/reasoning) models finish instead
     // of silently swapping in the canned fallback after a few seconds.
@@ -1277,6 +1277,20 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
         : "Simulate a standard jump forward to the requested target date. Return JSON only.",
     variables,
   });
+
+  // A model can answer with VALID but EMPTY JSON (reasoning models told
+  // "JSON only" often emit a bare object). That used to be accepted as a
+  // successful turn of nothing: no events, no summary, an invisible history
+  // entry — the game looked like it "did nothing" with no fallback either.
+  // An empty turn now counts as a failure and takes the fallback path.
+  const emptyTurn =
+    normalizeArray(payload?.events).length === 0 &&
+    !normalizeString(payload?.summary) &&
+    !payload?.catalyst;
+  if (emptyTurn) {
+    console.warn("[ai] jump returned an empty turn — using the deterministic fallback.");
+    payload = await fallbackJumpSimulation({ bundle, days: safeDays, mode, targetDate });
+  }
 
   const result = {
     catalyst: payload?.catalyst ?? null,


### PR DESCRIPTION
Two commits.

## An empty AI turn no longer counts as success

`runJsonTask` accepts **any parseable JSON**. A model that answers quickly with a bare or partial object — no `events`, no `summary`, no `catalyst` — was treated as a *successful simulation of nothing*: the history entry rendered empty, the jump looked like it did nothing, and the fallback never fired because parsing "succeeded". Reasoning models told "JSON only" do this regularly. An empty turn now takes the deterministic fallback path (which always produces at least one visible event) and logs a console warning.

## The app's internal origin collided with the game server

Screen recording of Build 4 showed the app looping on "Connecting…" forever with **no error**: the native-HTTP probe succeeds, but the app is served from `http://localhost` and Capacitor's request interception on that host can capture the navigation to the REAL `http://localhost:3000` — landing the WebView right back on its own connect screen, which auto-connects again, forever. The app now lives on `http://app.paxhistoria`, a hostname that cannot collide with any real server. (One-time side effect: the app's saved-server storage resets; it re-detects the Termux server automatically.)

After merging, the auto-dispatch publishes **Build 5** — Build ≥2 installs will offer it on the update screen.