### PR TITLE
Attribution: Arkniem made commit 6c9a11d on July  1, 2026 at 17:10 -0400

### DIFF
--- a/attributions/6c9a11d.md
+++ b/attributions/6c9a11d.md
@@ -1,0 +1,5 @@
+Arkniem made commit `6c9a11df67b49de5629168a44d33041e05a61d1a`
+("feat(hub): Community tab — browse/vote/import shared scenarios, publish to the hub")
+on July  1, 2026 at 17:10 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `6c9a11df67b49de5629168a44d33041e05a61d1a` — "feat(hub): Community tab — browse/vote/import shared scenarios, publish to the hub" — on **July  1, 2026 at 17:10 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.