### PR TITLE
Attribution: Arkniem made commit 2ed9c4a on July  2, 2026 at 15:49 -0400

### DIFF
--- a/attributions/2ed9c4a.md
+++ b/attributions/2ed9c4a.md
@@ -1,0 +1,5 @@
+Arkniem made commit `2ed9c4aee5bb9b2b6b6721a89c2e0159640ae371`
+("fix(ai): stop silently discarding slow AI turns — real timeouts, loud fallbacks")
+on July  2, 2026 at 15:49 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `2ed9c4aee5bb9b2b6b6721a89c2e0159640ae371` — "fix(ai): stop silently discarding slow AI turns — real timeouts, loud fallbacks" — on **July  2, 2026 at 15:49 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.