### PR TITLE
Attribution: Arkniem made commit d3583cb on July  1, 2026 at 16:56 -0400

### DIFF
--- a/attributions/d3583cb.md
+++ b/attributions/d3583cb.md
@@ -1,0 +1,5 @@
+Arkniem made commit `d3583cb980b02c3db69d6bf8861b7852ada8f445`
+("feat(editor): city/POI extraction (70k cities) + Feature Manager with full-import")
+on July  1, 2026 at 16:56 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `d3583cb980b02c3db69d6bf8861b7852ada8f445` — "feat(editor): city/POI extraction (70k cities) + Feature Manager with full-import" — on **July  1, 2026 at 16:56 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.