### PR TITLE
Attribution: Arkniem made commit 439d32d on July  2, 2026 at 18:37 -0400

### DIFF
--- a/attributions/439d32d.md
+++ b/attributions/439d32d.md
@@ -1,0 +1,5 @@
+Arkniem made commit `439d32d60494fb79f88f3e1d1838a982cc618ad4`
+("feat(military): era- and type-aware reach for deployments, moves and attacks")
+on July  2, 2026 at 18:37 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `439d32d60494fb79f88f3e1d1838a982cc618ad4` — "feat(military): era- and type-aware reach for deployments, moves and attacks" — on **July  2, 2026 at 18:37 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.