### PR TITLE
Attribution: Arkniem made commit 4917a51 on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/4917a51.md
+++ b/attributions/4917a51.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4917a519b9eda68cb23640d10372e9f2fd25f364`
+("feat(preset): Mongol World 1300 — four khanates, vassal Rus', Ottoman origin (new)")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4917a519b9eda68cb23640d10372e9f2fd25f364` — "feat(preset): Mongol World 1300 — four khanates, vassal Rus', Ottoman origin (new)" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.