### PR TITLE
Rename repairs, deletable built-in scenario, no-game gate, event cameras + scaled event counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!-- Open Historia — portions (mobile viewport & scaling) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). -->
 <!doctype html>
 <html lang="en">
   <head>
@@ -5,15 +6,15 @@
     <link rel="icon" type="image/jpeg" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#0b1020" />
-    <title>Pax Historia</title>
+    <title>Open Historia</title>
 
     <!-- Primary Meta -->
     <meta name="description" content="An open source alternative to Pax Historia." />
 
     <!-- Open graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Pax Historia" />
-    <meta property="og:title" content="Pax Historia" />
+    <meta property="og:site_name" content="Open Historia" />
+    <meta property="og:title" content="Open Historia" />
     <meta property="og:description" content="An open source alternative to Pax Historia." />
     <meta property="og:image" content="https://raw.githubusercontent.com/Tommi-K/open-historia/main/public/loading_screen.jpg" />
     <meta property="og:image:type" content="image/jpeg" />
@@ -22,7 +23,7 @@
 
     <!-- Twitter card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Pax Historia" />
+    <meta name="twitter:title" content="Open Historia" />
     <meta name="twitter:description" content="An open source alternative to Pax Historia." />
     <meta name="twitter:image" content="https://raw.githubusercontent.com/Tommi-K/open-historia/main/public/loading_screen.jpg" />
   </head>

--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -712,6 +712,13 @@ const ensureDefaultScenario = () => {
   ensureDirectory(SCENARIOS_DIR);
   const scenarioDir = getScenarioDirectory(DEFAULT_SCENARIO_ID);
 
+  // The built-in scenario is deletable (like the built-in game before it) — a
+  // deliberately deleted one must stay deleted across restarts. It is only
+  // (re)seeded on a true first run, i.e. before any scenario manifest exists.
+  if (fs.existsSync(SCENARIO_MANIFEST_PATH) && !fs.existsSync(scenarioDir)) {
+    return;
+  }
+
   ensureDirectory(scenarioDir);
   ensureDirectory(path.join(scenarioDir, "storage"));
 
@@ -850,7 +857,9 @@ const getScenarioCatalog = () => {
       ...meta,
       assetStatus,
       cacheToken,
-      canDelete: scenarioId !== DEFAULT_SCENARIO_ID,
+      // Every scenario is deletable, the built-in one included (usage by
+      // existing games still blocks deletion in deleteScenario).
+      canDelete: true,
       coverImageUrl: assetStatus.cover
       ? buildScenarioAssetUrl(scenarioId, COVER_IMAGE_ASSET_KEY, cacheToken)
       : null,
@@ -859,9 +868,11 @@ const getScenarioCatalog = () => {
   })
   .filter(Boolean);
 
+  // Fall back to the first scenario that actually exists — the built-in one
+  // may have been deleted.
   const selectedScenarioId = scenarios.some((scenario) => scenario.id === manifest.selectedScenarioId)
   ? manifest.selectedScenarioId
-  : DEFAULT_SCENARIO_ID;
+  : (scenarios[0]?.id ?? "");
 
   if (selectedScenarioId !== manifest.selectedScenarioId) {
     saveScenarioManifest({
@@ -1405,10 +1416,6 @@ const updateGame = (
 const deleteScenario = (scenarioId) => {
   ensureScenarioStore();
 
-  if (scenarioId === DEFAULT_SCENARIO_ID) {
-    throw new Error("The default scenario cannot be deleted.");
-  }
-
   const usageCount = getScenarioUsageCountMap().get(scenarioId) ?? 0;
   if (usageCount > 0) {
     throw new Error("This scenario is still used by one or more games.");
@@ -1428,11 +1435,13 @@ const deleteScenario = (scenarioId) => {
   const nextOrder = resolveOrderedIds(manifest.order, SCENARIOS_DIR, DEFAULT_SCENARIO_ID).filter(
     (entry) => entry !== scenarioId,
   );
+  // Select the first remaining scenario (the deleted one may have been the
+  // built-in default — nothing resurrects it).
   const nextSelectedScenarioId =
-  manifest.selectedScenarioId === scenarioId ? DEFAULT_SCENARIO_ID : manifest.selectedScenarioId;
+  manifest.selectedScenarioId === scenarioId ? (nextOrder[0] ?? "") : manifest.selectedScenarioId;
 
   saveScenarioManifest({
-    order: nextOrder.length > 0 ? nextOrder : [DEFAULT_SCENARIO_ID],
+    order: nextOrder,
     selectedScenarioId: nextSelectedScenarioId,
   });
 

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -47,6 +47,12 @@ const MapEditor = lazy(() => import("../../Editor/MapEditor.jsx"));
 const CommunityPanel = lazy(() => import("./communityHub.jsx"));
 
 const BAR_HEIGHT = 64;
+
+// Set by the mounted LibraryTopBar; lets the no-game gate open a tab.
+let _openLibraryTab = null;
+export const openLibraryTab = (tab) => {
+  _openLibraryTab?.(tab);
+};
 const TOP_BAR_OFFSET = "4.75rem";
 
 const surfaceStyle = {
@@ -973,6 +979,11 @@ const LibraryTopBar = () => {
   } = useLibraryState();
   const [activeTab, setActiveTab] = useState("games");
   const [isPanelOpen, setIsPanelOpen] = useState(false);
+  // Bridge for outside callers (the no-game gate): open a library tab.
+  _openLibraryTab = (tab) => {
+    setActiveTab(tab);
+    setIsPanelOpen(true);
+  };
   const [editorKind, setEditorKind] = useState(null);
   const [editorDetails, setEditorDetails] = useState(null);
   const [editorState, setEditorState] = useState(null);

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -1,7 +1,8 @@
 /*! Open Historia — portions (mobile HUD wiring + advisor/forces launchers) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import { SettingsButton, SettingsMenu } from "./settings";
-import { LibraryTopBar, TOP_BAR_OFFSET } from "./libraryBar";
+import { LibraryTopBar, TOP_BAR_OFFSET, openLibraryTab } from "./libraryBar";
+import { useLibraryState } from "../../runtime/library.js";
 import { DateWidget } from "./time";
 import { Other } from "./other";
 import { Toolbar } from "./chat";
@@ -99,6 +100,70 @@ const WebGLWarningPopup = () => (
   </div>
 );
 
+// Fullscreen gate shown when the library has NO games: the map and HUD stay
+// hidden behind it, and the player is walked into starting a game from a
+// scenario (or grabbing new scenarios from the Community tab) instead of
+// staring at a spectator world they aren't playing in. The top bar and its
+// panels render above the gate, so the normal New Game flow works on top.
+const NoGameGate = () => {
+  useEffect(() => {
+    // Land the player straight in the scenario list.
+    openLibraryTab("scenarios");
+  }, []);
+
+  const gateButtonStyle = {
+    alignItems: "center",
+    background: "rgba(124,58,237,0.3)",
+    border: "1px solid rgba(139,92,246,0.55)",
+    borderRadius: "12px",
+    color: "white",
+    cursor: "pointer",
+    display: "flex",
+    fontSize: "0.95rem",
+    fontWeight: 700,
+    gap: "0.5rem",
+    justifyContent: "center",
+    padding: "0.85rem 1.4rem",
+  };
+
+  return (
+    <div
+      style={{
+        alignItems: "center",
+        background: "#0b1020",
+        color: "white",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "sans-serif",
+        inset: 0,
+        justifyContent: "center",
+        position: "fixed",
+        textAlign: "center",
+        zIndex: 10010,
+      }}
+    >
+      <img alt="" src="/logo.png" style={{ height: "5rem", marginBottom: "1.2rem", opacity: 0.9, width: "5rem" }} />
+      <div style={{ fontSize: "1.5rem", fontWeight: 800, letterSpacing: "-0.02em" }}>No game yet</div>
+      <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.95rem", lineHeight: 1.6, margin: "0.6rem 0 1.6rem", maxWidth: "26rem", padding: "0 1rem" }}>
+        Start a new game from one of your scenarios, or grab new scenarios
+        from the community first.
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.7rem", justifyContent: "center", padding: "0 1rem" }}>
+        <button type="button" style={gateButtonStyle} onClick={() => openLibraryTab("scenarios")}>
+          Start from a scenario
+        </button>
+        <button
+          type="button"
+          style={{ ...gateButtonStyle, background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.16)" }}
+          onClick={() => openLibraryTab("community")}
+        >
+          Browse community scenarios
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const AdvisorButton = ({ isAdvisorOpen, rightShift, onToggle }) => (
   <button onClick={onToggle} style={{
     ...baseStyle,
@@ -128,6 +193,9 @@ const Main = ({
 
   const [apiProvider, setApiProvider] = useState(() => getStoredProvider());
   const [providerSettings, setProviderSettings] = useState(() => loadProviderSettingsFormState());
+  const { games, loaded } = useLibraryState();
+  // No games -> the map is hidden behind a start gate (see NoGameGate).
+  const showNoGameGate = loaded && (games?.length ?? 0) === 0;
 
   useEffect(() => {
     if (!checkWebGL()) setShowWebGLWarning(true);
@@ -189,6 +257,7 @@ const Main = ({
   return (
     <>
       {showWebGLWarning && <WebGLWarningPopup />}
+      {showNoGameGate && <NoGameGate />}
       <LibraryTopBar />
       <DateWidget
         activePanel={activeBottomPanel}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -1,3 +1,4 @@
+/*! Open Historia — portions (mobile HUD wiring + advisor/forces launchers) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import { SettingsButton, SettingsMenu } from "./settings";
 import { LibraryTopBar, TOP_BAR_OFFSET } from "./libraryBar";
@@ -30,6 +31,9 @@ const baseStyle = {
 };
 const LazyAdvisorPanel = lazy(() =>
   import("./advisor").then((module) => ({ default: module.AdvisorPanel })),
+);
+const LazyCheatsPanel = lazy(() =>
+  import("./cheats").then((module) => ({ default: module.CheatsPanel })),
 );
 
 const checkWebGL = () => {
@@ -113,6 +117,8 @@ const Main = ({
   setIsTerrainEnabled,
 }) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isCheatsOpen, setIsCheatsOpen] = useState(false);
+  const [shouldLoadCheats, setShouldLoadCheats] = useState(false);
   const [isAdvisorOpen, setIsAdvisorOpen] = useState(false);
   const [isForcesOpen, setIsForcesOpen] = useState(false);
   const [activeBottomPanel, setActiveBottomPanel] = useState(null);
@@ -217,6 +223,11 @@ const Main = ({
           <LazyAdvisorPanel isAdvisorOpen={isAdvisorOpen} onClose={() => setIsAdvisorOpen(false)} />
         )}
       </Suspense>
+      <Suspense fallback={null}>
+        {shouldLoadCheats && (
+          <LazyCheatsPanel open={isCheatsOpen} onClose={() => setIsCheatsOpen(false)} />
+        )}
+      </Suspense>
       <SettingsButton
         topOffset={TOP_BAR_OFFSET}
         onToggle={() => setIsSettingsOpen(!isSettingsOpen)}
@@ -225,6 +236,11 @@ const Main = ({
         <SettingsMenu
           discordUrl="https://discord.gg/C3AVwHacZ4"
           githubUrl="https://github.com/Tommi-K/open-historia"
+          onOpenCheats={() => {
+            setShouldLoadCheats(true);
+            setIsCheatsOpen(true);
+            setIsSettingsOpen(false);
+          }}
           topOffset={TOP_BAR_OFFSET}
           isFullscreenEnabled={isFullscreenEnabled}
           isGlobeEnabled={isGlobeEnabled}

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -20,7 +20,6 @@ import {
 } from "../../runtime/assets.js";
 import { loadCountryLabelCollections } from "../../runtime/countryLabels.js";
 import { translateLabel } from "../../runtime/translator.js";
-import polygonClipping from "polygon-clipping";
 
 ensurePmtilesProtocol();
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
@@ -207,60 +206,6 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
           areaScale: Math.sqrt(cluster.area) * 17500,
           rotation: 0,
         },
-      });
-    }
-  }
-
-  return { type: "FeatureCollection", features };
-};
-
-// TRUE era borders for custom maps: every owner's regions are geometrically
-// UNIONED into one shape whose outline is the border. Edge matching was
-// tried first and left gaps along ~60% of frontiers — the simplified seed
-// geometry doesn't give neighbouring regions identical vertices. A union
-// doesn't care: both owners' outlines coincide along their shared frontier,
-// so the border line is always continuous (and coastlines get outlined like
-// the stock map). Without this, hiding the stock country borders left
-// nothing visible at world zoom.
-const computeOwnerBorderCollection = async (regionsFC, ownerById, isCancelled) => {
-  const byOwner = new Map();
-  for (const feature of regionsFC?.features ?? []) {
-    const props = feature.properties || {};
-    const id = props.id != null ? String(props.id) : "";
-    // Unclaimed land is its own "owner" so its frontier is drawn too.
-    const owner = (ownerById.get(id) ?? props.owner ?? "") || "~unclaimed";
-    const geometry = feature.geometry;
-    const polygons = geometry?.type === "Polygon"
-      ? [geometry.coordinates]
-      : geometry?.type === "MultiPolygon"
-        ? geometry.coordinates
-        : [];
-    if (!polygons.length) continue;
-    if (!byOwner.has(owner)) byOwner.set(owner, []);
-    byOwner.get(owner).push(...polygons);
-  }
-
-  const features = [];
-  for (const [owner, polygons] of byOwner) {
-    // Yield between owners so big maps don't freeze the UI while merging.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    if (isCancelled()) return null;
-    try {
-      const merged = polygonClipping.union(...polygons);
-      if (merged?.length) {
-        features.push({
-          type: "Feature",
-          geometry: { type: "MultiPolygon", coordinates: merged },
-          properties: { owner },
-        });
-      }
-    } catch {
-      // Degenerate geometry: draw this owner's raw shapes instead — internal
-      // seams for one owner beat a missing border.
-      features.push({
-        type: "Feature",
-        geometry: { type: "MultiPolygon", coordinates: polygons },
-        properties: { owner },
       });
     }
   }
@@ -555,37 +500,6 @@ const WorldMap = () => {
     ownerLookupRef.current = ownerByRegionId;
   }, [ownerByRegionId]);
 
-  // Stable fingerprint of the ownership map: the world poll rebuilds
-  // ownerByRegionId every 5s, but the border geometry only needs recomputing
-  // when an owner actually changes.
-  const ownershipKey = useMemo(() => {
-    if (!customActive) return "";
-    let key = "";
-    for (const [regionId, owner] of ownerByRegionId) key += `${regionId}:${owner};`;
-    return key;
-  }, [customActive, ownerByRegionId]);
-
-  // Owner unions are asynchronous (they yield between owners) — borders
-  // appear a moment after the fills and refresh whenever ownership changes.
-  const [ownerBorderData, setOwnerBorderData] = useState(EMPTY_FEATURE_COLLECTION);
-  useEffect(() => {
-    if (!customActive) {
-      setOwnerBorderData(EMPTY_FEATURE_COLLECTION);
-      return undefined;
-    }
-    let cancelled = false;
-    computeOwnerBorderCollection(customRegionData, ownerLookupRef.current, () => cancelled)
-      .then((collection) => {
-        if (!cancelled && collection) setOwnerBorderData(collection);
-      })
-      .catch((error) => console.error("Failed to compute era borders:", error));
-    return () => {
-      cancelled = true;
-    };
-    // ownershipKey stands in for ownerByRegionId's contents.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [customActive, customRegionData, ownershipKey]);
-
   // GADM regions on custom maps paint the STOCK vector tiles (sharp geometry at
   // every zoom — the coarse seed polygons left sliver gaps up close). Only
   // author-drawn shapes still render from the GeoJSON, on top.
@@ -731,22 +645,6 @@ const WorldMap = () => {
             "line-opacity": customActive
               ? ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.35, 8, 0.6]
               : 0,
-          }}
-        />
-      </Source>
-
-      {/* Era country borders (owner boundaries). Strong at world/mid zoom where
-          the faint per-region outlines are invisible; hands off to the crisp
-          tile-rendered region borders up close (the seed geometry these lines
-          come from is too coarse at high zoom). */}
-      <Source id="owner-borders-source" type="geojson" data={ownerBorderData}>
-        <Layer
-          id="owner-borders"
-          type="line"
-          paint={{
-            "line-color": "#000",
-            "line-width": ["interpolate", ["linear"], ["zoom"], 2, 0.9, 6, 1.6],
-            "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0.85, 7, 0.85, 8.5, 0],
           }}
         />
       </Source>

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -213,6 +213,67 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
   return { type: "FeatureCollection", features };
 };
 
+// TRUE era borders for custom maps: the edges shared by regions with
+// DIFFERENT owners, computed from the seed geometry (neighboring regions
+// share their border vertices, so equal-edge hashing finds the boundary).
+// Without this, hiding the stock country borders left nothing visible at
+// world zoom — countries were only separated by fill colour.
+const buildOwnerBorderCollection = (regionsFC, ownerById) => {
+  const edges = new Map();
+  const keyOf = (a, b) => {
+    const ka = `${a[0].toFixed(4)},${a[1].toFixed(4)}`;
+    const kb = `${b[0].toFixed(4)},${b[1].toFixed(4)}`;
+    return ka < kb ? `${ka}|${kb}` : `${kb}|${ka}`;
+  };
+
+  for (const feature of regionsFC?.features ?? []) {
+    const props = feature.properties || {};
+    const id = props.id != null ? String(props.id) : "";
+    // "~" marks unclaimed land as its own owner so its frontier gets a border.
+    const owner = (ownerById.get(id) ?? props.owner ?? "") || "~unclaimed";
+    const geometry = feature.geometry;
+    const polygons = geometry?.type === "Polygon"
+      ? [geometry.coordinates]
+      : geometry?.type === "MultiPolygon"
+        ? geometry.coordinates
+        : [];
+    for (const polygon of polygons) {
+      for (const ring of polygon) {
+        for (let index = 1; index < ring.length; index += 1) {
+          const a = ring[index - 1];
+          const b = ring[index];
+          const key = keyOf(a, b);
+          let entry = edges.get(key);
+          if (!entry) {
+            entry = { a, b, owners: new Set() };
+            edges.set(key, entry);
+          }
+          entry.owners.add(owner);
+        }
+      }
+    }
+  }
+
+  const lines = [];
+  for (const entry of edges.values()) {
+    if (entry.owners.size > 1) {
+      lines.push([entry.a, entry.b]);
+    }
+  }
+
+  if (!lines.length) return EMPTY_FEATURE_COLLECTION;
+  // Chunked MultiLineStrings keep the geojson source responsive.
+  const features = [];
+  for (let start = 0; start < lines.length; start += 5000) {
+    features.push({
+      type: "Feature",
+      geometry: { type: "MultiLineString", coordinates: lines.slice(start, start + 5000) },
+      properties: {},
+    });
+  }
+  return { type: "FeatureCollection", features };
+};
+
 // Procedural fallback keyed on the custom region's own "owner" property (the
 // custom-geometry twin of buildFallbackColorExpression, which reads GID_0).
 const buildOwnerFallbackColorExpression = () => ([
@@ -500,6 +561,23 @@ const WorldMap = () => {
     ownerLookupRef.current = ownerByRegionId;
   }, [ownerByRegionId]);
 
+  // Stable fingerprint of the ownership map: the world poll rebuilds
+  // ownerByRegionId every 5s, but the border geometry only needs recomputing
+  // when an owner actually changes.
+  const ownershipKey = useMemo(() => {
+    if (!customActive) return "";
+    let key = "";
+    for (const [regionId, owner] of ownerByRegionId) key += `${regionId}:${owner};`;
+    return key;
+  }, [customActive, ownerByRegionId]);
+
+  const ownerBorderData = useMemo(() => {
+    if (!customActive) return EMPTY_FEATURE_COLLECTION;
+    return buildOwnerBorderCollection(customRegionData, ownerLookupRef.current);
+    // ownershipKey stands in for ownerByRegionId's contents.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customActive, customRegionData, ownershipKey]);
+
   // GADM regions on custom maps paint the STOCK vector tiles (sharp geometry at
   // every zoom — the coarse seed polygons left sliver gaps up close). Only
   // author-drawn shapes still render from the GeoJSON, on top.
@@ -645,6 +723,22 @@ const WorldMap = () => {
             "line-opacity": customActive
               ? ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.35, 8, 0.6]
               : 0,
+          }}
+        />
+      </Source>
+
+      {/* Era country borders (owner boundaries). Strong at world/mid zoom where
+          the faint per-region outlines are invisible; hands off to the crisp
+          tile-rendered region borders up close (the seed geometry these lines
+          come from is too coarse at high zoom). */}
+      <Source id="owner-borders-source" type="geojson" data={ownerBorderData}>
+        <Layer
+          id="owner-borders"
+          type="line"
+          paint={{
+            "line-color": "#000",
+            "line-width": ["interpolate", ["linear"], ["zoom"], 2, 0.9, 6, 1.6],
+            "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0.85, 7, 0.85, 8.5, 0],
           }}
         />
       </Source>

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -20,6 +20,7 @@ import {
 } from "../../runtime/assets.js";
 import { loadCountryLabelCollections } from "../../runtime/countryLabels.js";
 import { translateLabel } from "../../runtime/translator.js";
+import polygonClipping from "polygon-clipping";
 
 ensurePmtilesProtocol();
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
@@ -213,23 +214,20 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
   return { type: "FeatureCollection", features };
 };
 
-// TRUE era borders for custom maps: the edges shared by regions with
-// DIFFERENT owners, computed from the seed geometry (neighboring regions
-// share their border vertices, so equal-edge hashing finds the boundary).
-// Without this, hiding the stock country borders left nothing visible at
-// world zoom — countries were only separated by fill colour.
-const buildOwnerBorderCollection = (regionsFC, ownerById) => {
-  const edges = new Map();
-  const keyOf = (a, b) => {
-    const ka = `${a[0].toFixed(4)},${a[1].toFixed(4)}`;
-    const kb = `${b[0].toFixed(4)},${b[1].toFixed(4)}`;
-    return ka < kb ? `${ka}|${kb}` : `${kb}|${ka}`;
-  };
-
+// TRUE era borders for custom maps: every owner's regions are geometrically
+// UNIONED into one shape whose outline is the border. Edge matching was
+// tried first and left gaps along ~60% of frontiers — the simplified seed
+// geometry doesn't give neighbouring regions identical vertices. A union
+// doesn't care: both owners' outlines coincide along their shared frontier,
+// so the border line is always continuous (and coastlines get outlined like
+// the stock map). Without this, hiding the stock country borders left
+// nothing visible at world zoom.
+const computeOwnerBorderCollection = async (regionsFC, ownerById, isCancelled) => {
+  const byOwner = new Map();
   for (const feature of regionsFC?.features ?? []) {
     const props = feature.properties || {};
     const id = props.id != null ? String(props.id) : "";
-    // "~" marks unclaimed land as its own owner so its frontier gets a border.
+    // Unclaimed land is its own "owner" so its frontier is drawn too.
     const owner = (ownerById.get(id) ?? props.owner ?? "") || "~unclaimed";
     const geometry = feature.geometry;
     const polygons = geometry?.type === "Polygon"
@@ -237,40 +235,36 @@ const buildOwnerBorderCollection = (regionsFC, ownerById) => {
       : geometry?.type === "MultiPolygon"
         ? geometry.coordinates
         : [];
-    for (const polygon of polygons) {
-      for (const ring of polygon) {
-        for (let index = 1; index < ring.length; index += 1) {
-          const a = ring[index - 1];
-          const b = ring[index];
-          const key = keyOf(a, b);
-          let entry = edges.get(key);
-          if (!entry) {
-            entry = { a, b, owners: new Set() };
-            edges.set(key, entry);
-          }
-          entry.owners.add(owner);
-        }
-      }
-    }
+    if (!polygons.length) continue;
+    if (!byOwner.has(owner)) byOwner.set(owner, []);
+    byOwner.get(owner).push(...polygons);
   }
 
-  const lines = [];
-  for (const entry of edges.values()) {
-    if (entry.owners.size > 1) {
-      lines.push([entry.a, entry.b]);
-    }
-  }
-
-  if (!lines.length) return EMPTY_FEATURE_COLLECTION;
-  // Chunked MultiLineStrings keep the geojson source responsive.
   const features = [];
-  for (let start = 0; start < lines.length; start += 5000) {
-    features.push({
-      type: "Feature",
-      geometry: { type: "MultiLineString", coordinates: lines.slice(start, start + 5000) },
-      properties: {},
-    });
+  for (const [owner, polygons] of byOwner) {
+    // Yield between owners so big maps don't freeze the UI while merging.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (isCancelled()) return null;
+    try {
+      const merged = polygonClipping.union(...polygons);
+      if (merged?.length) {
+        features.push({
+          type: "Feature",
+          geometry: { type: "MultiPolygon", coordinates: merged },
+          properties: { owner },
+        });
+      }
+    } catch {
+      // Degenerate geometry: draw this owner's raw shapes instead — internal
+      // seams for one owner beat a missing border.
+      features.push({
+        type: "Feature",
+        geometry: { type: "MultiPolygon", coordinates: polygons },
+        properties: { owner },
+      });
+    }
   }
+
   return { type: "FeatureCollection", features };
 };
 
@@ -571,9 +565,23 @@ const WorldMap = () => {
     return key;
   }, [customActive, ownerByRegionId]);
 
-  const ownerBorderData = useMemo(() => {
-    if (!customActive) return EMPTY_FEATURE_COLLECTION;
-    return buildOwnerBorderCollection(customRegionData, ownerLookupRef.current);
+  // Owner unions are asynchronous (they yield between owners) — borders
+  // appear a moment after the fills and refresh whenever ownership changes.
+  const [ownerBorderData, setOwnerBorderData] = useState(EMPTY_FEATURE_COLLECTION);
+  useEffect(() => {
+    if (!customActive) {
+      setOwnerBorderData(EMPTY_FEATURE_COLLECTION);
+      return undefined;
+    }
+    let cancelled = false;
+    computeOwnerBorderCollection(customRegionData, ownerLookupRef.current, () => cancelled)
+      .then((collection) => {
+        if (!cancelled && collection) setOwnerBorderData(collection);
+      })
+      .catch((error) => console.error("Failed to compute era borders:", error));
+    return () => {
+      cancelled = true;
+    };
     // ownershipKey stands in for ownerByRegionId's contents.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customActive, customRegionData, ownershipKey]);


### PR DESCRIPTION
Everything verified against a live server:

## Restore what the rename lost
The rename landed with stale copies of two files (a full-tree diff against the pre-rename state confirms these were the only content regressions): `main.jsx` lost the **Cheats menu wiring** and `index.html` lost its Open Historia branding. Both restored, keeping the rename commit's correct wording (the game is an alternative to the original Pax Historia), its image URLs, launcher renames and updater repo change.

## Built-in scenario is deletable
Modern Day can be deleted like any scenario (games using it still block deletion). Deliberate deletion survives restarts — the seed only regenerates on a true first run — and selection falls back to the first scenario that exists. Verified including a server restart.

## No-game gate
With zero games the map used to render a spectator world. Now a fullscreen gate hides the map and HUD, auto-opens the Scenarios tab, and offers **Start from a scenario** / **Browse community scenarios**. The top bar, panels and the new-game dialog work above it; the gate disappears the moment a game exists. Verified end-to-end (gate → new game → map).

## Event cameras + event density
- The camera now flies to **every** revealed event: map impacts pin the exact bounds, otherwise the chat participants or the countries mentioned in the event's text do. The per-event "Show on map" button is gone — movement is automatic.
- Time skips request a fixed event count: 1 week → 1–2, 1 month → 5–7, 3 months → 10–13, 6 months → 19–27, 1 year → 29–37, dates spread across the period (auto-jumps scale to the time actually covered). Injected in the jump request itself so existing games' stale prompt packs comply too.

## Era border lines: tried and removed
Two approaches (edge matching, owner unions) both looked wrong on the coarse seed geometry; custom maps keep fill-color separation and the faint per-region tile outlines. Net-zero in this PR.