### PR TITLE
Attribution: Arkniem made commit f66b438 on July  2, 2026 at 17:00 -0400

### DIFF
--- a/attributions/f66b438.md
+++ b/attributions/f66b438.md
@@ -1,0 +1,5 @@
+Arkniem made commit `f66b4386163fc5fe1a16f2102c2609e1713b05a5`
+("fix(mobile): advisor drawer overlays the HUD so buttons can't cover it")
+on July  2, 2026 at 17:00 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `f66b4386163fc5fe1a16f2102c2609e1713b05a5` — "fix(mobile): advisor drawer overlays the HUD so buttons can't cover it" — on **July  2, 2026 at 17:00 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.