### PR TITLE
Attribution: Arkniem made commit 54eae7f on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/54eae7f.md
+++ b/attributions/54eae7f.md
@@ -1,0 +1,5 @@
+Arkniem made commit `54eae7fc9f047922d6b109ff0ec6e9e8f0dce910`
+("feat(server): per-scenario regions.geojson asset, runtime serving, template world keys, seed-date hardening")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `54eae7fc9f047922d6b109ff0ec6e9e8f0dce910` — "feat(server): per-scenario regions.geojson asset, runtime serving, template world keys, seed-date hardening" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.