### PR TITLE
fix(map): label disputed territories "Disputed (<claimant>)" instead of Z-codes

### DIFF
--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -158,6 +158,16 @@ const mergeOwnerClusters = (clusters, joinDeg) => {
   return clusters;
 };
 
+// GADM assigns disputed / undetermined boundary areas the codes Z01-Z09 (the
+// slivers around India — Kashmir, Aksai Chin, Arunachal Pradesh). The base map
+// carries each as its own polity named with the bare code, which surfaced on the
+// map as "Z01" labels; show "Disputed (<claimant>)" instead, keyed to the main
+// country that administers/claims each (per server/country-names.json).
+const DISPUTED_TERRITORY_CLAIMANT = {
+  Z01: "India", Z02: "China", Z03: "China", Z04: "India", Z05: "India",
+  Z06: "Pakistan", Z07: "India", Z08: "China", Z09: "India",
+};
+
 const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameResolver) => {
   const perOwner = new Map(); // owner -> [{c:[lng,lat], area}]
   const countryNameByCode = new Map(); // gid0 -> modern country name (fallback labels)
@@ -204,7 +214,9 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
 
     mergeOwnerClusters(clusters, CLUSTER_JOIN_DEGREES);
     clusters.sort((a, b) => b.area - a.area);
-    const rawName = polityOverrides?.[owner]?.name || countryNameByCode.get(owner) || owner;
+    const rawName = DISPUTED_TERRITORY_CLAIMANT[owner]
+      ? `Disputed (${DISPUTED_TERRITORY_CLAIMANT[owner]})`
+      : polityOverrides?.[owner]?.name || countryNameByCode.get(owner) || owner;
     const name = String(nameResolver ? nameResolver(rawName, owner) : rawName).toUpperCase();
     for (let index = 0; index < clusters.length; index += 1) {
       const cluster = clusters[index];


### PR DESCRIPTION
The slivers around India were rendering as raw codes — **`Z01`, `Z03`, `Z07`**, etc. Those are **GADM's codes for disputed / undetermined boundary areas** (Kashmir, Aksai Chin, Arunachal Pradesh, …). The base map ships each as its own polity whose display name is set to the bare code, so `Nations.jsx` printed the code verbatim.

This labels them **"Disputed (\<claimant\>)"** — the main country that administers/claims each, taken from the existing `server/country-names.json` mapping:

| Codes | Claimant |
|---|---|
| Z01, Z04, Z05, Z07, Z09 | India |
| Z02, Z03, Z08 | China |
| Z06 | Pakistan |

so they read **DISPUTED (INDIA)**, **DISPUTED (CHINA)**, **DISPUTED (PAKISTAN)** on the map.

Done in the owner-label pipeline (`buildOwnerLabelCollection` in `src/Game/Map/Nations.jsx`) rather than in the scenario's `world.json`, so it applies to **existing games too** — the label is derived from the region's owner code at render time, independent of any per-game world snapshot. `npm run build` and `npm run lint` pass.