### PR TITLE
feat(editor): basemap background + preset menu (default Ocean)

### DIFF
--- a/src/Editor/BottomBar.jsx
+++ b/src/Editor/BottomBar.jsx
@@ -9,14 +9,12 @@
 
 import Icon from "./Icon.jsx";
 import { panelSurface, inputStyle } from "./editorStyles.js";
+import { EDITOR_BASEMAPS } from "./basemaps.js";
 
 const BASEMAPS = [
-  { v: "osm", l: "Your Basemap" },
-  { v: "light", l: "Light" },
-  { v: "dark", l: "Dark" },
-  { v: "white", l: "White" },
-  { v: "grayscale", l: "Grayscale" },
-  { v: "black", l: "Black" },
+  ...EDITOR_BASEMAPS.map((b) => ({ v: b.id, l: b.label })),
+  { v: "osm", l: "OpenStreetMap" },
+  { v: "dark", l: "None (dark)" },
 ];
 
 const SAVE = {

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -15,6 +15,8 @@ import Map from "ol/Map";
 import View from "ol/View";
 import TileLayer from "ol/layer/Tile";
 import OSM from "ol/source/OSM";
+import XYZ from "ol/source/XYZ";
+import { editorBasemapById, esriXyzUrl } from "./basemaps.js";
 import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import Style from "ol/style/Style";
@@ -897,8 +899,16 @@ const OlMap = ({
       map.removeLayer(baseLayerRef.current);
       baseLayerRef.current = null;
     }
-    if (basemap === "osm" || basemap === "light") {
-      const base = new TileLayer({ source: new OSM(), opacity: basemap === "light" ? 0.85 : 1 });
+    const esri = editorBasemapById(basemap);
+    let base = null;
+    if (esri) {
+      base = new TileLayer({
+        source: new XYZ({ url: esriXyzUrl(esri.service), maxZoom: esri.maxZoom, crossOrigin: "anonymous" }),
+      });
+    } else if (basemap === "osm" || basemap === "light") {
+      base = new TileLayer({ source: new OSM(), opacity: basemap === "light" ? 0.85 : 1 });
+    }
+    if (base) {
       base.setZIndex(0);
       map.addLayer(base);
       baseLayerRef.current = base;

--- a/src/Editor/basemaps.js
+++ b/src/Editor/basemaps.js
@@ -1,0 +1,24 @@
+/*! Open Historia Map Editor — ESRI basemap presets © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// ESRI / ArcGIS Online basemaps (public, token-free) shown behind the editor's
+// regions so you can see where you're drawing. Kept local to the editor so it
+// doesn't pull the game's runtime/assets.js (and its maplibre/pmtiles module
+// side effects) into the lazily-loaded editor bundle. Ocean is first = default.
+export const EDITOR_BASEMAPS = [
+  { id: "ocean", label: "Ocean", service: "Ocean/World_Ocean_Base", maxZoom: 13 },
+  { id: "imagery", label: "Satellite", service: "World_Imagery", maxZoom: 19 },
+  { id: "streets", label: "Streets", service: "World_Street_Map", maxZoom: 19 },
+  { id: "topo", label: "Topographic", service: "World_Topo_Map", maxZoom: 19 },
+  { id: "terrain", label: "Terrain", service: "World_Terrain_Base", maxZoom: 13 },
+  { id: "shaded", label: "Shaded Relief", service: "World_Shaded_Relief", maxZoom: 13 },
+  { id: "natgeo", label: "National Geographic", service: "NatGeo_World_Map", maxZoom: 16 },
+  { id: "physical", label: "Physical", service: "World_Physical_Map", maxZoom: 8 },
+  { id: "light-gray", label: "Light Gray Canvas", service: "Canvas/World_Light_Gray_Base", maxZoom: 16 },
+  { id: "dark-gray", label: "Dark Gray Canvas", service: "Canvas/World_Dark_Gray_Base", maxZoom: 16 },
+];
+
+export const editorBasemapById = (id) => EDITOR_BASEMAPS.find((b) => b.id === id) || null;
+
+// EPSG:3857 XYZ template for an ESRI service — the editor View is web-mercator,
+// so these render without reprojection.
+export const esriXyzUrl = (service) =>
+  `https://server.arcgisonline.com/ArcGIS/rest/services/${service}/MapServer/tile/{z}/{y}/{x}`;

--- a/src/Editor/useMapDocument.js
+++ b/src/Editor/useMapDocument.js
@@ -63,7 +63,7 @@ export const createDocument = ({ name = "Untitled Map", kind = "import-world" } 
       name,
       kind,
       author: "",
-      basemap: "dark",
+      basemap: "ocean",
       view: { center: [0, 20], zoom: 2, rotation: 0 },
       reference: { image: null },
       createdAt: now,


### PR DESCRIPTION
The map editor drew regions on a **blank dark canvas**, so you couldn't see where you were placing them. This adds a real **basemap** behind the regions and a menu to choose it.

- **Background basemap**: ESRI/ArcGIS tiles render under the region/label/city layers (`zIndex 0`). The editor View is EPSG:3857 and the tiles are web-mercator XYZ, so no reprojection.
- **Preset menu**: the bottom-bar basemap dropdown now lists Ocean, Satellite, Streets, Topographic, Terrain, Shaded Relief, National Geographic, Physical, Light/Dark Gray Canvas — plus OpenStreetMap and "None (dark)".
- **Default**: new maps default to **Ocean** (matching the in-game background), so geography shows immediately.
- A small `src/Editor/basemaps.js` holds the preset list + tile-URL builder, so the editor doesn't pull the game's `runtime/assets.js` (with its maplibre/pmtiles side effects) into its lazily-loaded bundle. Existing documents saved with `osm`/`dark`/color basemaps still render.

Build + lint pass. (Custom-background *uploads* — GeoTIFF/Shapefile/GeoJSON/PNG/etc. — are a separate, larger follow-up.)