### PR TITLE
Attribution: Arkniem made commit 7d44f37 on July  2, 2026 at 11:57 -0400

### DIFF
--- a/attributions/7d44f37.md
+++ b/attributions/7d44f37.md
@@ -1,0 +1,5 @@
+Arkniem made commit `7d44f372ff531df4959dafb3685244ef493bbd8a`
+("feat(hub): real install counts — bundles are release assets, downloads are counted")
+on July  2, 2026 at 11:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `7d44f372ff531df4959dafb3685244ef493bbd8a` — "feat(hub): real install counts — bundles are release assets, downloads are counted" — on **July  2, 2026 at 11:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.