### PR TITLE
Attribution: Arkniem made commit fbcab64 on July  2, 2026 at 17:40 -0400

### DIFF
--- a/attributions/fbcab64.md
+++ b/attributions/fbcab64.md
@@ -1,0 +1,5 @@
+Arkniem made commit `fbcab6491790438b7373583413d4a813d1c5a5d3`
+("feat(cheats): cheats menu — Master AI, annexation by click, country/region/feature/event editing")
+on July  2, 2026 at 17:40 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `fbcab6491790438b7373583413d4a813d1c5a5d3` — "feat(cheats): cheats menu — Master AI, annexation by click, country/region/feature/event editing" — on **July  2, 2026 at 17:40 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.