### PR TITLE
Attribution: Arkniem made commit bd3b2d5 on June 30, 2026 at 23:57 -0400

### DIFF
--- a/attributions/bd3b2d5.md
+++ b/attributions/bd3b2d5.md
@@ -1,0 +1,5 @@
+Arkniem made commit `bd3b2d5c771da58d70caa802be39252b81549f0a`
+("Fix country flags: restcountries API is deprecated")
+on June 30, 2026 at 23:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `bd3b2d5c771da58d70caa802be39252b81549f0a` — "Fix country flags: restcountries API is deprecated" — on **June 30, 2026 at 23:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.