### PR TITLE
Attribution: Arkniem made commit 27b8fe8 on July  2, 2026 at 11:11 -0400

### DIFF
--- a/attributions/27b8fe8.md
+++ b/attributions/27b8fe8.md
@@ -1,0 +1,5 @@
+Arkniem made commit `27b8fe8ae4d31e309cd62ca91c702d22c499e3c6`
+("feat(map): per-scenario custom cities — era city sets replace modern labels")
+on July  2, 2026 at 11:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `27b8fe8ae4d31e309cd62ca91c702d22c499e3c6` — "feat(map): per-scenario custom cities — era city sets replace modern labels" — on **July  2, 2026 at 11:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.