### PR TITLE
Attribution: Arkniem made commit ca1c77d on July  2, 2026 at 12:57 -0400

### DIFF
--- a/attributions/ca1c77d.md
+++ b/attributions/ca1c77d.md
@@ -1,0 +1,5 @@
+Arkniem made commit `ca1c77dbdd40f1151a230403fee131d0e552274f`
+("fix(ui): usable panel heights on small laptops; editor search moves into the bottom bar")
+on July  2, 2026 at 12:57 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `ca1c77dbdd40f1151a230403fee131d0e552274f` — "fix(ui): usable panel heights on small laptops; editor search moves into the bottom bar" — on **July  2, 2026 at 12:57 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.