### PR TITLE
Attribution: Arkniem made commit 4ce6bc1 on July  2, 2026 at 11:31 -0400

### DIFF
--- a/attributions/4ce6bc1.md
+++ b/attributions/4ce6bc1.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4ce6bc15471c1ee960aa436cc4f14a24cfbaace4`
+("fix(ai): intelligence briefings get a real target dossier")
+on July  2, 2026 at 11:31 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4ce6bc15471c1ee960aa436cc4f14a24cfbaace4` — "fix(ai): intelligence briefings get a real target dossier" — on **July  2, 2026 at 11:31 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.