### PR TITLE
Attribution: Arkniem made commit 2b6e187 on July  2, 2026 at 11:11 -0400

### DIFF
--- a/attributions/2b6e187.md
+++ b/attributions/2b6e187.md
@@ -1,0 +1,5 @@
+Arkniem made commit `2b6e187aaed39881b05a56ac104acb0f782d12b5`
+("feat(editor): place search — modern world places and custom places in one box")
+on July  2, 2026 at 11:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `2b6e187aaed39881b05a56ac104acb0f782d12b5` — "feat(editor): place search — modern world places and custom places in one box" — on **July  2, 2026 at 11:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.