### PR TITLE
Attribution: Arkniem made commit bc6cb9e on July  2, 2026 at 10:06 -0400

### DIFF
--- a/attributions/bc6cb9e.md
+++ b/attributions/bc6cb9e.md
@@ -1,0 +1,5 @@
+Arkniem made commit `bc6cb9e8f618a9e5b2994a13c04afb5c04332edb`
+("fix(map): crisp region borders on custom maps — paint stock tiles by ownership, GeoJSON only for drawn shapes")
+on July  2, 2026 at 10:06 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `bc6cb9e8f618a9e5b2994a13c04afb5c04332edb` — "fix(map): crisp region borders on custom maps — paint stock tiles by ownership, GeoJSON only for drawn shapes" — on **July  2, 2026 at 10:06 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.