### PR TITLE
Attribution: Arkniem made commit 4882a28 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/4882a28.md
+++ b/attributions/4882a28.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4882a282fb5e43def2c39e5b4c70eec94ae451cd`
+("feat(preset): Medieval 1200 — accurate Rus'/steppe, Ghurids, Volga Bulgaria, SE Asia, tier-2 map + cover")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4882a282fb5e43def2c39e5b4c70eec94ae451cd` — "feat(preset): Medieval 1200 — accurate Rus'/steppe, Ghurids, Volga Bulgaria, SE Asia, tier-2 map + cover" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.