### PR TITLE
Attribution: Arkniem made commit 59b44ee on July  2, 2026 at 10:41 -0400

### DIFF
--- a/attributions/59b44ee.md
+++ b/attributions/59b44ee.md
@@ -1,0 +1,5 @@
+Arkniem made commit `59b44eefa569aaddf312e442024f73f96b68efd1`
+("feat(tooling): Linux/macOS launch and update scripts")
+on July  2, 2026 at 10:41 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `59b44eefa569aaddf312e442024f73f96b68efd1` — "feat(tooling): Linux/macOS launch and update scripts" — on **July  2, 2026 at 10:41 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.