### PR TITLE
Attribution: Arkniem made commit 7f54fbe on July  2, 2026 at 17:58 -0400

### DIFF
--- a/attributions/7f54fbe.md
+++ b/attributions/7f54fbe.md
@@ -1,0 +1,5 @@
+Arkniem made commit `7f54fbe358e57505078b94de969bee1415ea4e48`
+("feat(i18n): pre-translate everything once per language instead of live-swapping")
+on July  2, 2026 at 17:58 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `7f54fbe358e57505078b94de969bee1415ea4e48` — "feat(i18n): pre-translate everything once per language instead of live-swapping" — on **July  2, 2026 at 17:58 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.