### PR TITLE
Attribution: Arkniem made commit b79a2b0 on July  2, 2026 at 09:00 -0400

### DIFF
--- a/attributions/b79a2b0.md
+++ b/attributions/b79a2b0.md
@@ -1,0 +1,5 @@
+Arkniem made commit `b79a2b0af933987841e1a480ea83f9d495c0fda5`
+("feat(tooling): one-click updater (Update Pax Historia.bat) — preserves saves, scenarios and map data")
+on July  2, 2026 at 09:00 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `b79a2b0af933987841e1a480ea83f9d495c0fda5` — "feat(tooling): one-click updater (Update Pax Historia.bat) — preserves saves, scenarios and map data" — on **July  2, 2026 at 09:00 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.