### PR TITLE
Attribution: Arkniem made commit 5341a04 on July  2, 2026 at 14:25 -0400

### DIFF
--- a/attributions/5341a04.md
+++ b/attributions/5341a04.md
@@ -1,0 +1,5 @@
+Arkniem made commit `5341a04d5f0cc675170a29ce5e0c4ea006009084`
+("fix(android): app couldn't connect — CORS headers on the API, http scheme in the app")
+on July  2, 2026 at 14:25 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `5341a04d5f0cc675170a29ce5e0c4ea006009084` — "fix(android): app couldn't connect — CORS headers on the API, http scheme in the app" — on **July  2, 2026 at 14:25 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.