### PR TITLE
Attribution: Arkniem made commit 71a3dc6 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/71a3dc6.md
+++ b/attributions/71a3dc6.md
@@ -1,0 +1,5 @@
+Arkniem made commit `71a3dc6a7629e2a38cc872dcdfda75072e3e618e`
+("feat(app): standalone map-editor mode behind a URL flag (?editor=1)")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `71a3dc6a7629e2a38cc872dcdfda75072e3e618e` — "feat(app): standalone map-editor mode behind a URL flag (?editor=1)" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.