### PR TITLE
Attribution: Arkniem made commit 1152b48 on July  2, 2026 at 10:18 -0400

### DIFF
--- a/attributions/1152b48.md
+++ b/attributions/1152b48.md
@@ -1,0 +1,5 @@
+Arkniem made commit `1152b48548583257f9f81fdd8526f78b7f59c8a9`
+("World border zoom fix")
+on July  2, 2026 at 10:18 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `1152b48548583257f9f81fdd8526f78b7f59c8a9` — "World border zoom fix" — on **July  2, 2026 at 10:18 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.