### PR TITLE
Attribution: Arkniem made commit 4fcbe4e on July  2, 2026 at 11:25 -0400

### DIFF
--- a/attributions/4fcbe4e.md
+++ b/attributions/4fcbe4e.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4fcbe4ed42e49a62e09dfadea373ffc51347cf32`
+("fix(editor): every owner gets its own color")
+on July  2, 2026 at 11:25 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4fcbe4ed42e49a62e09dfadea373ffc51347cf32` — "fix(editor): every owner gets its own color" — on **July  2, 2026 at 11:25 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.