### PR TITLE
Attribution: Arkniem made commit c3319ee on July  2, 2026 at 15:42 -0400

### DIFF
--- a/attributions/c3319ee.md
+++ b/attributions/c3319ee.md
@@ -1,0 +1,5 @@
+Arkniem made commit `c3319eedac82e3f3f3b2a95e7ac945f8715ffe21`
+("fix(server): say why startup failed when the port is taken")
+on July  2, 2026 at 15:42 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `c3319eedac82e3f3f3b2a95e7ac945f8715ffe21` — "fix(server): say why startup failed when the port is taken" — on **July  2, 2026 at 15:42 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.