### PR TITLE
Attribution: Arkniem made commit 83b2dd2 on July  2, 2026 at 12:11 -0400

### DIFF
--- a/attributions/83b2dd2.md
+++ b/attributions/83b2dd2.md
@@ -1,0 +1,5 @@
+Arkniem made commit `83b2dd2397f5879f523ef9fd0f51f484ce56f228`
+("feat(hub): Official badge covers all hub collaborators; document collaborator-only pinning")
+on July  2, 2026 at 12:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `83b2dd2397f5879f523ef9fd0f51f484ce56f228` — "feat(hub): Official badge covers all hub collaborators; document collaborator-only pinning" — on **July  2, 2026 at 12:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.