### PR TITLE
Attribution: Arkniem made commit 7eefedc on July  2, 2026 at 15:20 -0400

### DIFF
--- a/attributions/7eefedc.md
+++ b/attributions/7eefedc.md
@@ -1,0 +1,5 @@
+Arkniem made commit `7eefedc8aac16850a4e525f52621519d20e8e08c`
+("fix(android): update screen no longer strands the app; visible build number")
+on July  2, 2026 at 15:20 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `7eefedc8aac16850a4e525f52621519d20e8e08c` — "fix(android): update screen no longer strands the app; visible build number" — on **July  2, 2026 at 15:20 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.