### PR TITLE
fix(map): cover globe poles + restore custom background on editor reopen

### DIFF
--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -143,6 +143,10 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     hydratedRef.current = true;
     const base = createDocument({ name: initialMap.name || "Scenario Map", kind: "import-world" });
     base.metadata.author = initialMap.author || "";
+    // Carry the restored background in the document metadata so Apply & Play
+    // (buildGameSeed reads doc.metadata.customBackground) re-persists it instead of
+    // clearing the scenario's background when the user re-opens and re-applies.
+    if (initialMap.background) base.metadata.customBackground = initialMap.background;
     base.features = (initialMap.cities?.features || [])
       .map((f) => ({
         id: newId("feat"),
@@ -161,6 +165,10 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     if (initialMap.colors) d.mergeColors(initialMap.colors);
     if (initialMap.regions) api.loadRegions(initialMap.regions);
     else api.reseedWorldWithOwners(initialMap.ownershipOverrides || {});
+    // Restore the scenario's custom map background so re-opening its map editor
+    // shows the uploaded map, not a blank basemap. It's marked persisted, so the
+    // OlMap effect renders it without re-emitting (no dirty/autosave on open).
+    setCustomBg(initialMap.background ? rebuildPersistedBackground(initialMap.background) : null);
     d.setSaveStatus("saved");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, initialMap]);

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -946,7 +946,9 @@ const OlMap = ({
         if (ex && Number.isFinite(ex[0]) && ex[0] !== Infinity) {
           map.getView().fit(ex, { padding: [60, 60, 60, 60], duration: 300, maxZoom: 10 });
         }
-        onCustomBackgroundSaveRef.current?.({ kind: "vector", geojson: vectorLayerToGeoJSON(bg.layer) });
+        // Skip re-emitting a restored background (persisted) — only fresh uploads
+        // need to be written into the document.
+        if (!bg.persisted) onCustomBackgroundSaveRef.current?.({ kind: "vector", geojson: vectorLayerToGeoJSON(bg.layer) });
       }
       return () => {
         map.removeLayer(bg.layer);
@@ -962,7 +964,9 @@ const OlMap = ({
     });
     imageLayer.setZIndex(5);
     map.addLayer(imageLayer);
-    onCustomBackgroundSaveRef.current?.({ kind: "image", dataUrl: bg.dataUrl });
+    // Only fresh uploads write back into the document; a restored (persisted)
+    // background is already in the doc/scenario, so don't re-dirty it on open.
+    if (!bg.persisted) onCustomBackgroundSaveRef.current?.({ kind: "image", dataUrl: bg.dataUrl });
     return () => {
       map.removeLayer(imageLayer);
     };

--- a/src/Editor/customBackground.js
+++ b/src/Editor/customBackground.js
@@ -147,12 +147,16 @@ export const vectorLayerFromGeoJSON = (geojson) =>
 // PMTiles) is session-only, so it never round-trips through here.
 export const rebuildPersistedBackground = (saved) => {
   if (!saved) return null;
+  // `persisted` marks a background restored from a saved doc/scenario (vs a fresh
+  // upload) so the OlMap effect doesn't re-emit it back into the document and mark
+  // it dirty on open — which would trigger an autosave and create a stray doc.
   if (saved.kind === "vector") {
-    return { kind: "vector", layer: vectorLayerFromGeoJSON(saved.geojson) };
+    return { kind: "vector", persisted: true, layer: vectorLayerFromGeoJSON(saved.geojson) };
   }
   if (saved.kind === "image") {
     return {
       kind: "image",
+      persisted: true,
       url: saved.dataUrl,
       dataUrl: saved.dataUrl,
       aspect: saved.aspect || 1,

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -1900,7 +1900,16 @@ const LibraryTopBar = () => {
               downloadScenarioJsonAsset(scenario.id, "regionsGeojson"),
               downloadScenarioJsonAsset(scenario.id, "citiesGeojson"),
               downloadScenarioJsonAsset(scenario.id, "colors"),
-            ]).then(([regions, cities, colors]) => {
+              // The custom map background so re-opening the editor restores it.
+              world.background?.kind ? downloadScenarioJsonAsset(scenario.id, "backgroundData") : Promise.resolve(null),
+            ]).then(([regions, cities, colors, bgData]) => {
+              const bgDesc = world.background;
+              const background =
+                bgDesc?.kind === "image" && bgData?.dataUrl
+                  ? { kind: "image", dataUrl: bgData.dataUrl }
+                  : bgDesc?.kind === "vector" && bgData?.geojson
+                    ? { kind: "vector", geojson: bgData.geojson }
+                    : null;
               setMapEditorSeed({
                 name: scenario.name || "",
                 author: world.author || "",
@@ -1908,6 +1917,7 @@ const LibraryTopBar = () => {
                 regions: regions && Array.isArray(regions.features) && regions.features.length ? regions : null,
                 cities: cities && Array.isArray(cities.features) ? cities : null,
                 colors: colors && typeof colors === "object" && !Array.isArray(colors) ? colors : null,
+                background,
               });
             });
           }

--- a/src/Game/Map/World.jsx
+++ b/src/Game/Map/World.jsx
@@ -34,24 +34,44 @@ const SATELLITE_PAINT = {
   "raster-brightness-max": 0.78,
 };
 
-// Full-world image corners (TL, TR, BR, BL) — a custom map stretches across the
-// whole mercator world so it fully replaces Earth.
-const WORLD_IMAGE_COORDS = [
+// Full-map image corners (TL, TR, BR, BL). The flat mercator map only reaches
+// ±85.0511° (the projection limit), but the globe shows all the way to the poles
+// — so on the globe the image stretches nearly to ±90° to cover the pole caps.
+// NOT exactly ±90: mercatorYfromLat(±90) is ±Infinity, which makes MapLibre's
+// ImageSource.setCoordinates throw — so we stop a hair short (the custom-bg-base
+// layer fills the negligible remaining sliver).
+const WORLD_IMAGE_COORDS_FLAT = [
   [-180, 85.0511],
   [180, 85.0511],
   [180, -85.0511],
   [-180, -85.0511],
 ];
+const WORLD_IMAGE_COORDS_GLOBE = [
+  [-180, 89.9],
+  [180, 89.9],
+  [180, -89.9],
+  [-180, -89.9],
+];
 
-const buildWorldStyle = (basemapId, customBg, backgroundDeclared) => {
+const buildWorldStyle = (basemapId, customBg, backgroundDeclared, isGlobe) => {
   // A custom uploaded map replaces the ESRI basemap entirely — no satellite or
   // terrain tiles load at all (saves those requests), the uploaded map is the
   // base layer, and the regions/labels from <Nations> paint on top of it.
   if (customBg?.kind === "image" && customBg.imageUrl) {
     return {
       version: 8,
-      sources: { "custom-bg": { type: "image", url: customBg.imageUrl, coordinates: WORLD_IMAGE_COORDS } },
-      layers: [{ id: "custom-bg-layer", type: "raster", source: "custom-bg", paint: { "raster-fade-duration": 0 } }],
+      sources: {
+        "custom-bg": {
+          type: "image",
+          url: customBg.imageUrl,
+          coordinates: isGlobe ? WORLD_IMAGE_COORDS_GLOBE : WORLD_IMAGE_COORDS_FLAT,
+        },
+      },
+      layers: [
+        // Solid base beneath the image so no edge/pole ever shows a transparent hole.
+        { id: "custom-bg-base", type: "background", paint: { "background-color": "#0b1a2b" } },
+        { id: "custom-bg-layer", type: "raster", source: "custom-bg", paint: { "raster-fade-duration": 0 } },
+      ],
       sky: { "atmosphere-blend": 0 },
     };
   }
@@ -154,12 +174,11 @@ function World({ mapRef, projection, terrainEnabled, onInitialIdle }) {
   // `declared` flips on from the light world.json poll (before the heavy payload)
   // so the map drops ESRI immediately rather than flashing satellite Earth.
   const { background: customBg, declared: bgDeclared } = useCustomBackground();
-  const worldStyle = useMemo(
-    () => buildWorldStyle(DEFAULT_BASEMAP_ID, customBg, bgDeclared),
-    [customBg, bgDeclared],
-  );
-
   const isGlobe = projection === "globe";
+  const worldStyle = useMemo(
+    () => buildWorldStyle(DEFAULT_BASEMAP_ID, customBg, bgDeclared, isGlobe),
+    [customBg, bgDeclared, isGlobe],
+  );
   // Earth's terrain DEM has no meaning over a custom map, and its source is dropped
   // from the style, so disable 3D terrain whenever a custom background is active.
   const terrain = useMemo(


### PR DESCRIPTION
Follow-up to #170 (merged). Fixes the two bugs just reported. Targets **`alpha`**; applies only these fixes on top of what's merged.

## 1. Two holes at the globe's poles
On the globe the custom image only reached ±85.05° (the flat-map mercator limit), so the two pole caps showed through. Now:
- On the globe the image stretches to **±89.9°** (flat map keeps ±85.0511°), and a **solid base layer** sits beneath the image so a pole can never show a transparent hole.
- **Not** ±90° — `mercatorYfromLat(±90)` is ±Infinity, which makes MapLibre's `ImageSource.setCoordinates` throw and drop the image entirely. (Caught by adversarial review before shipping; ±89.9 is finite and valid.)

## 2. Re-opening the map editor lost the chosen background
The **scenario** "Edit map" reopen path never loaded the background: `onOpenMapEditor` fetched regions/cities/colors but not the `backgroundData` asset, and the editor's hydration effect never restored it. Now:
- The seed fetches `backgroundData`, the hydration restores the background, and it's written into the doc metadata so **Apply & Play re-persists it** instead of clearing the scenario's background on re-apply.
- Restored backgrounds are marked `persisted` so the editor renders them **without** re-emitting into the document — which was dirtying the doc on open and auto-creating a stray editor document each time.

## Verification
Built + linted clean.
- ✅ **Standalone reopen** (live): re-opening a saved doc with an 11 MB image restores it (image at z5, full-world, ESRI off, regions on top), status stays **"All saved"**, and **no stray document** is created.
- ✅ Globe coordinate math verified (±89.9 → finite mercator Y, valid tile id; ±90 → throws).
- 🔍 5-lens adversarial review with verification → 2 confirmed findings, both fixed here (the ±90 throw, the stray-doc autosave).
- ⚠️ The headless preview can't **paint** the globe (WebGL render loop paused when backgrounded), so the pole coverage is best confirmed hands-on — but it now renders (no throw) and the base layer guarantees no hole.
