### PR TITLE
Attribution: Arkniem made commit 6ea4e5a on July  1, 2026 at 17:10 -0400

### DIFF
--- a/attributions/6ea4e5a.md
+++ b/attributions/6ea4e5a.md
@@ -1,0 +1,5 @@
+Arkniem made commit `6ea4e5aa3bd2d0b36b4f87cff10132ea2bccffbd`
+("feat(hub): server proxy for GitHub-hosted scenario bundles (host-allowlisted)")
+on July  1, 2026 at 17:10 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `6ea4e5aa3bd2d0b36b4f87cff10132ea2bccffbd` — "feat(hub): server proxy for GitHub-hosted scenario bundles (host-allowlisted)" — on **July  1, 2026 at 17:10 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.