### PR TITLE
Updater asks: update to the beta branch, or stay

### DIFF
--- a/Update Pax Historia.bat
+++ b/Update Pax Historia.bat
@@ -40,6 +40,21 @@ echo             PAX HISTORIA  -  UPDATER
 echo    source: %REPO_OWNER%/%REPO_NAME% (%REPO_BRANCH%)
 echo ===================================================
 echo.
+echo Would you like to update to the most recent release on Beta
+echo (the %REPO_BRANCH% branch of %REPO_OWNER%/%REPO_NAME%) or stay
+echo on your current branch?
+echo.
+echo    [U] Update to the most recent Beta release
+echo    [S] Stay on your current branch
+echo.
+choice /C US /N /M "Your choice [U/S]: "
+if errorlevel 2 (
+    echo.
+    echo Staying on your current branch - nothing was changed.
+    pause
+    exit /b 0
+)
+echo.
 
 REM ---- Git installs: a proper pull is the cleanest update ----
 if exist ".git" (
@@ -49,8 +64,8 @@ if exist ".git" (
         echo Install Git from https://git-scm.com/ and run this again.
         pause & exit /b 1
     )
-    echo This is a git install - updating with git pull...
-    git pull --ff-only
+    echo This is a git install - pulling the Beta repository...
+    git pull --ff-only https://github.com/%REPO_OWNER%/%REPO_NAME%.git %REPO_BRANCH%
     if errorlevel 1 (
         echo.
         echo [WARN] git pull could not fast-forward ^(local changes?^).

--- a/Update Pax Historia.sh
+++ b/Update Pax Historia.sh
@@ -51,6 +51,24 @@ main() {
     echo "   source: $REPO_OWNER/$REPO_NAME ($REPO_BRANCH)"
     echo "==================================================="
     echo ""
+    echo "Would you like to update to the most recent release on Beta"
+    echo "(the $REPO_BRANCH branch of $REPO_OWNER/$REPO_NAME) or stay"
+    echo "on your current branch?"
+    echo ""
+    echo "   [u] Update to the most recent Beta release"
+    echo "   [s] Stay on your current branch"
+    echo ""
+    printf "Your choice [u/s]: "
+    read -r choice
+    case "$choice" in
+        u|U|update|Update|UPDATE) ;;
+        *)
+            echo ""
+            echo "Staying on your current branch - nothing was changed."
+            exit 0
+            ;;
+    esac
+    echo ""
 
     # ---- Git installs: a proper pull is the cleanest update ----
     if [ -d ".git" ]; then
@@ -59,8 +77,8 @@ main() {
             echo "Install Git (https://git-scm.com/) and run this again."
             exit 1
         fi
-        echo "This is a git install - updating with git pull..."
-        if ! git pull --ff-only; then
+        echo "This is a git install - pulling the Beta repository..."
+        if ! git pull --ff-only "https://github.com/$REPO_OWNER/$REPO_NAME.git" "$REPO_BRANCH"; then
             echo ""
             echo "[WARN] git pull could not fast-forward (local changes?)."
             echo "Commit/stash your changes, or resolve manually, then retry."


### PR DESCRIPTION
The updater now asks whether to update to the most recent release on Beta (the beta branch of this repository) or stay on the current branch; choosing stay exits without touching anything. Git installs that choose update pull the beta branch explicitly.

Stacked on the updater-beta-branch PR - merge that one first. Supersedes #145.