### PR TITLE
Attribution: Arkniem made commit 3595a00 on July  2, 2026 at 13:14 -0400

### DIFF
--- a/attributions/3595a00.md
+++ b/attributions/3595a00.md
@@ -1,0 +1,5 @@
+Arkniem made commit `3595a004ed59724f1992edc70f9c219b48e5083d`
+("feat(map): every scenario renders the custom map style; AI knows drawn-region names")
+on July  2, 2026 at 13:14 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `3595a004ed59724f1992edc70f9c219b48e5083d` — "feat(map): every scenario renders the custom map style; AI knows drawn-region names" — on **July  2, 2026 at 13:14 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.