### PR TITLE
Attribution: Arkniem made commit 4f04a2b on July  1, 2026 at 16:56 -0400

### DIFF
--- a/attributions/4f04a2b.md
+++ b/attributions/4f04a2b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4f04a2bcaa9068a5f0992c202484e446c3436556`
+("chore(build): add OpenLayers/polygon-clipping/turf deps, vendor-ol chunk, dev API proxy")
+on July  1, 2026 at 16:56 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4f04a2bcaa9068a5f0992c202484e446c3436556` — "chore(build): add OpenLayers/polygon-clipping/turf deps, vendor-ol chunk, dev API proxy" — on **July  1, 2026 at 16:56 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.