### PR TITLE
Attribution: Arkniem made commit 0a28155 on July  2, 2026 at 15:54 -0400

### DIFF
--- a/attributions/0a28155.md
+++ b/attributions/0a28155.md
@@ -1,0 +1,5 @@
+Arkniem made commit `0a281552046fa4f50c654c23a3bef4d7763a353b`
+("fix(ai): an empty AI turn no longer counts as success")
+on July  2, 2026 at 15:54 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `0a281552046fa4f50c654c23a3bef4d7763a353b` — "fix(ai): an empty AI turn no longer counts as success" — on **July  2, 2026 at 15:54 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.