### PR TITLE
Attribution: Arkniem made commit ab839d4 on July  2, 2026 at 17:00 -0400

### DIFF
--- a/attributions/ab839d4.md
+++ b/attributions/ab839d4.md
@@ -1,0 +1,5 @@
+Arkniem made commit `ab839d4787e684e58be3f09b728139d7d3e75047`
+("chore(credits): copyright headers on all files with Nicholas Krol contributions")
+on July  2, 2026 at 17:00 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `ab839d4787e684e58be3f09b728139d7d3e75047` — "chore(credits): copyright headers on all files with Nicholas Krol contributions" — on **July  2, 2026 at 17:00 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.