### PR TITLE
Attribution: Arkniem made commit 3a05d5b on July  1, 2026 at 16:56 -0400

### DIFF
--- a/attributions/3a05d5b.md
+++ b/attributions/3a05d5b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `3a05d5b42e756612e4ead74af4739e386578d6cb`
+("feat(editor): server-side map-document persistence (/api/mapeditor CRUD)")
+on July  1, 2026 at 16:56 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `3a05d5b42e756612e4ead74af4739e386578d6cb` — "feat(editor): server-side map-document persistence (/api/mapeditor CRUD)" — on **July  1, 2026 at 16:56 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.