### PR TITLE
Attribution: Arkniem made commit d48806b on July  1, 2026 at 16:56 -0400

### DIFF
--- a/attributions/d48806b.md
+++ b/attributions/d48806b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `d48806b29a9df2f8f9a1577b8022b144d25be8f4`
+("feat(editor): OpenLayers map surface, geometry ops (split/merge/lasso/dissolve), styling")
+on July  1, 2026 at 16:56 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `d48806b29a9df2f8f9a1577b8022b144d25be8f4` — "feat(editor): OpenLayers map surface, geometry ops (split/merge/lasso/dissolve), styling" — on **July  1, 2026 at 16:56 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.