### PR TITLE
Attribution: Arkniem made commit f1b3542 on July  2, 2026 at 11:43 -0400

### DIFF
--- a/attributions/f1b3542.md
+++ b/attributions/f1b3542.md
@@ -1,0 +1,5 @@
+Arkniem made commit `f1b3542201c26e52f14e58e04d8b640a1ded7052`
+("fix(preset): New World 1650 — no more gray Eurasia")
+on July  2, 2026 at 11:43 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `f1b3542201c26e52f14e58e04d8b640a1ded7052` — "fix(preset): New World 1650 — no more gray Eurasia" — on **July  2, 2026 at 11:43 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.