### PR TITLE
Attribution: Arkniem made commit 4c720c4 on July  2, 2026 at 10:07 -0400

### DIFF
--- a/attributions/4c720c4.md
+++ b/attributions/4c720c4.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4c720c45b0d4988807eb67d7fb8e036a4853f9e8`
+("chore(data): default scenario saved state — explicit troop-type defaults")
+on July  2, 2026 at 10:07 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4c720c45b0d4988807eb67d7fb8e036a4853f9e8` — "chore(data): default scenario saved state — explicit troop-type defaults" — on **July  2, 2026 at 10:07 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.