### PR TITLE
Attribution: Arkniem made commit 3c2c106 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/3c2c106.md
+++ b/attributions/3c2c106.md
@@ -1,0 +1,5 @@
+Arkniem made commit `3c2c10628776a6ae4bb6f5f6233698d04e6f27ed`
+("feat(editor): game-seed export (tier-1 re-ownership / tier-2 custom geometry) + creator credit")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `3c2c10628776a6ae4bb6f5f6233698d04e6f27ed` — "feat(editor): game-seed export (tier-1 re-ownership / tier-2 custom geometry) + creator credit" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.