### PR TITLE
Attribution: Arkniem made commit c11b60f on July  2, 2026 at 11:25 -0400

### DIFF
--- a/attributions/c11b60f.md
+++ b/attributions/c11b60f.md
@@ -1,0 +1,5 @@
+Arkniem made commit `c11b60fec8802cd471072d5238af8e6a558d8c02`
+("fix(editor): open the scenario's own map, not the default world")
+on July  2, 2026 at 11:25 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `c11b60fec8802cd471072d5238af8e6a558d8c02` — "fix(editor): open the scenario's own map, not the default world" — on **July  2, 2026 at 11:25 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.