### PR TITLE
Attribution: Arkniem made commit 092349a on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/092349a.md
+++ b/attributions/092349a.md
@@ -1,0 +1,5 @@
+Arkniem made commit `092349af4b8f4eb91808295eac8235178c14e276`
+("feat(ui): loading screen cycles era artwork + discrete image credit")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `092349af4b8f4eb91808295eac8235178c14e276` — "feat(ui): loading screen cycles era artwork + discrete image credit" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.