### PR TITLE
Attribution: Arkniem made commit 37bf7a9 on July  2, 2026 at 16:01 -0400

### DIFF
--- a/attributions/37bf7a9.md
+++ b/attributions/37bf7a9.md
@@ -1,0 +1,5 @@
+Arkniem made commit `37bf7a9a6d8c28f83e3ee6b8396899bf1bad05fd`
+("fix(android): the app's internal origin collided with the game server")
+on July  2, 2026 at 16:01 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `37bf7a9a6d8c28f83e3ee6b8396899bf1bad05fd` — "fix(android): the app's internal origin collided with the game server" — on **July  2, 2026 at 16:01 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.