### PR TITLE
Camera on every event + event counts scaled to skip length

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1312,12 +1312,23 @@ export const advanceActiveCatalyst = async (choiceText) => {
   });
 };
 
+// Event density per skip length (player-tuned): longer skips must return
+// proportionally more events, and short ones must stay brief.
+const eventCountRangeForDays = (days) => {
+  if (days <= 7) return [1, 2];
+  if (days <= 31) return [5, 7];
+  if (days <= 92) return [10, 13];
+  if (days <= 184) return [19, 27];
+  return [29, 37];
+};
+
 export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
   const bundle = await readGameStateBundle({ force: true });
   const baseColors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
   const safeDays = Math.max(1, Math.trunc(Number(days) || 0));
   const targetDate = dayjs(bundle.game.gameDate).add(safeDays, "day").format("YYYY-MM-DD");
   const variables = await buildTemplateVariables(bundle, { targetDate });
+  const [minEvents, maxEvents] = eventCountRangeForDays(safeDays);
   let payload = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {
     fallback: () => fallbackJumpSimulation({ bundle, days: safeDays, mode, targetDate }),
     // The jump IS the game — let slow (local/reasoning) models finish instead
@@ -1325,8 +1336,12 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
     timeoutMs: 180000,
     userMessage:
       mode === "auto"
-        ? "Simulate an auto-jump and stop at the next notable or player-relevant event. Return JSON only."
-        : "Simulate a standard jump forward to the requested target date. Return JSON only.",
+        ? "Simulate an auto-jump and stop at the next notable or player-relevant event. Return JSON only. " +
+          "Scale the events array to the time actually covered before your stop point: roughly 1-2 events per week, " +
+          "5-7 per month, 10-13 per quarter, up to 29-37 for a full year — spread their dates across the covered period."
+        : `Simulate a standard jump forward to the requested target date. Return JSON only. The "events" array must ` +
+          `contain between ${minEvents} and ${maxEvents} events (this jump covers ${safeDays} days), with their dates ` +
+          `spread across the skipped period.`,
     variables,
   });
 

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -423,6 +423,43 @@ const getEventFocusBounds = (event, { countryBounds, regionBounds }) => {
     return resolvedBounds;
 };
 
+// Every event moves the camera. When the impacts don't pin a location, fall
+// back to the chat participants, then to the countries the event's text
+// actually mentions.
+const deriveEventFocusBounds = (event, { countryBounds, regionBounds, polityLookup }) => {
+    const impactBounds = getEventFocusBounds(event, { countryBounds, regionBounds });
+    if (impactBounds) {
+        return impactBounds;
+    }
+
+    let bounds = null;
+    for (const chat of event?.impacts?.createdChats ?? []) {
+        for (const country of chat?.countries ?? []) {
+            if (country?.code) {
+                bounds = extendBounds(bounds, countryBounds.get(String(country.code)) || null);
+            }
+        }
+    }
+    if (bounds) {
+        return bounds;
+    }
+
+    const haystack = `${event?.title ?? ""} ${event?.description ?? ""}`.toLowerCase();
+    for (const [code, name] of polityLookup) {
+        // Very short names ("Chad") false-match inside other words rarely
+        // enough to accept; sub-4-character names don't.
+        if (!name || String(name).length < 4) {
+            continue;
+        }
+
+        if (haystack.includes(String(name).toLowerCase())) {
+            bounds = extendBounds(bounds, countryBounds.get(code) || null);
+        }
+    }
+
+    return bounds;
+};
+
 const getMapInstance = (mapRef) => mapRef?.current?.getMap?.() ?? mapRef?.current ?? null;
 
 const focusMapOnBounds = (mapRef, bounds) => {
@@ -928,7 +965,6 @@ const TimelineSkipPanel = ({
 
 const TimelineHistoryPanel = ({
     isOpen,
-    onFocusEvent,
     onRevealNextEvent,
     lookups,
     onClose,
@@ -972,31 +1008,12 @@ const TimelineHistoryPanel = ({
             <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
             {visibleEvents.map((event, index) => {
                 const isLastVisible = index === visibleEvents.length - 1;
-                const hasMapChanges = getEventMapChangeCount(event) > 0;
 
                 return (
                     <div key={event.id} ref={isLastVisible ? lastVisibleEventRef : null}>
-                    <EventCard
-                    event={event}
-                    lookups={lookups}
-                    footer={(
-                        hasMapChanges ? (
-                            <div style={{ display: "flex", justifyContent: "center", marginTop: "0.15rem" }}>
-                            <button
-                            type="button"
-                            onClick={() => onFocusEvent(event)}
-                            style={{
-                                ...ghostButtonStyle,
-                                color: "#bfdbfe",
-                            }}
-                            >
-                            <MapIcon />
-                            <span>Show on map</span>
-                            </button>
-                            </div>
-                        ) : null
-                    )}
-                    />
+                    {/* No "Show on map" footer: the camera already flies to
+                        every event as it is revealed. */}
+                    <EventCard event={event} lookups={lookups} />
                     </div>
                 );
             })}
@@ -1208,14 +1225,16 @@ const DateWidget = ({
         setVisibleEventCount(1);
     }, [latestTurnRecord?.id]);
 
+    // The camera follows EVERY revealed event — impacts pin the exact spot,
+    // otherwise the countries the event involves do.
     useEffect(() => {
         if (!activeVisibleEvent) {
             return;
         }
 
-        const bounds = getEventFocusBounds(activeVisibleEvent, { countryBounds, regionBounds });
+        const bounds = deriveEventFocusBounds(activeVisibleEvent, { countryBounds, regionBounds, polityLookup });
         focusMapOnBounds(mapRef, bounds);
-    }, [activeVisibleEvent, countryBounds, mapRef, regionBounds]);
+    }, [activeVisibleEvent, countryBounds, mapRef, polityLookup, regionBounds]);
 
     const revealNextEvent = () => {
         setVisibleEventCount((current) => {
@@ -1225,11 +1244,6 @@ const DateWidget = ({
 
             return Math.min(totalVisibleEvents, current + 1);
         });
-    };
-
-    const focusEvent = (event) => {
-        const bounds = getEventFocusBounds(event, { countryBounds, regionBounds });
-        focusMapOnBounds(mapRef, bounds);
     };
 
     return (
@@ -1246,7 +1260,6 @@ const DateWidget = ({
         />
         <TimelineHistoryPanel
         isOpen={openPanel === "history"}
-        onFocusEvent={focusEvent}
         onRevealNextEvent={revealNextEvent}
         lookups={lookups}
         onClose={() => setPanel(null)}


### PR DESCRIPTION
Landed after #138 was merged, so it gets its own PR:

- **The camera flies to every revealed event**, not only ones with map impacts: impacts pin the exact bounds, otherwise the chat participants or the countries mentioned in the event´s own text do. The per-event "Show on map" button is removed — movement is automatic.
- **Time skips request a fixed event density**: 1 week → 1–2 events, 1 month → 5–7, 3 months → 10–13, 6 months → 19–27, 1 year → 29–37, with dates spread across the skipped period. Auto-jumps scale to the time actually covered before their stop point. The requirement rides in the jump request itself, so existing games with stale prompt packs comply too.