### PR TITLE
Attribution: Arkniem made commit 210cb1b on July  2, 2026 at 10:11 -0400

### DIFF
--- a/attributions/210cb1b.md
+++ b/attributions/210cb1b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `210cb1b1aa981fde0dfdb91eefe313d3d896ee97`
+("fix(map): crossfade custom-map fill — seed geometry zoomed out, stock tiles zoomed in")
+on July  2, 2026 at 10:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `210cb1b1aa981fde0dfdb91eefe313d3d896ee97` — "fix(map): crossfade custom-map fill — seed geometry zoomed out, stock tiles zoomed in" — on **July  2, 2026 at 10:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.