### PR TITLE
Links follow the Open-Historia organisation (main)

### DIFF
--- a/Launch Open Historia.bat
+++ b/Launch Open Historia.bat
@@ -122,7 +122,7 @@ REM  Usage:  call :ensure_asset "local\path" "repo/path"
 REM ============================================================
 :ensure_asset
 set "TARGET=%~1"
-set "URL=https://media.githubusercontent.com/media/Tommi-K/open-historia/main/%~2"
+set "URL=https://media.githubusercontent.com/media/Open-Historia/open-historia/main/%~2"
 set "FSIZE=0"
 if exist "%TARGET%" for %%A in ("%TARGET%") do set "FSIZE=%%~zA"
 

--- a/Launch Open Historia.sh
+++ b/Launch Open Historia.sh
@@ -86,7 +86,7 @@ echo ""
 #  The big map files ship as tiny Git LFS pointer stubs in a
 #  ZIP download. Pull the real binaries from GitHub's media CDN.
 #  Real files are several MB; LFS pointer stubs are ~150 B.
-ASSET_BASE="https://media.githubusercontent.com/media/Tommi-K/open-historia/main"
+ASSET_BASE="https://media.githubusercontent.com/media/Open-Historia/open-historia/main"
 
 ensure_asset() { # ensure_asset <local path == repo path>
     local target="$1" size=0

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@
 </div>
 
 <div align="center">
-  <sub>Built with ❤︎ by <a href="https://github.com/Tommi-K/open-historia/graphs/contributors">contributors</a>.
+  <sub>Built with ❤︎ by <a href="https://github.com/Open-Historia/open-historia/graphs/contributors">contributors</a>.
 </div>
 
 <br />
 <br />
 
-![](https://github.com/Tommi-K/open-historia/blob/main/public/screenshot.png?raw=true)
+![](https://github.com/Open-Historia/open-historia/blob/main/public/screenshot.png?raw=true)
 
 ---
 
@@ -65,7 +65,7 @@ while preserving your saves, scenarios, and map data.
 #### Android app (thin APK)
 
 Easiest: download **`pax-historia.apk`** from the
-[**Android release**](https://github.com/Tommi-K/open-historia/releases/tag/android)
+[**Android release**](https://github.com/Open-Historia/open-historia/releases/tag/android)
 and open it to install (allow installs from your browser when Android asks).
 On first launch the app finds the Termux server on the same phone by itself;
 to play against another machine, type its address once — it's remembered.
@@ -95,7 +95,7 @@ release APK — run it after changing `mobile/`.
 Prerequisites: [Git](https://git-scm.com/) (with [Git LFS](https://git-lfs.com/)) and [Node.js](https://nodejs.org/en).
 
 ```bash
-git clone https://github.com/Tommi-K/open-historia.git
+git clone https://github.com/Open-Historia/open-historia.git
 cd open-historia
 git lfs install        # Set up Git LFS
 git lfs pull           # Pull large files (map tiles + editor seeds + world map)

--- a/Update Open Historia.bat
+++ b/Update Open Historia.bat
@@ -27,8 +27,8 @@ REM  it reinstalls dependencies and rebuilds automatically.
 REM ============================================================
 
 REM Which repository to update from. The beta channel lives on the beta
-REM BRANCH of the main repository - updating keeps tracking that branch.
-set "REPO_OWNER=Tommi-K"
+REM branch of the organisation repository - updating keeps tracking it.
+set "REPO_OWNER=Open-Historia"
 set "REPO_NAME=open-historia"
 set "REPO_BRANCH=beta"
 

--- a/Update Open Historia.sh
+++ b/Update Open Historia.sh
@@ -27,8 +27,8 @@
 # ============================================================
 
 # Which repository to update from. The beta channel lives on the beta
-# BRANCH of the main repository - updating keeps tracking that branch.
-REPO_OWNER="Tommi-K"
+# branch of the organisation repository - updating keeps tracking it.
+REPO_OWNER="Open-Historia"
 REPO_NAME="open-historia"
 REPO_BRANCH="beta"
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta property="og:site_name" content="Open Historia" />
     <meta property="og:title" content="Open Historia" />
     <meta property="og:description" content="An open source alternative to Pax Historia." />
-    <meta property="og:image" content="https://raw.githubusercontent.com/Tommi-K/open-historia/main/public/loading_screen.jpg" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="720" />
@@ -25,7 +25,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Open Historia" />
     <meta name="twitter:description" content="An open source alternative to Pax Historia." />
-    <meta name="twitter:image" content="https://raw.githubusercontent.com/Tommi-K/open-historia/main/public/loading_screen.jpg" />
+    <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   </head>
   <body>
     <div id="root"></div>

--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -91,10 +91,11 @@
       // Stamped with the CI run number at build time; hand-built ("dev")
       // copies skip the update check entirely.
       const APP_BUILD = "__APP_BUILD__";
-      // Self-update polls the Beta repository's rolling "android" release —
-      // the asset name pax-historia.apk must never change (installed apps
-      // look for exactly that name).
-      const RELEASE_API = "https://api.github.com/repos/Arkniem/Open-Historia-Beta/releases/tags/android";
+      // Self-update polls the organisation repository's rolling "android"
+      // release (the android-apk.yml workflow publishes there) — the asset
+      // name pax-historia.apk must never change (installed apps look for
+      // exactly that name).
+      const RELEASE_API = "https://api.github.com/repos/Open-Historia/open-historia/releases/tags/android";
       const setup = document.getElementById("setup");
       const connecting = document.getElementById("connecting");
       const input = document.getElementById("server");

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -304,7 +304,7 @@ const Main = ({
       {isSettingsOpen && (
         <SettingsMenu
           discordUrl="https://discord.gg/C3AVwHacZ4"
-          githubUrl="https://github.com/Arkniem/Open-Historia-Beta"
+          githubUrl="https://github.com/Open-Historia/open-historia"
           onOpenCheats={() => {
             setShouldLoadCheats(true);
             setIsCheatsOpen(true);


### PR DESCRIPTION
Same link redo as the beta-branch PR, applied to main: updater and APK URLs point at Open-Historia/open-historia, launcher/README/social links follow the organisation, and the in-game GitHub button points at the main repository again.