### PR TITLE
Zero-games saves auto-create the session; empty AI suggestions take the fallback

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -1726,9 +1726,25 @@ const writeRuntimeJsonAsset = (assetKey, value) => {
     throw new Error(`Unsupported JSON asset key: ${assetKey}`);
   }
 
-  const activeGameId = getActiveGameId();
+  let activeGameId = getActiveGameId();
   if (!activeGameId) {
-    throw new Error("No active game — start a game from a scenario first.");
+    // With every game deleted, the map still renders (reads fall back to the
+    // selected scenario) so play LOOKS possible — but there was nowhere to
+    // save, and every AI feature died on this guard. The first stateful
+    // interaction now quietly creates a real session from the selected
+    // scenario instead, which is how it always felt back when a built-in
+    // game guaranteed a write target.
+    const scenario = getSelectedScenarioSummary();
+    if (!scenario) {
+      throw new Error("No active game — start a game from a scenario first.");
+    }
+    const details = createGame({
+      name: `${scenario.name} Session`,
+      scenarioId: scenario.id,
+      setActive: true,
+    });
+    activeGameId = details.game.id;
+    console.log(`No active game — created "${activeGameId}" from scenario "${scenario.id}".`);
   }
   const targetPath = getGameJsonPath(activeGameId, assetKey);
   writeJsonFile(targetPath, value);

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -914,36 +914,51 @@ export const generateActionSuggestions = async ({ force = true } = {}) => {
     variables,
   });
 
-  const topics = normalizeArray(payload?.topics)
-    .map((topic, topicIndex) => {
-      if (!topic || typeof topic !== "object") {
-        return null;
-      }
+  const normalizeTopics = (raw) =>
+    normalizeArray(raw)
+      .map((topic, topicIndex) => {
+        if (!topic || typeof topic !== "object") {
+          return null;
+        }
 
-      const title = normalizeString(topic.title || topic.name);
-      if (!title) {
-        return null;
-      }
+        const title = normalizeString(topic.title || topic.name);
+        if (!title) {
+          return null;
+        }
 
-      return {
-        actions: normalizeArray(topic.actions)
-          .map((action, actionIndex) =>
-            normalizeActionEntry(
-              {
-                ...action,
-                source: "suggested",
-                suggestionTopic: title,
-              },
-              actionIndex,
-            ),
-          )
-          .filter(Boolean),
-        description: normalizeString(topic.description),
-        id: normalizeString(topic.id) || `topic-${topicIndex}`,
-        title,
-      };
-    })
-    .filter(Boolean);
+        return {
+          actions: normalizeArray(topic.actions)
+            .map((action, actionIndex) =>
+              normalizeActionEntry(
+                {
+                  ...action,
+                  source: "suggested",
+                  suggestionTopic: title,
+                },
+                actionIndex,
+              ),
+            )
+            .filter(Boolean),
+          description: normalizeString(topic.description),
+          id: normalizeString(topic.id) || `topic-${topicIndex}`,
+          title,
+        };
+      })
+      .filter(Boolean);
+
+  // Models told "JSON only" mislabel or wrap the list — accept the common
+  // shapes (top-level array, topics, suggestions) before giving up.
+  let topics = normalizeTopics(
+    Array.isArray(payload) ? payload : payload?.topics ?? payload?.suggestions,
+  );
+
+  // A parseable-but-EMPTY answer used to be accepted as "no suggestions were
+  // generated" — the deterministic fallback (which always has topics) now
+  // covers it, same as empty timeline turns.
+  if (topics.length === 0) {
+    console.warn("[ai] action suggestions came back empty — using the deterministic fallback.");
+    topics = normalizeTopics((await fallbackActionSuggestions(bundle))?.topics);
+  }
 
   const world = normalizeWorldState(await readWorldState());
   world.actionSuggestions = topics;


### PR DESCRIPTION
Root-cause fix for "no suggestions were generated" and AI turns that silently did nothing — reproduced live and verified fixed.

## Playing with zero games broke every save

Removing the undeletable built-in game (#36) left a trap: with every game deleted, the map still renders (runtime reads fall back to the selected scenario) so play **looks** possible — but every stateful AI feature (suggestions, timeline jumps, action resolution) died on the `No active game` guard with a 400 the UI swallowed. Reproduced against a live server: `activeGameId: ""`, world write → `400 No active game`.

The first write now quietly **creates a real session from the selected scenario** — the exact feel of the old always-present game, without the undeletable instance. Verified with a zero-games store: a world write creates and activates the session and the save lands.

## Empty suggestion answers take the fallback

Same hole as #43's empty turns, in the suggestions task: any parseable JSON was accepted, so a bare object (or a list labeled something other than `topics`) yielded an empty list — "no suggestions were generated" — while the deterministic fallback never fired. The parser now tolerates common shapes (top-level array, `topics`, `suggestions`) and an empty result falls back with a console warning. The button always yields suggestions.

Game/server code only — reaches phones via the server, no APK rebuild needed.