### PR TITLE
Organisation links, self-updating updater, loading screen 5 (beta)

### DIFF
--- a/Update Open Historia.bat
+++ b/Update Open Historia.bat
@@ -32,8 +32,20 @@ set "REPO_OWNER=Open-Historia"
 set "REPO_NAME=open-historia"
 set "REPO_BRANCH=beta"
 
-REM Work from the folder this script lives in (the project root)
-cd /d "%~dp0"
+REM ---- Self-update safety --------------------------------------------------
+REM cmd reads batch files incrementally, so the update replacing THIS script
+REM on disk mid-run would corrupt the running interpreter. Re-run from a temp
+REM copy instead: the copy performs the update and can safely overwrite the
+REM original updater along with everything else. (The .sh updater is already
+REM safe - bash parses it fully into main() before any of it executes.)
+if /I not "%~1"=="/from-temp" (
+    copy /Y "%~f0" "%TEMP%\open-historia-updater.bat" >nul
+    "%TEMP%\open-historia-updater.bat" /from-temp "%~dp0"
+    exit /b
+)
+
+REM Work from the folder the ORIGINAL script lives in (the project root)
+cd /d "%~2"
 
 echo.
 echo ===================================================

--- a/src/runtime/StartupScreen.jsx
+++ b/src/runtime/StartupScreen.jsx
@@ -9,6 +9,7 @@ const LOADING_IMAGES = [
   "/loading_screen_2.jpg",
   "/loading_screen_3.jpg",
   "/loading_screen_4.jpg",
+  "/loading_screen_5.png",
 ];
 const IMAGE_ROTATE_MS = 4500;
 


### PR DESCRIPTION
Supersedes #151 (repository rules freeze existing branches, so additions arrive on a fresh branch):

- All links follow the Open-Historia organisation; the in-game GitHub button points at the main repository
- The updater can now safely update ITSELF: the .bat re-runs from a temp copy before overwriting the install (cmd reads batch files incrementally - replacing the running script mid-run corrupted the interpreter). The .sh was already parse-safe. Verified with a live self-overwrite test.
- Loading screen 5 joins the startup cycle