### PR TITLE
Attribution: Arkniem made commit 383d061 on July  1, 2026 at 17:24 -0400

### DIFF
--- a/attributions/383d061.md
+++ b/attributions/383d061.md
@@ -1,0 +1,5 @@
+Arkniem made commit `383d061d1dce0890b6cf8ac5461ac539c19473df`
+("refactor(ui): move Forces launcher into the bottom toolbar next to Chat and Actions")
+on July  1, 2026 at 17:24 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `383d061d1dce0890b6cf8ac5461ac539c19473df` — "refactor(ui): move Forces launcher into the bottom toolbar next to Chat and Actions" — on **July  1, 2026 at 17:24 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.