### PR TITLE
Attribution: Arkniem made commit 1ae13f6 on July  2, 2026 at 15:38 -0400

### DIFF
--- a/attributions/1ae13f6.md
+++ b/attributions/1ae13f6.md
@@ -1,0 +1,5 @@
+Arkniem made commit `1ae13f61322614540d8ab03c40b004efdc887a51`
+("fix(android): probe the server with native HTTP — the WebView blocks loopback fetches")
+on July  2, 2026 at 15:38 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `1ae13f61322614540d8ab03c40b004efdc887a51` — "fix(android): probe the server with native HTTP — the WebView blocks loopback fetches" — on **July  2, 2026 at 15:38 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.