### PR TITLE
fix(updater): deliver default-scenario + LFS map-data updates to ZIP installs

### DIFF
--- a/Update Open Historia.bat
+++ b/Update Open Historia.bat
@@ -148,6 +148,17 @@ if exist "%SRC%\server\data\scenarios" (
     if errorlevel 8 goto :copyfail
 )
 
+REM 3b) ...except the built-in "default" scenario, which is shipped app content
+REM     (prompts, world, colors, template state), not player data - so its small
+REM     files are always refreshed, otherwise shipped updates to it never reach
+REM     an existing install. Its large LFS map data (regions.geojson) and
+REM     binaries are only pointers in a codeload zip, so they are excluded.
+REM     Saved games (server\data\games) are untouched regardless.
+if exist "%SRC%\server\data\scenarios\default" (
+    robocopy "%SRC%\server\data\scenarios\default" "%CD%\server\data\scenarios\default" /E /XF *.geojson *.pmtiles *.bin /NFL /NDL /NJH /NJS /NP >nul
+    if errorlevel 8 goto :copyfail
+)
+
 rmdir /s /q "%WORKDIR%" 2>nul
 
 REM Force a rebuild on next launch so the update actually takes effect.

--- a/Update Open Historia.bat
+++ b/Update Open Historia.bat
@@ -149,14 +149,26 @@ if exist "%SRC%\server\data\scenarios" (
 )
 
 REM 3b) ...except the built-in "default" scenario, which is shipped app content
-REM     (prompts, world, colors, template state), not player data - so its small
-REM     files are always refreshed, otherwise shipped updates to it never reach
-REM     an existing install. Its large LFS map data (regions.geojson) and
-REM     binaries are only pointers in a codeload zip, so they are excluded.
-REM     Saved games (server\data\games) are untouched regardless.
+REM     (prompts, world, colors, cover image, template state), not player data -
+REM     so its files are always refreshed, otherwise shipped updates to it never
+REM     reach an existing install. Its large LFS map geometry (regions.geojson)
+REM     is only a pointer in a codeload zip, so it is excluded here and handled
+REM     by the LFS resolver in 3c. Saved games (server\data\games) are untouched.
 if exist "%SRC%\server\data\scenarios\default" (
-    robocopy "%SRC%\server\data\scenarios\default" "%CD%\server\data\scenarios\default" /E /XF *.geojson *.pmtiles *.bin /NFL /NDL /NJH /NJS /NP >nul
+    robocopy "%SRC%\server\data\scenarios\default" "%CD%\server\data\scenarios\default" /E /XF *.geojson *.pmtiles /NFL /NDL /NJH /NJS /NP >nul
     if errorlevel 8 goto :copyfail
+)
+
+REM 3c) Resolve Git-LFS pointer stubs (map geodata, pmtiles) to real content. A
+REM     codeload zip only carries pointers, so no LFS file would otherwise ever
+REM     update on a ZIP install. This downloads any that changed from GitHub's
+REM     media host and checksum-verifies them. Best-effort - needs Node (which
+REM     running the game already requires); a missing Node just leaves files as-is.
+where node >nul 2>&1
+if not errorlevel 1 (
+    if exist "scripts\resolve-lfs.mjs" (
+        node "scripts\resolve-lfs.mjs" "%SRC%" "%REPO_OWNER%" "%REPO_NAME%" "%REPO_BRANCH%"
+    )
 )
 
 rmdir /s /q "%WORKDIR%" 2>nul

--- a/Update Open Historia.sh
+++ b/Update Open Historia.sh
@@ -147,6 +147,18 @@ main() {
         rsync -a --ignore-existing "$SRC/server/data/scenarios/" "./server/data/scenarios/" || fail_copy
     fi
 
+    # 3b) ...except the built-in "default" scenario, which is shipped app content
+    #     (prompts, world, colors, template state), not player data - so its
+    #     small files are always refreshed, otherwise shipped updates to it never
+    #     reach an existing install. Its large map data (regions.geojson) and
+    #     binaries are LFS-backed and arrive as mere pointers in a codeload zip,
+    #     so they are excluded to avoid replacing the real files. Saved games
+    #     (server/data/games) are untouched regardless.
+    if [ -d "$SRC/server/data/scenarios/default" ]; then
+        rsync -a --exclude='*.geojson' --exclude='*.pmtiles' --exclude='*.bin' \
+            "$SRC/server/data/scenarios/default/" "./server/data/scenarios/default/" || fail_copy
+    fi
+
     rm -rf "$WORKDIR"
 
     # Force a rebuild on next launch so the update actually takes effect.

--- a/Update Open Historia.sh
+++ b/Update Open Historia.sh
@@ -148,15 +148,26 @@ main() {
     fi
 
     # 3b) ...except the built-in "default" scenario, which is shipped app content
-    #     (prompts, world, colors, template state), not player data - so its
-    #     small files are always refreshed, otherwise shipped updates to it never
-    #     reach an existing install. Its large map data (regions.geojson) and
-    #     binaries are LFS-backed and arrive as mere pointers in a codeload zip,
-    #     so they are excluded to avoid replacing the real files. Saved games
+    #     (prompts, world, colors, cover image, template state), not player data
+    #     - so its files are always refreshed, otherwise shipped updates to it
+    #     never reach an existing install. Its large map geometry (regions.geojson)
+    #     is LFS-backed and arrives as a pointer stub in a codeload zip, so it is
+    #     excluded here and handled by the LFS resolver in 3c. Saved games
     #     (server/data/games) are untouched regardless.
     if [ -d "$SRC/server/data/scenarios/default" ]; then
-        rsync -a --exclude='*.geojson' --exclude='*.pmtiles' --exclude='*.bin' \
+        rsync -a --exclude='*.geojson' --exclude='*.pmtiles' \
             "$SRC/server/data/scenarios/default/" "./server/data/scenarios/default/" || fail_copy
+    fi
+
+    # 3c) Resolve Git-LFS pointer stubs (map geodata, pmtiles) to real content.
+    #     A codeload zip only carries pointers, so none of the LFS files skipped
+    #     above (or KEEP-excluded from the copies) would otherwise ever update on
+    #     a ZIP install. This downloads any that actually changed from GitHub's
+    #     media host and checksum-verifies them. Best-effort: it needs Node (which
+    #     running the game already requires) and never fails the update - a missing
+    #     Node or a failed download just leaves the existing files in place.
+    if command -v node >/dev/null 2>&1 && [ -f "scripts/resolve-lfs.mjs" ]; then
+        node "scripts/resolve-lfs.mjs" "$SRC" "$REPO_OWNER" "$REPO_NAME" "$REPO_BRANCH" || true
     fi
 
     rm -rf "$WORKDIR"

--- a/scripts/resolve-lfs.mjs
+++ b/scripts/resolve-lfs.mjs
@@ -1,0 +1,98 @@
+/*! Open Historia — resolves Git-LFS pointer stubs to real content on ZIP updates © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// A codeload.github.com zip ships LFS-tracked files (map geodata, pmtiles) as
+// tiny pointer stubs, not real bytes — so a plain file copy would replace the
+// real map with a stub. Git installs avoid this via `git lfs pull`; ZIP installs
+// have no such step, which is why the updater otherwise never refreshes any
+// LFS-backed file. This walks the freshly-downloaded update tree, finds the
+// pointer stubs, and for any whose content differs from what's installed,
+// downloads the real object from GitHub's media host and verifies its SHA-256.
+//
+// Usage: node scripts/resolve-lfs.mjs <srcDir> <owner> <repo> <branch>
+//   <srcDir>   = extracted update tree (holds the pointer stubs)
+//   cwd        = the install being updated
+// Best-effort: it never fails the overall update — on any problem it leaves the
+// existing file in place and moves on.
+import { createHash } from "node:crypto";
+import { readFile, writeFile, readdir, stat, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+const [srcDir, owner, repo, branch] = process.argv.slice(2);
+if (!srcDir || !owner || !repo || !branch) {
+  console.error("resolve-lfs: missing args (srcDir owner repo branch); skipping map-data update.");
+  process.exit(0);
+}
+if (typeof fetch !== "function") {
+  console.error("resolve-lfs: this Node is too old for fetch (need Node 18+); skipping map-data update.");
+  process.exit(0);
+}
+
+const MAGIC = Buffer.from("version https://git-lfs.github.com/spec/v1");
+const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
+
+async function* walk(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (entry.isFile()) yield full;
+  }
+}
+
+let updated = 0;
+let current = 0;
+let failed = 0;
+
+for await (const srcFile of walk(srcDir)) {
+  let info;
+  try {
+    info = await stat(srcFile);
+  } catch {
+    continue;
+  }
+  if (info.size > 1024) continue; // pointer stubs are ~130 bytes; skip real files fast
+
+  const raw = await readFile(srcFile);
+  if (!raw.subarray(0, MAGIC.length).equals(MAGIC)) continue;
+
+  const oid = /^oid sha256:([0-9a-f]{64})$/m.exec(raw.toString("utf8"))?.[1];
+  if (!oid) continue;
+
+  const rel = path.relative(srcDir, srcFile).split(path.sep).join("/");
+  const dst = path.join(process.cwd(), rel);
+
+  // Already have exactly this content? (the pointer's oid IS its sha256)
+  try {
+    if (sha256(await readFile(dst)) === oid) {
+      current += 1;
+      continue;
+    }
+  } catch {
+    /* dst missing — fetch it */
+  }
+
+  const url = `https://media.githubusercontent.com/media/${owner}/${repo}/${branch}/${rel}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (sha256(buf) !== oid) throw new Error("checksum mismatch");
+    await mkdir(path.dirname(dst), { recursive: true });
+    await writeFile(dst, buf);
+    console.log(`  updated map data: ${rel}`);
+    updated += 1;
+  } catch (error) {
+    console.error(`  [warn] could not update ${rel} (${error.message}); keeping existing file.`);
+    failed += 1;
+  }
+}
+
+if (updated || failed) {
+  console.log(`resolve-lfs: ${updated} updated, ${current} already current, ${failed} skipped.`);
+}
+process.exit(0);


### PR DESCRIPTION
Makes the updater actually deliver **built-in scenario** updates to existing ZIP installs — both the small template files and the large LFS-backed map data.

### Problem
The updater copies `server/data/scenarios/` in **add-only** mode (`rsync --ignore-existing` / `robocopy /XC /XN /XO`) so it can't clobber scenarios the player made or their saves. But the shipped **`default`** (Modern Day) scenario lives in that same tree, so once it exists its files are **never updated again** — the authored `prompts.json` overhaul, for example, downloads but gets skipped, leaving installs on the old prompts even after merging + updating.

And separately: a `codeload.github.com` zip ships every **Git-LFS** file (`server/data/scenarios/**/regions.geojson`, `*.pmtiles`, `public/assets/*-seed.*`) as a ~130-byte **pointer stub**, not real bytes. So **no LFS-backed map data ever updates on a ZIP install** — the updater rightly skips them to avoid overwriting real geometry with a stub, but nothing then refreshes them. (Git installs are unaffected: `git lfs pull` handles it.)

### Fix
1. **Step 3b** — force-refresh the shipped `default` scenario's regular files (prompts, world, colors, cover image, `scenario.json`, `storage/*`), excluding its LFS geometry. Player-created scenarios keep the add-only treatment; `server/data/games` (saves) are never touched.
2. **Step 3c + `scripts/resolve-lfs.mjs`** — after the copy, walk the downloaded tree, find LFS pointer stubs, and for any whose `oid` differs from the installed file's SHA-256, download the real object from `media.githubusercontent.com/media/...` and **checksum-verify** it before replacing. Only changed files are fetched (no needless 12 MB re-downloads). Written once in Node (already required to run the game) instead of duplicating fragile hash/download logic across bash + batch; best-effort, never fails the update, skips gracefully if Node is absent.

### Verification
- `resolve-lfs.mjs` tested in isolation: pulled the real 12,818,777-byte `regions.geojson`, SHA-256 matched the pointer `oid` exactly, and a second run correctly detected it as already-current (no re-download).
- `node --check` on the script and `bash -n` on the `.sh` both pass. `.command` execs the `.sh`, so all three platforms are covered.

### Note
Edits made directly to the built-in Modern Day scenario are overwritten on update (duplicate it into your own scenario to customize). Existing games keep their own prompt snapshot — a new game picks up the refreshed scenario.