### PR TITLE
Attribution: Arkniem made commit b823438 on July  2, 2026 at 09:00 -0400

### DIFF
--- a/attributions/b823438.md
+++ b/attributions/b823438.md
@@ -1,0 +1,5 @@
+Arkniem made commit `b823438d6b60e764a297c8e003b2f832ee6aff57`
+("feat(tooling): one-click updater (Update Pax Historia.bat) — preserves saves, scenarios and map data")
+on July  2, 2026 at 09:00 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `b823438d6b60e764a297c8e003b2f832ee6aff57` — "feat(tooling): one-click updater (Update Pax Historia.bat) — preserves saves, scenarios and map data" — on **July  2, 2026 at 09:00 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.