### PR TITLE
Attribution: Arkniem made commit a9e70d2 on July  2, 2026 at 13:44 -0400

### DIFF
--- a/attributions/a9e70d2.md
+++ b/attributions/a9e70d2.md
@@ -1,0 +1,5 @@
+Arkniem made commit `a9e70d2b97845f6d1602816f447e82697f567d41`
+("feat(android): self-updating app + the game logo as its icon")
+on July  2, 2026 at 13:44 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `a9e70d2b97845f6d1602816f447e82697f567d41` — "feat(android): self-updating app + the game logo as its icon" — on **July  2, 2026 at 13:44 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.