### PR TITLE
Attribution: Arkniem made commit 4353130 on July  2, 2026 at 17:58 -0400

### DIFF
--- a/attributions/4353130.md
+++ b/attributions/4353130.md
@@ -1,0 +1,5 @@
+Arkniem made commit `4353130fa62a959cf23a41a33b5f9388b1d97ba6`
+("feat(ui): country info button opens a full panel — events, aliases, regions, advisor report, diplomacy")
+on July  2, 2026 at 17:58 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `4353130fa62a959cf23a41a33b5f9388b1d97ba6` — "feat(ui): country info button opens a full panel — events, aliases, regions, advisor report, diplomacy" — on **July  2, 2026 at 17:58 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.