### PR TITLE
Attribution: Arkniem made commit c104f1c on July  1, 2026 at 16:56 -0400

### DIFF
--- a/attributions/c104f1c.md
+++ b/attributions/c104f1c.md
@@ -1,0 +1,5 @@
+Arkniem made commit `c104f1c1fe765e0e611bae9a0f497f2893037600`
+("feat(editor): document model, editor shell, managers (Types/Regions/Layers), toolbar, author field")
+on July  1, 2026 at 16:56 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `c104f1c1fe765e0e611bae9a0f497f2893037600` — "feat(editor): document model, editor shell, managers (Types/Regions/Layers), toolbar, author field" — on **July  1, 2026 at 16:56 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.