### PR TITLE
Attribution: Arkniem made commit 7f320cc on July  2, 2026 at 11:48 -0400

### DIFF
--- a/attributions/7f320cc.md
+++ b/attributions/7f320cc.md
@@ -1,0 +1,5 @@
+Arkniem made commit `7f320cc65f5dfac3475c5131e1fe9a009d8225f0`
+("fix(map): Russia is green, not placeholder gray")
+on July  2, 2026 at 11:48 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `7f320cc65f5dfac3475c5131e1fe9a009d8225f0` — "fix(map): Russia is green, not placeholder gray" — on **July  2, 2026 at 11:48 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.