### PR TITLE
Attribution: Arkniem made commit ddfe7ed on July  1, 2026 at 17:18 -0400

### DIFF
--- a/attributions/ddfe7ed.md
+++ b/attributions/ddfe7ed.md
@@ -1,0 +1,5 @@
+Arkniem made commit `ddfe7edca1030185c34780f9c897e4db4364a775`
+("feat(hub): Netflix-style Community tab — Pinned shelf + Most Played / Most Liked / Most Recent rows")
+on July  1, 2026 at 17:18 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `ddfe7edca1030185c34780f9c897e4db4364a775` — "feat(hub): Netflix-style Community tab — Pinned shelf + Most Played / Most Liked / Most Recent rows" — on **July  1, 2026 at 17:18 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.