### PR TITLE
Attribution: Arkniem made commit 6dc0147 on July  2, 2026 at 16:17 -0400

### DIFF
--- a/attributions/6dc0147.md
+++ b/attributions/6dc0147.md
@@ -1,0 +1,5 @@
+Arkniem made commit `6dc0147e2ecd355c2a6bca2a21c705892117cae5`
+("fix(library): playing with zero games auto-creates the session instead of failing every save")
+on July  2, 2026 at 16:17 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `6dc0147e2ecd355c2a6bca2a21c705892117cae5` — "fix(library): playing with zero games auto-creates the session instead of failing every save" — on **July  2, 2026 at 16:17 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.