### PR TITLE
Attribution: Arkniem made commit 1c13c7f on July  2, 2026 at 16:11 -0400

### DIFF
--- a/attributions/1c13c7f.md
+++ b/attributions/1c13c7f.md
@@ -1,0 +1,5 @@
+Arkniem made commit `1c13c7f946b16aa34921af371b42ef682db8e4b5`
+("fix(ai): empty suggestion answers take the fallback instead of 'no suggestions'")
+on July  2, 2026 at 16:11 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `1c13c7f946b16aa34921af371b42ef682db8e4b5` — "fix(ai): empty suggestion answers take the fallback instead of 'no suggestions'" — on **July  2, 2026 at 16:11 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.