### PR TITLE
Attribution: Arkniem made commit 3f5cfbd on July  1, 2026 at 00:08 -0400

### DIFF
--- a/attributions/3f5cfbd.md
+++ b/attributions/3f5cfbd.md
@@ -1,0 +1,5 @@
+Arkniem made commit `3f5cfbd6f3806d5255f8d262052964fe54189204`
+("Remove stray empty files")
+on July  1, 2026 at 00:08 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `3f5cfbd6f3806d5255f8d262052964fe54189204` — "Remove stray empty files" — on **July  1, 2026 at 00:08 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.