### PR TITLE
Attribution: Arkniem made commit 2f23322 on July  1, 2026 at 16:56 -0400

### DIFF
--- a/attributions/2f23322.md
+++ b/attributions/2f23322.md
@@ -1,0 +1,5 @@
+Arkniem made commit `2f23322a8a7a6a0af468b35e6c2a321893c55f9c`
+("chore(assets): track large seed/generated geodata with Git LFS")
+on July  1, 2026 at 16:56 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `2f23322a8a7a6a0af468b35e6c2a321893c55f9c` — "chore(assets): track large seed/generated geodata with Git LFS" — on **July  1, 2026 at 16:56 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.