### PR TITLE
Attribution: Arkniem made commit c330d4b on July  2, 2026 at 11:11 -0400

### DIFF
--- a/attributions/c330d4b.md
+++ b/attributions/c330d4b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `c330d4bc46b7382ad5830b4d212edeab3cea0012`
+("feat(editor): city tool — click to add, click a city to edit, inline popup")
+on July  2, 2026 at 11:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `c330d4bc46b7382ad5830b4d212edeab3cea0012` — "feat(editor): city tool — click to add, click a city to edit, inline popup" — on **July  2, 2026 at 11:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.