### PR TITLE
Era country borders on custom maps + restore the Cheats wiring lost in the rename

### DIFF
--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -1,3 +1,4 @@
+/*! Open Historia — portions (mobile HUD wiring + advisor/forces launchers) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import { SettingsButton, SettingsMenu } from "./settings";
 import { LibraryTopBar, TOP_BAR_OFFSET } from "./libraryBar";
@@ -30,6 +31,9 @@ const baseStyle = {
 };
 const LazyAdvisorPanel = lazy(() =>
   import("./advisor").then((module) => ({ default: module.AdvisorPanel })),
+);
+const LazyCheatsPanel = lazy(() =>
+  import("./cheats").then((module) => ({ default: module.CheatsPanel })),
 );
 
 const checkWebGL = () => {
@@ -113,6 +117,8 @@ const Main = ({
   setIsTerrainEnabled,
 }) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isCheatsOpen, setIsCheatsOpen] = useState(false);
+  const [shouldLoadCheats, setShouldLoadCheats] = useState(false);
   const [isAdvisorOpen, setIsAdvisorOpen] = useState(false);
   const [isForcesOpen, setIsForcesOpen] = useState(false);
   const [activeBottomPanel, setActiveBottomPanel] = useState(null);
@@ -217,6 +223,11 @@ const Main = ({
           <LazyAdvisorPanel isAdvisorOpen={isAdvisorOpen} onClose={() => setIsAdvisorOpen(false)} />
         )}
       </Suspense>
+      <Suspense fallback={null}>
+        {shouldLoadCheats && (
+          <LazyCheatsPanel open={isCheatsOpen} onClose={() => setIsCheatsOpen(false)} />
+        )}
+      </Suspense>
       <SettingsButton
         topOffset={TOP_BAR_OFFSET}
         onToggle={() => setIsSettingsOpen(!isSettingsOpen)}
@@ -225,6 +236,11 @@ const Main = ({
         <SettingsMenu
           discordUrl="https://discord.gg/C3AVwHacZ4"
           githubUrl="https://github.com/Tommi-K/open-historia"
+          onOpenCheats={() => {
+            setShouldLoadCheats(true);
+            setIsCheatsOpen(true);
+            setIsSettingsOpen(false);
+          }}
           topOffset={TOP_BAR_OFFSET}
           isFullscreenEnabled={isFullscreenEnabled}
           isGlobeEnabled={isGlobeEnabled}

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -213,6 +213,67 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
   return { type: "FeatureCollection", features };
 };
 
+// TRUE era borders for custom maps: the edges shared by regions with
+// DIFFERENT owners, computed from the seed geometry (neighboring regions
+// share their border vertices, so equal-edge hashing finds the boundary).
+// Without this, hiding the stock country borders left nothing visible at
+// world zoom — countries were only separated by fill colour.
+const buildOwnerBorderCollection = (regionsFC, ownerById) => {
+  const edges = new Map();
+  const keyOf = (a, b) => {
+    const ka = `${a[0].toFixed(4)},${a[1].toFixed(4)}`;
+    const kb = `${b[0].toFixed(4)},${b[1].toFixed(4)}`;
+    return ka < kb ? `${ka}|${kb}` : `${kb}|${ka}`;
+  };
+
+  for (const feature of regionsFC?.features ?? []) {
+    const props = feature.properties || {};
+    const id = props.id != null ? String(props.id) : "";
+    // "~" marks unclaimed land as its own owner so its frontier gets a border.
+    const owner = (ownerById.get(id) ?? props.owner ?? "") || "~unclaimed";
+    const geometry = feature.geometry;
+    const polygons = geometry?.type === "Polygon"
+      ? [geometry.coordinates]
+      : geometry?.type === "MultiPolygon"
+        ? geometry.coordinates
+        : [];
+    for (const polygon of polygons) {
+      for (const ring of polygon) {
+        for (let index = 1; index < ring.length; index += 1) {
+          const a = ring[index - 1];
+          const b = ring[index];
+          const key = keyOf(a, b);
+          let entry = edges.get(key);
+          if (!entry) {
+            entry = { a, b, owners: new Set() };
+            edges.set(key, entry);
+          }
+          entry.owners.add(owner);
+        }
+      }
+    }
+  }
+
+  const lines = [];
+  for (const entry of edges.values()) {
+    if (entry.owners.size > 1) {
+      lines.push([entry.a, entry.b]);
+    }
+  }
+
+  if (!lines.length) return EMPTY_FEATURE_COLLECTION;
+  // Chunked MultiLineStrings keep the geojson source responsive.
+  const features = [];
+  for (let start = 0; start < lines.length; start += 5000) {
+    features.push({
+      type: "Feature",
+      geometry: { type: "MultiLineString", coordinates: lines.slice(start, start + 5000) },
+      properties: {},
+    });
+  }
+  return { type: "FeatureCollection", features };
+};
+
 // Procedural fallback keyed on the custom region's own "owner" property (the
 // custom-geometry twin of buildFallbackColorExpression, which reads GID_0).
 const buildOwnerFallbackColorExpression = () => ([
@@ -500,6 +561,23 @@ const WorldMap = () => {
     ownerLookupRef.current = ownerByRegionId;
   }, [ownerByRegionId]);
 
+  // Stable fingerprint of the ownership map: the world poll rebuilds
+  // ownerByRegionId every 5s, but the border geometry only needs recomputing
+  // when an owner actually changes.
+  const ownershipKey = useMemo(() => {
+    if (!customActive) return "";
+    let key = "";
+    for (const [regionId, owner] of ownerByRegionId) key += `${regionId}:${owner};`;
+    return key;
+  }, [customActive, ownerByRegionId]);
+
+  const ownerBorderData = useMemo(() => {
+    if (!customActive) return EMPTY_FEATURE_COLLECTION;
+    return buildOwnerBorderCollection(customRegionData, ownerLookupRef.current);
+    // ownershipKey stands in for ownerByRegionId's contents.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customActive, customRegionData, ownershipKey]);
+
   // GADM regions on custom maps paint the STOCK vector tiles (sharp geometry at
   // every zoom — the coarse seed polygons left sliver gaps up close). Only
   // author-drawn shapes still render from the GeoJSON, on top.
@@ -645,6 +723,22 @@ const WorldMap = () => {
             "line-opacity": customActive
               ? ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.35, 8, 0.6]
               : 0,
+          }}
+        />
+      </Source>
+
+      {/* Era country borders (owner boundaries). Strong at world/mid zoom where
+          the faint per-region outlines are invisible; hands off to the crisp
+          tile-rendered region borders up close (the seed geometry these lines
+          come from is too coarse at high zoom). */}
+      <Source id="owner-borders-source" type="geojson" data={ownerBorderData}>
+        <Layer
+          id="owner-borders"
+          type="line"
+          paint={{
+            "line-color": "#000",
+            "line-width": ["interpolate", ["linear"], ["zoom"], 2, 0.9, 6, 1.6],
+            "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0.85, 7, 0.85, 8.5, 0],
           }}
         />
       </Source>


### PR DESCRIPTION
## Era borders (the vanishing-borders fix)
Starting a game briefly showed the stock map — crisp modern country borders — then the custom world loaded, the stock border layer switched off (by design: modern borders are wrong for e.g. 1650), and all that remained were per-region hairlines that fade to zero below zoom 4. At world view, countries were separated by fill color alone.

Custom maps now get **true era borders**: the edges shared by regions with *different owners*, found by hashing the map geometry's edges (neighboring regions share their border vertices). They render as a strong black line at world/mid zoom and fade out up close, where the crisp tile-rendered region outlines take over. They recompute only when ownership actually changes, so conquests and annexations move the borders. Measured on the 1650 preset: 3,661 regions → 7,008 boundary segments in ~0.7 s. Stock maps are untouched (verified in-browser).

## Cheats wiring restored
The "renamed to Open Historia" commit (c3ca5f3) used a stale copy of `src/Game/GameUI/main.jsx`, silently dropping the Cheats button and its panel wiring (the panel file itself survived, unreachable) plus the credit header. Restored, keeping that commit's updated GitHub link.