### PR TITLE
Attribution: Arkniem made commit 8ec1390 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/8ec1390.md
+++ b/attributions/8ec1390.md
@@ -1,0 +1,5 @@
+Arkniem made commit `8ec1390b37d660e27decc133036015b0905ef817`
+("feat(map): tier-2 custom-region rendering (fill/borders/click) + per-owner clustered labels")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `8ec1390b37d660e27decc133036015b0905ef817` — "feat(map): tier-2 custom-region rendering (fill/borders/click) + per-owner clustered labels" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.