### PR TITLE
Attribution: Arkniem made commit 5a6bccb on July  2, 2026 at 16:43 -0400

### DIFF
--- a/attributions/5a6bccb.md
+++ b/attributions/5a6bccb.md
@@ -1,0 +1,5 @@
+Arkniem made commit `5a6bccb183174450eb0363c969ae810a505e28c2`
+("fix(mobile): country name sits beside the date instead of covering it")
+on July  2, 2026 at 16:43 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `5a6bccb183174450eb0363c969ae810a505e28c2` — "fix(mobile): country name sits beside the date instead of covering it" — on **July  2, 2026 at 16:43 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.