### PR TITLE
Attribution: Arkniem made commit 05bf706 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/05bf706.md
+++ b/attributions/05bf706.md
@@ -1,0 +1,5 @@
+Arkniem made commit `05bf706d63a2dcb44e482da92dea408eceb638e8`
+("docs(editor): MIT license (c) 2026 Nicholas Krol for the map editor")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `05bf706d63a2dcb44e482da92dea408eceb638e8` — "docs(editor): MIT license (c) 2026 Nicholas Krol for the map editor" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.