### PR TITLE
Attribution: Arkniem made commit dca8b63 on July  2, 2026 at 11:11 -0400

### DIFF
--- a/attributions/dca8b63.md
+++ b/attributions/dca8b63.md
@@ -1,0 +1,5 @@
+Arkniem made commit `dca8b6386c7df0975ac0ac9dfd953c164cfc307e`
+("feat(presets): era-accurate cities for all five official scenarios")
+on July  2, 2026 at 11:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `dca8b6386c7df0975ac0ac9dfd953c164cfc307e` — "feat(presets): era-accurate cities for all five official scenarios" — on **July  2, 2026 at 11:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.