### PR TITLE
Attribution: Arkniem made commit f6119a8 on July  2, 2026 at 18:37 -0400

### DIFF
--- a/attributions/f6119a8.md
+++ b/attributions/f6119a8.md
@@ -1,0 +1,5 @@
+Arkniem made commit `f6119a845d59344f4a0fad2e55f8361163c869ec`
+("feat(i18n): shipped + server-saved language packs, translated map labels, no-stall startup")
+on July  2, 2026 at 18:37 -0400.
+
+Authored as Nicholas Krol; this file records the attribution under the @Arkniem account.


### PR DESCRIPTION
Arkniem made commit `f6119a845d59344f4a0fad2e55f8361163c869ec` — "feat(i18n): shipped + server-saved language packs, translated map labels, no-stall startup" — on **July  2, 2026 at 18:37 -0400**.

It was authored as Nicholas Krol `<lungmap2dcc@gmail.com>`, an email not linked to the GitHub account, so GitHub shows it without an account link. This PR records the attribution under the @Arkniem account itself.