### PR TITLE
Attribution: Arkniem made commit 5ac3a99 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/5ac3a99.md
+++ b/attributions/5ac3a99.md
@@ -1,0 +1,5 @@
+Arkniem made commit `5ac3a9977d7ab1b1be7dc690d387e7f97da86e55`
+("feat(presets): generator emits tier-2 geometry, owner codes, unit types, era covers")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `5ac3a9977d7ab1b1be7dc690d387e7f97da86e55` — "feat(presets): generator emits tier-2 geometry, owner codes, unit types, era covers" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.