### PR TITLE
Attribution: Arkniem made commit fb90a71 on July  2, 2026 at 11:31 -0400

### DIFF
--- a/attributions/fb90a71.md
+++ b/attributions/fb90a71.md
@@ -1,0 +1,5 @@
+Arkniem made commit `fb90a71254dd19cef7c424364cdb9b5dd69b7abe`
+("fix(runtime): never cache a failed asset load for the whole session")
+on July  2, 2026 at 11:31 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `fb90a71254dd19cef7c424364cdb9b5dd69b7abe` — "fix(runtime): never cache a failed asset load for the whole session" — on **July  2, 2026 at 11:31 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.