### PR TITLE
Attribution: Arkniem made commit 579dc14 on July  1, 2026 at 17:24 -0400

### DIFF
--- a/attributions/579dc14.md
+++ b/attributions/579dc14.md
@@ -1,0 +1,5 @@
+Arkniem made commit `579dc1421ac0692a2b7e462da48cfb499e8ba0bd`
+("feat(hub): verified Official badge — purple title + chip for hub-owner posts only")
+on July  1, 2026 at 17:24 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `579dc1421ac0692a2b7e462da48cfb499e8ba0bd` — "feat(hub): verified Official badge — purple title + chip for hub-owner posts only" — on **July  1, 2026 at 17:24 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.