### PR TITLE
Attribution: Arkniem made commit 8d77959 on July  2, 2026 at 15:48 -0400

### DIFF
--- a/attributions/8d77959.md
+++ b/attributions/8d77959.md
@@ -1,0 +1,5 @@
+Arkniem made commit `8d77959fbb29a56d067e7e2282a8e738d4be8cfa`
+("fix(ui): advisor drawer actually closes — its closed position was invalid CSS")
+on July  2, 2026 at 15:48 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `8d77959fbb29a56d067e7e2282a8e738d4be8cfa` — "fix(ui): advisor drawer actually closes — its closed position was invalid CSS" — on **July  2, 2026 at 15:48 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.