### PR TITLE
Attribution: Arkniem made commit 54039ab on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/54039ab.md
+++ b/attributions/54039ab.md
@@ -1,0 +1,5 @@
+Arkniem made commit `54039abca3470ba7589eb0d440c84f8b1ef20fcd`
+("feat(library): map editor embed, Apply & Play, scenario-faction country picker, troop-type controls")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `54039abca3470ba7589eb0d440c84f8b1ef20fcd` — "feat(library): map editor embed, Apply & Play, scenario-faction country picker, troop-type controls" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.