### PR TITLE
Attribution: Arkniem made commit c19f63b on July  2, 2026 at 13:14 -0400

### DIFF
--- a/attributions/c19f63b.md
+++ b/attributions/c19f63b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `c19f63baa60c000b1248a5dcc7ae8e947d72c277`
+("feat(android): thin APK — a WebView app that connects to your server")
+on July  2, 2026 at 13:14 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `c19f63baa60c000b1248a5dcc7ae8e947d72c277` — "feat(android): thin APK — a WebView app that connects to your server" — on **July  2, 2026 at 13:14 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.