### PR TITLE
Attribution: Arkniem made commit ca0e20d on July  2, 2026 at 15:38 -0400

### DIFF
--- a/attributions/ca0e20d.md
+++ b/attributions/ca0e20d.md
@@ -1,0 +1,5 @@
+Arkniem made commit `ca0e20d334369e2b2ee21a6b68e3699a909c6be3`
+("fix(ui): advisor panel gets a close button — the drawer covers its own launcher on phones")
+on July  2, 2026 at 15:38 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `ca0e20d334369e2b2ee21a6b68e3699a909c6be3` — "fix(ui): advisor panel gets a close button — the drawer covers its own launcher on phones" — on **July  2, 2026 at 15:38 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.