### PR TITLE
Attribution: Arkniem made commit 033de42 on July  2, 2026 at 13:59 -0400

### DIFF
--- a/attributions/033de42.md
+++ b/attributions/033de42.md
@@ -1,0 +1,5 @@
+Arkniem made commit `033de4244dff98967fc3a18a7b9c0b2549a5be79`
+("fix(library): no more undeletable built-in game")
+on July  2, 2026 at 13:59 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `033de4244dff98967fc3a18a7b9c0b2549a5be79` — "fix(library): no more undeletable built-in game" — on **July  2, 2026 at 13:59 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.