### PR TITLE
fix(ui): timeline/events panel taller on short laptop screens

### DIFF
--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -730,9 +730,12 @@ const PanelChrome = ({
             bottom: isOpen ? "4.9rem" : "-34rem",
             display: "flex",
             flexDirection: "column",
-            height: "calc(100vh - 33rem)",
+            // Match the Actions/Chat panels: on short laptop screens the sliver
+            // calc(100vh - 33rem) collapsed to the 10rem floor, so grow to at
+            // least 30rem while still capping at calc(100vh - 9rem) to fit. (The
+            // min() already caps height, so no separate maxHeight is needed.)
+            height: "min(calc(100vh - 9rem), max(calc(100vh - 33rem), 30rem))",
             left: "0.5rem",
-            maxHeight: "calc(100vh - 33rem)",
             maxWidth: "calc(100vw - 1rem)",
             minHeight: "10rem",
             opacity: isOpen ? 1 : 0,


### PR DESCRIPTION
The timeline/events panel (`PanelChrome` in `src/Game/GameUI/time.jsx`) still used the old `height: calc(100vh - 33rem)` with a matching `maxHeight` that clamped it right back, so on short laptop screens it collapsed to its `10rem` floor — the same "too short" problem the **Actions** and **Diplomatic chat** panels already had fixed.

This applies their exact formula to it:

```
height: min(calc(100vh - 9rem), max(calc(100vh - 33rem), 30rem))
```

- `max(calc(100vh - 33rem), 30rem)` — grows to at least **30rem** on short screens instead of the sliver.
- `min(calc(100vh - 9rem), ...)` — caps it so it never overflows the viewport.
- The redundant `maxHeight: calc(100vh - 33rem)` is removed (the `min()` already caps the height); `minHeight: 10rem` stays.

Tall desktops render identically to before (the formula resolves back to `calc(100vh - 33rem)` there). `npm run build` and `npm run lint` pass.