### PR TITLE
Attribution: Arkniem made commit 319c2a2 on July  2, 2026 at 17:58 -0400

### DIFF
--- a/attributions/319c2a2.md
+++ b/attributions/319c2a2.md
@@ -1,0 +1,5 @@
+Arkniem made commit `319c2a24310c0ccb285daedff2e3aabc290dcb34`
+("feat: rename Pax Historia to Open Historia")
+on July  2, 2026 at 17:58 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `319c2a24310c0ccb285daedff2e3aabc290dcb34` — "feat: rename Pax Historia to Open Historia" — on **July  2, 2026 at 17:58 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.