### PR TITLE
Attribution: Arkniem made commit 556638b on July  2, 2026 at 15:01 -0400

### DIFF
--- a/attributions/556638b.md
+++ b/attributions/556638b.md
@@ -1,0 +1,5 @@
+Arkniem made commit `556638bcb89efab63566b5088de3f66509387c67`
+("fix(ai): relay OpenAI-style calls through the game server — self-hosted endpoints work")
+on July  2, 2026 at 15:01 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `556638bcb89efab63566b5088de3f66509387c67` — "fix(ai): relay OpenAI-style calls through the game server — self-hosted endpoints work" — on **July  2, 2026 at 15:01 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.