### PR TITLE
Attribution: Arkniem made commit 1ed0ee2 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/1ed0ee2.md
+++ b/attributions/1ed0ee2.md
@@ -1,0 +1,5 @@
+Arkniem made commit `1ed0ee247cc43460873a3b91aa2f041a177cc020`
+("fix(ui): defensive timeline dates (no more Invalid Date/Undated)")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `1ed0ee247cc43460873a3b91aa2f041a177cc020` — "fix(ui): defensive timeline dates (no more Invalid Date/Undated)" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.