### PR TITLE
Attribution: Arkniem made commit fa9c83c on July  1, 2026 at 16:57 -0400

### DIFF
--- a/attributions/fa9c83c.md
+++ b/attributions/fa9c83c.md
@@ -1,0 +1,5 @@
+Arkniem made commit `fa9c83c51af604bb22e50e48e1b606d1c1735be0`
+("feat(preset): New World 1650 — colonial empires and native nations (new)")
+on July  1, 2026 at 16:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `fa9c83c51af604bb22e50e48e1b606d1c1735be0` — "feat(preset): New World 1650 — colonial empires and native nations (new)" — on **July  1, 2026 at 16:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.