### PR TITLE
feat(map): default the world background to Ocean, remove the in-game basemap picker

### DIFF
--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -13,7 +13,6 @@ import {
     getStoredLanguage,
     setStoredLanguage,
 } from "../../runtime/i18n.js";
-import { ESRI_BASEMAPS } from "../../runtime/assets.js";
 import {
     MAP_SETTING_KEYS,
     getMapSetting,
@@ -750,7 +749,6 @@ const SettingsMenu = ({
     const [mapSettings, setMapSettingsState] = useState(() => ({
         hideCountryLabels: getMapSetting(MAP_SETTING_KEYS.hideCountryLabels),
         disableIdleRotation: getMapSetting(MAP_SETTING_KEYS.disableIdleRotation),
-        basemapStyle: getMapSetting(MAP_SETTING_KEYS.basemapStyle),
     }));
 
     const updateMapSetting = (stateKey, settingKey, value) => {
@@ -833,21 +831,6 @@ const SettingsMenu = ({
         enabled={mapSettings.disableIdleRotation}
         onToggle={() => updateMapSetting("disableIdleRotation", MAP_SETTING_KEYS.disableIdleRotation, !mapSettings.disableIdleRotation)}
         />
-        <div style={{ marginBottom: "0.5rem" }}>
-        <div style={{ fontSize: "0.9rem", marginBottom: "0.4rem" }}>Map style</div>
-        <select
-        data-no-translate
-        value={mapSettings.basemapStyle}
-        onChange={(event) => updateMapSetting("basemapStyle", MAP_SETTING_KEYS.basemapStyle, event.target.value)}
-        style={{ ...inputStyle, cursor: "pointer" }}
-        >
-        {ESRI_BASEMAPS.map((basemap) => (
-            <option key={basemap.id} value={basemap.id} style={{ color: "black" }}>
-            {basemap.label}
-            </option>
-        ))}
-        </select>
-        </div>
         </div>
         <ComingSoonToggle label="Country borders" note="Not available yet — coming soon." />
 

--- a/src/Game/Map/World.jsx
+++ b/src/Game/Map/World.jsx
@@ -9,6 +9,7 @@ import Cities from "./Cities";
 import Units from "./Units";
 import UnitPopup from "../Selection/Units";
 import {
+  DEFAULT_BASEMAP_ID,
   TERRAIN_TILE_TEMPLATE,
   basemapMaxZoom,
   basemapProtocolTemplate,
@@ -16,7 +17,6 @@ import {
   esriTileTemplate,
 } from "../../runtime/assets.js";
 import { SKYBOX_SIZE, getSkyboxUrl } from "./skybox.js";
-import { MAP_SETTING_KEYS, useMapSetting } from "../../runtime/mapSettings.js";
 
 // The high-res source goes through the ohbase protocol so ESRI's "Map Data
 // Not Yet Available" placeholders get replaced with upscaled ancestor tiles.
@@ -103,8 +103,8 @@ const buildWorldStyle = (basemapId) => ({
 
 function World({ mapRef, projection, terrainEnabled, onInitialIdle }) {
   const hasReportedInitialIdleRef = useRef(false);
-  const basemapId = useMapSetting(MAP_SETTING_KEYS.basemapStyle);
-  const worldStyle = useMemo(() => buildWorldStyle(basemapId), [basemapId]);
+  // Fixed to the ocean preset — the in-game basemap picker was removed.
+  const worldStyle = useMemo(() => buildWorldStyle(DEFAULT_BASEMAP_ID), []);
 
   const isGlobe = projection === "globe";
   const terrain = useMemo(

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -77,7 +77,7 @@ export const ESRI_BASEMAPS = [
   { id: "light-gray", label: "Light Gray Canvas", service: "Canvas/World_Light_Gray_Base", maxZoom: 16 },
   { id: "dark-gray", label: "Dark Gray Canvas", service: "Canvas/World_Dark_Gray_Base", maxZoom: 16 },
 ];
-export const DEFAULT_BASEMAP_ID = "imagery";
+export const DEFAULT_BASEMAP_ID = "ocean";
 // Mirrors mapSettings.js's MAP_SETTING_KEYS.basemapStyle key.
 const BASEMAP_STORAGE_KEY = "map_basemap_style";
 

--- a/src/runtime/mapSettings.js
+++ b/src/runtime/mapSettings.js
@@ -6,40 +6,17 @@
 // beside the data it subscribes to.
 import { useEffect, useState } from "react";
 
-// Keep in sync with assets.js DEFAULT_BASEMAP_ID.
-const DEFAULT_BASEMAP_ID = "imagery";
-
 export const MAP_SETTING_KEYS = {
     hideCountryLabels: "map_hide_country_labels",
     disableIdleRotation: "map_disable_idle_rotation",
-    basemapStyle: "map_basemap_style",
-};
-
-const BOOLEAN_KEYS = new Set([
-    MAP_SETTING_KEYS.hideCountryLabels,
-    MAP_SETTING_KEYS.disableIdleRotation,
-]);
-
-const STRING_DEFAULTS = {
-    [MAP_SETTING_KEYS.basemapStyle]: DEFAULT_BASEMAP_ID,
 };
 
 export function getMapSetting(key) {
-    if (BOOLEAN_KEYS.has(key)) {
-        return localStorage.getItem(key) === "1";
-    }
-
-    // String-valued settings (e.g. the basemap picker): stored value or default.
-    return localStorage.getItem(key) || STRING_DEFAULTS[key];
+    return localStorage.getItem(key) === "1";
 }
 
 export function setMapSetting(key, value) {
-    if (BOOLEAN_KEYS.has(key)) {
-        localStorage.setItem(key, value ? "1" : "0");
-    } else {
-        localStorage.setItem(key, String(value));
-    }
-
+    localStorage.setItem(key, value ? "1" : "0");
     window.dispatchEvent(new Event("mapSettings:updated"));
 }
 


### PR DESCRIPTION
Removes the in-game **Settings → Map style** dropdown and fixes the world background to the ESRI **Ocean** preset.

- Drops the `basemapStyle` map-setting (localStorage key `map_basemap_style`) and its picker UI in `settings.jsx`; `mapSettings.js` is back to just the two boolean toggles.
- `World.jsx` and `preload.js` now use `DEFAULT_BASEMAP_ID`, changed from `imagery` to **`ocean`**.
- `ESRI_BASEMAPS` stays exported (unused in-game now) — it feeds the **map editor's** basemap menu in the follow-up.

Build + lint pass.