### PR TITLE
Attribution: Arkniem made commit 9053e1b on July  2, 2026 at 13:25 -0400

### DIFF
--- a/attributions/9053e1b.md
+++ b/attributions/9053e1b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `9053e1b519543aa2e58fcab8596a3485d5c18088`
+("feat(ui): exit button — shut the server down from the top bar")
+on July  2, 2026 at 13:25 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `9053e1b519543aa2e58fcab8596a3485d5c18088` — "feat(ui): exit button — shut the server down from the top bar" — on **July  2, 2026 at 13:25 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.