### PR TITLE
feat(editor): basemap picker — built-in + your basemaps + community

### DIFF
--- a/server/basemapStore.js
+++ b/server/basemapStore.js
@@ -1,0 +1,159 @@
+/*!
+ * Open Historia — basemap library store.
+ * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
+ */
+
+// Persistence for the user's basemap library ("Your basemaps" in the editor's
+// basemap picker). Mirrors the mapEditorStore idioms and is fully self-contained.
+// Each basemap is split into a light metadata file (listed in the picker — it
+// carries a small thumbnail data URL) and a heavy payload file (the full image
+// data URL or vector GeoJSON, fetched only when a basemap is applied). A
+// content hash dedupes identical uploads (and later lets a scenario reference a
+// community basemap instead of re-embedding it).
+
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import url from "url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, "data");
+const BASEMAPS_DIR = path.join(DATA_DIR, "basemaps");
+const MANIFEST_PATH = path.join(DATA_DIR, "basemaps-manifest.json");
+
+const ensureDir = (dir) => {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+};
+
+const readJson = (target, fallback) => {
+  try {
+    return JSON.parse(fs.readFileSync(target, "utf8"));
+  } catch {
+    return fallback;
+  }
+};
+
+const writeJson = (target, value) => {
+  ensureDir(path.dirname(target));
+  fs.writeFileSync(target, JSON.stringify(value));
+};
+
+const normalizeId = (raw, fallback = "basemap") => {
+  const base = String(raw ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return base || fallback;
+};
+
+const metaPath = (id) => path.join(BASEMAPS_DIR, `${id}.json`);
+const payloadPath = (id) => path.join(BASEMAPS_DIR, `${id}.payload.json`);
+
+const getManifest = () => {
+  const m = readJson(MANIFEST_PATH, null);
+  return m && Array.isArray(m.order)
+    ? { version: 1, order: m.order, byHash: m.byHash || {} }
+    : { version: 1, order: [], byHash: {} };
+};
+
+const saveManifest = (manifest) => {
+  writeJson(MANIFEST_PATH, {
+    version: 1,
+    order: Array.from(new Set(manifest.order ?? [])),
+    byHash: manifest.byHash ?? {},
+  });
+};
+
+const uniqueId = (desired) => {
+  let id = desired;
+  let n = 2;
+  while (fs.existsSync(metaPath(id))) id = `${desired}-${n++}`;
+  return id;
+};
+
+export const ensureBasemapStore = () => {
+  ensureDir(BASEMAPS_DIR);
+  if (!fs.existsSync(MANIFEST_PATH)) saveManifest({ order: [], byHash: {} });
+};
+
+// The catalog is the light metadata files in manifest order (no heavy payloads).
+export const getBasemapCatalog = () => {
+  const manifest = getManifest();
+  return manifest.order.map((id) => readJson(metaPath(id), null)).filter(Boolean);
+};
+
+export const getBasemapMeta = (id) => readJson(metaPath(id), null);
+
+export const getBasemapPayload = (id) => {
+  const payload = readJson(payloadPath(id), null);
+  if (!payload) throw new Error(`Basemap payload not found: ${id}`);
+  return payload;
+};
+
+export const findBasemapIdByHash = (hash) => {
+  if (!hash) return null;
+  const manifest = getManifest();
+  const id = manifest.byHash[hash];
+  return id && fs.existsSync(metaPath(id)) ? id : null;
+};
+
+// Hash the payload so identical basemaps dedupe. Prefer a client-supplied hash
+// (it already computed one for the community-dedup check) but verify shape.
+const hashPayload = (payload, supplied) => {
+  if (typeof supplied === "string" && /^[a-f0-9]{16,64}$/i.test(supplied)) return supplied.toLowerCase();
+  const canonical = payload?.dataUrl ?? JSON.stringify(payload?.geojson ?? payload ?? null);
+  return crypto.createHash("sha256").update(String(canonical)).digest("hex");
+};
+
+export const createBasemap = (body = {}) => {
+  ensureBasemapStore();
+  const kind = body.kind === "vector" ? "vector" : "image";
+  const payload = body.payload && typeof body.payload === "object" ? body.payload : null;
+  if (!payload || (kind === "image" && !payload.dataUrl) || (kind === "vector" && !payload.geojson)) {
+    throw new Error("Basemap payload missing (need { dataUrl } for image or { geojson } for vector).");
+  }
+  const contentHash = hashPayload(payload, body.contentHash);
+
+  // Dedup: an identical basemap already in the library is reused, not duplicated.
+  const existingId = findBasemapIdByHash(contentHash);
+  if (existingId) return getBasemapMeta(existingId);
+
+  const now = new Date().toISOString();
+  const name = String(body.name || "Custom basemap").trim().slice(0, 80) || "Custom basemap";
+  const id = uniqueId(normalizeId(body.id || name));
+  const meta = {
+    id,
+    name,
+    kind,
+    contentHash,
+    aspect: Number(body.aspect) > 0 ? Number(body.aspect) : null,
+    author: String(body.author || "").slice(0, 80),
+    thumbnail: typeof body.thumbnail === "string" ? body.thumbnail : null,
+    // A community basemap this was installed from (set later by the community
+    // import flow) so re-publishing a scenario can reference it instead of re-upload.
+    source: body.source && typeof body.source === "object" ? body.source : null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeJson(metaPath(id), meta);
+  writeJson(payloadPath(id), kind === "image" ? { dataUrl: payload.dataUrl } : { geojson: payload.geojson });
+
+  const manifest = getManifest();
+  manifest.order = [id, ...manifest.order.filter((x) => x !== id)];
+  manifest.byHash[contentHash] = id;
+  saveManifest(manifest);
+  return meta;
+};
+
+export const deleteBasemap = (id) => {
+  const meta = getBasemapMeta(id);
+  if (fs.existsSync(metaPath(id))) fs.rmSync(metaPath(id));
+  if (fs.existsSync(payloadPath(id))) fs.rmSync(payloadPath(id));
+  const manifest = getManifest();
+  manifest.order = manifest.order.filter((x) => x !== id);
+  if (meta?.contentHash && manifest.byHash[meta.contentHash] === id) delete manifest.byHash[meta.contentHash];
+  saveManifest(manifest);
+  return { id, deleted: true };
+};

--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -1999,6 +1999,9 @@ const exportScenarioBundle = (scenarioId, { mode = "light" } = {}) => {
       regions: buildScenarioBundleAsset(scenarioId, "regions", mode),
       regionsGeojson: buildScenarioBundleAsset(scenarioId, "regionsGeojson", mode),
       citiesGeojson: buildScenarioBundleAsset(scenarioId, "citiesGeojson", mode),
+      // The custom map background travels with the scenario (always embedded, like
+      // the geometry) so a shared/imported custom map isn't blank.
+      backgroundData: buildScenarioBundleAsset(scenarioId, "backgroundData", mode),
     },
     data: {
       actions: cloneJson(details.data.actions),

--- a/server/server.js
+++ b/server/server.js
@@ -39,6 +39,13 @@ import {
   getMapEditorDocument,
   updateMapEditorDocument,
 } from "./mapEditorStore.js";
+import {
+  createBasemap,
+  deleteBasemap,
+  ensureBasemapStore,
+  getBasemapCatalog,
+  getBasemapPayload,
+} from "./basemapStore.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const app = express();
@@ -70,6 +77,7 @@ app.use((req, res, next) => {
 ensureScenarioStore();
 ensureGameStore();
 ensureMapEditorStore();
+ensureBasemapStore();
 
 const sendError = (res, statusCode, error) => {
   const message = error instanceof Error ? error.message : String(error);
@@ -561,6 +569,39 @@ app.put("/api/mapeditor/documents/:id", largeJsonParser, (req, res) => {
 app.delete("/api/mapeditor/documents/:id", (req, res) => {
   try {
     res.json(deleteMapEditorDocument(req.params.id));
+  } catch (error) {
+    sendError(res, 400, error);
+  }
+});
+
+// ---- Basemap library ("Your basemaps") -----------------------------------
+app.get("/api/basemaps", (_req, res) => {
+  try {
+    res.json(getBasemapCatalog());
+  } catch (error) {
+    sendError(res, 500, error);
+  }
+});
+
+app.post("/api/basemaps", largeJsonParser, (req, res) => {
+  try {
+    res.status(201).json(createBasemap(req.body ?? {}));
+  } catch (error) {
+    sendError(res, 400, error);
+  }
+});
+
+app.get("/api/basemaps/:id/payload", (req, res) => {
+  try {
+    res.json(getBasemapPayload(req.params.id));
+  } catch (error) {
+    sendError(res, 404, error);
+  }
+});
+
+app.delete("/api/basemaps/:id", (req, res) => {
+  try {
+    res.json(deleteBasemap(req.params.id));
   } catch (error) {
     sendError(res, 400, error);
   }

--- a/src/Editor/BasemapPicker.jsx
+++ b/src/Editor/BasemapPicker.jsx
@@ -1,0 +1,268 @@
+/*!
+ * Open Historia Map Editor — basemap picker overlay.
+ * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
+ */
+
+// A Netflix-style overlay (matching the game's Community hub look) for choosing
+// the editor basemap: a "Built-in maps" shelf of ESRI presets (previewed by their
+// whole-world z0 tile), a "Your basemaps" shelf of the user's uploaded basemaps
+// (server-side library, thumbnailed), and a Community tab (filled in Phase 2).
+
+import { useEffect, useState } from "react";
+import { EDITOR_BASEMAPS, esriPreviewUrl } from "./basemaps.js";
+import { BACKGROUND_ACCEPT } from "./customBackground.js";
+import { listBasemaps, deleteBasemap as deleteBasemapApi } from "../runtime/basemapLibrary.js";
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  zIndex: 120,
+  background: "rgba(4,6,14,0.74)",
+  backdropFilter: "blur(4px)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "1.5rem",
+};
+
+const panel = {
+  width: "min(66rem, 96vw)",
+  maxHeight: "88vh",
+  display: "flex",
+  flexDirection: "column",
+  background: "rgba(14,18,32,0.98)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "18px",
+  color: "#fff",
+  boxShadow: "0 24px 80px rgba(0,0,0,0.55)",
+  overflow: "hidden",
+};
+
+const headerBar = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.6rem",
+  padding: "0.85rem 1.1rem",
+  borderBottom: "1px solid rgba(255,255,255,0.08)",
+};
+
+const bodyBox = { padding: "1.1rem", overflowY: "auto" };
+
+const cardSurface = {
+  background: "rgba(255,255,255,0.04)",
+  border: "1px solid rgba(255,255,255,0.09)",
+  borderRadius: "14px",
+  overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
+  flex: "0 0 12.5rem",
+  cursor: "pointer",
+};
+
+const rowTitle = { color: "rgba(255,255,255,0.9)", fontSize: "0.95rem", fontWeight: 800, margin: "0 0 0.6rem" };
+const rowScroll = { display: "flex", gap: "0.8rem", overflowX: "auto", paddingBottom: "0.4rem", scrollbarWidth: "thin" };
+const dim = { color: "rgba(255,255,255,0.4)", fontSize: "0.82rem", padding: "0.3rem 0 0.7rem" };
+
+const tabBtn = (active) => ({
+  background: active ? "rgba(124,58,237,0.35)" : "rgba(255,255,255,0.06)",
+  border: active ? "1px solid rgba(124,58,237,0.6)" : "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "999px",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: "0.8rem",
+  fontWeight: 700,
+  padding: "0.32rem 0.9rem",
+});
+
+const uploadBtn = {
+  alignItems: "center",
+  background: "rgba(59,130,246,0.85)",
+  border: "1px solid rgba(147,197,253,0.5)",
+  borderRadius: "999px",
+  color: "#fff",
+  cursor: "pointer",
+  display: "inline-flex",
+  fontSize: "0.8rem",
+  fontWeight: 700,
+  gap: "0.35rem",
+  padding: "0.34rem 0.9rem",
+};
+
+const closeBtn = {
+  background: "rgba(255,255,255,0.06)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "999px",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: "0.85rem",
+  fontWeight: 700,
+  height: "2rem",
+  width: "2rem",
+};
+
+const BasemapCard = ({ title, imageUrl, active, badge, onClick, onDelete }) => (
+  <div
+    style={{ ...cardSurface, outline: active ? "2px solid #7c3aed" : "none", outlineOffset: "-2px" }}
+    onClick={onClick}
+    title={title}
+  >
+    <div style={{ position: "relative", aspectRatio: "3 / 2", background: "#0b1020" }}>
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt=""
+          loading="lazy"
+          onError={(e) => { e.currentTarget.style.visibility = "hidden"; }}
+          style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+        />
+      ) : (
+        <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", fontSize: "1.6rem", opacity: 0.5 }}>
+          🗺️
+        </div>
+      )}
+      {badge && (
+        <span style={{ position: "absolute", left: 6, top: 6, background: "rgba(0,0,0,0.55)", borderRadius: "6px", fontSize: "0.6rem", fontWeight: 700, letterSpacing: "0.04em", padding: "0.1rem 0.35rem", textTransform: "uppercase" }}>
+          {badge}
+        </span>
+      )}
+      {active && (
+        <span style={{ position: "absolute", right: 6, top: 6, background: "rgba(124,58,237,0.9)", borderRadius: "999px", fontSize: "0.62rem", fontWeight: 700, padding: "0.1rem 0.4rem" }}>
+          ✓ In use
+        </span>
+      )}
+      {onDelete && (
+        <button
+          type="button"
+          title="Remove from your basemaps"
+          onClick={(e) => { e.stopPropagation(); onDelete(); }}
+          style={{ position: "absolute", right: 6, bottom: 6, background: "rgba(0,0,0,0.6)", border: "1px solid rgba(255,255,255,0.2)", borderRadius: "999px", color: "#fff", cursor: "pointer", fontSize: "0.7rem", height: "1.5rem", width: "1.5rem", lineHeight: 1 }}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+    <div style={{ padding: "0.5rem 0.6rem", fontSize: "0.8rem", fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+      {title}
+    </div>
+  </div>
+);
+
+const BasemapPicker = ({
+  open,
+  onClose,
+  currentBasemap,
+  currentCustomId,
+  onSelectBuiltin,
+  onSelectCustom,
+  onUpload,
+}) => {
+  const [tab, setTab] = useState("mine"); // mine | community
+  const [mine, setMine] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = () => {
+    setLoading(true);
+    listBasemaps().then((list) => setMine(Array.isArray(list) ? list : [])).finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleUpload = async (file) => {
+    if (!file) return;
+    setBusy(true);
+    try {
+      await onUpload(file);
+      refresh();
+    } catch (e) {
+      window.alert(`Could not add that basemap: ${e?.message || e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    await deleteBasemapApi(id).catch(() => {});
+    refresh();
+  };
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={panel} onClick={(e) => e.stopPropagation()}>
+        <div style={headerBar}>
+          <div style={{ fontSize: "1.05rem", fontWeight: 800, marginRight: "0.4rem" }}>Basemaps</div>
+          <button type="button" style={tabBtn(tab === "mine")} onClick={() => setTab("mine")}>My Basemaps</button>
+          <button type="button" style={tabBtn(tab === "community")} onClick={() => setTab("community")}>Community</button>
+          <div style={{ flex: 1 }} />
+          <label style={uploadBtn}>
+            {busy ? "Uploading…" : "⬆ Upload basemap"}
+            <input
+              type="file"
+              accept={BACKGROUND_ACCEPT}
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                e.target.value = "";
+                handleUpload(f);
+              }}
+            />
+          </label>
+          <button type="button" style={closeBtn} onClick={onClose} title="Close">✕</button>
+        </div>
+
+        <div style={bodyBox}>
+          {tab === "mine" ? (
+            <>
+              <div style={{ marginBottom: "1.3rem" }}>
+                <div style={rowTitle}>Built-in maps</div>
+                <div style={rowScroll}>
+                  {EDITOR_BASEMAPS.map((b) => (
+                    <BasemapCard
+                      key={b.id}
+                      title={b.label}
+                      imageUrl={esriPreviewUrl(b.service)}
+                      active={!currentCustomId && currentBasemap === b.id}
+                      onClick={() => { onSelectBuiltin(b.id); onClose(); }}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div style={rowTitle}>Your basemaps</div>
+                {loading ? (
+                  <div style={dim}>Loading…</div>
+                ) : mine.length === 0 ? (
+                  <div style={dim}>No uploaded basemaps yet — use “⬆ Upload basemap” to add your own map image (it stays here so you can reuse it on any map).</div>
+                ) : (
+                  <div style={rowScroll}>
+                    {mine.map((bm) => (
+                      <BasemapCard
+                        key={bm.id}
+                        title={bm.name}
+                        imageUrl={bm.thumbnail}
+                        active={currentCustomId === bm.id}
+                        badge={bm.kind === "vector" ? "vector" : undefined}
+                        onClick={() => { onSelectCustom(bm); onClose(); }}
+                        onDelete={() => handleDelete(bm.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <div style={{ ...dim, padding: "2.5rem 1rem", textAlign: "center", fontSize: "0.9rem" }}>
+              🌐 Community basemaps are coming soon — browse and install basemaps shared by other players here.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BasemapPicker;

--- a/src/Editor/BasemapPicker.jsx
+++ b/src/Editor/BasemapPicker.jsx
@@ -11,7 +11,8 @@
 import { useEffect, useState } from "react";
 import { EDITOR_BASEMAPS, esriPreviewUrl } from "./basemaps.js";
 import { BACKGROUND_ACCEPT } from "./customBackground.js";
-import { listBasemaps, deleteBasemap as deleteBasemapApi } from "../runtime/basemapLibrary.js";
+import { listBasemaps, deleteBasemap as deleteBasemapApi, getBasemapPayload } from "../runtime/basemapLibrary.js";
+import { fetchCommunityBasemaps, installCommunityBasemap, publishBasemap } from "../runtime/communityBasemaps.js";
 
 const overlay = {
   position: "fixed",
@@ -100,7 +101,7 @@ const closeBtn = {
   width: "2rem",
 };
 
-const BasemapCard = ({ title, imageUrl, active, badge, onClick, onDelete }) => (
+const BasemapCard = ({ title, imageUrl, active, badge, onClick, onDelete, onPublish }) => (
   <div
     style={{ ...cardSurface, outline: active ? "2px solid #7c3aed" : "none", outlineOffset: "-2px" }}
     onClick={onClick}
@@ -129,6 +130,16 @@ const BasemapCard = ({ title, imageUrl, active, badge, onClick, onDelete }) => (
         <span style={{ position: "absolute", right: 6, top: 6, background: "rgba(124,58,237,0.9)", borderRadius: "999px", fontSize: "0.62rem", fontWeight: 700, padding: "0.1rem 0.4rem" }}>
           ✓ In use
         </span>
+      )}
+      {onPublish && (
+        <button
+          type="button"
+          title="Share this basemap to the community"
+          onClick={(e) => { e.stopPropagation(); onPublish(); }}
+          style={{ position: "absolute", left: 6, bottom: 6, background: "rgba(124,58,237,0.85)", border: "1px solid rgba(167,139,250,0.5)", borderRadius: "999px", color: "#fff", cursor: "pointer", fontSize: "0.7rem", height: "1.5rem", width: "1.5rem", lineHeight: 1 }}
+        >
+          ⤴
+        </button>
       )}
       {onDelete && (
         <button
@@ -160,15 +171,36 @@ const BasemapPicker = ({
   const [mine, setMine] = useState([]);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [community, setCommunity] = useState([]);
+  const [communityLoading, setCommunityLoading] = useState(false);
+  const [communityError, setCommunityError] = useState(null);
+  const [communityLoaded, setCommunityLoaded] = useState(false);
+  const [busyId, setBusyId] = useState(null);
 
   const refresh = () => {
     setLoading(true);
     listBasemaps().then((list) => setMine(Array.isArray(list) ? list : [])).finally(() => setLoading(false));
   };
 
+  const loadCommunity = (force = false) => {
+    setCommunityLoading(true);
+    setCommunityError(null);
+    fetchCommunityBasemaps({ force })
+      .then((p) => setCommunity(Array.isArray(p) ? p : []))
+      .catch((e) => setCommunityError(e.message))
+      .finally(() => {
+        setCommunityLoading(false);
+        setCommunityLoaded(true);
+      });
+  };
+
   useEffect(() => {
     if (open) refresh();
   }, [open]);
+
+  useEffect(() => {
+    if (open && tab === "community" && !communityLoaded) loadCommunity();
+  }, [open, tab, communityLoaded]);
 
   if (!open) return null;
 
@@ -188,6 +220,29 @@ const BasemapPicker = ({
   const handleDelete = async (id) => {
     await deleteBasemapApi(id).catch(() => {});
     refresh();
+  };
+
+  const handlePublish = async (bm) => {
+    try {
+      const payload = await getBasemapPayload(bm.id);
+      publishBasemap(bm, payload);
+    } catch (e) {
+      window.alert(`Could not prepare that basemap for publishing: ${e?.message || e}`);
+    }
+  };
+
+  const handleInstall = async (post) => {
+    if (busyId) return;
+    setBusyId(post.id);
+    try {
+      await installCommunityBasemap(post);
+      refresh();
+      setTab("mine");
+    } catch (e) {
+      window.alert(`Install failed: ${e?.message || e}`);
+    } finally {
+      setBusyId(null);
+    }
   };
 
   return (
@@ -248,6 +303,7 @@ const BasemapPicker = ({
                         badge={bm.kind === "vector" ? "vector" : undefined}
                         onClick={() => { onSelectCustom(bm); onClose(); }}
                         onDelete={() => handleDelete(bm.id)}
+                        onPublish={() => handlePublish(bm)}
                       />
                     ))}
                   </div>
@@ -255,8 +311,67 @@ const BasemapPicker = ({
               </div>
             </>
           ) : (
-            <div style={{ ...dim, padding: "2.5rem 1rem", textAlign: "center", fontSize: "0.9rem" }}>
-              🌐 Community basemaps are coming soon — browse and install basemaps shared by other players here.
+            <div>
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.7rem" }}>
+                <div style={{ ...rowTitle, margin: 0 }}>Community basemaps</div>
+                <div style={{ flex: 1 }} />
+                <a
+                  href="https://github.com/Arkniem/pax-historia-scenarios/issues?q=is%3Aissue+is%3Aopen+label%3Abasemap"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ ...tabBtn(false), textDecoration: "none" }}
+                >
+                  Open hub ↗
+                </a>
+                <button type="button" style={tabBtn(false)} onClick={() => loadCommunity(true)}>↻ Refresh</button>
+              </div>
+              {communityError && <div style={{ ...dim, color: "#fecaca" }}>{communityError}</div>}
+              {communityLoading ? (
+                <div style={dim}>Loading community basemaps…</div>
+              ) : community.length === 0 && !communityError ? (
+                <div style={dim}>No community basemaps yet — share one of yours with the ⤴ button on a “Your basemaps” card.</div>
+              ) : (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(11rem, 1fr))", gap: "0.8rem" }}>
+                  {community.map((post) => (
+                    <div key={post.id} style={{ ...cardSurface, flex: "unset", cursor: "default" }}>
+                      <div style={{ position: "relative", aspectRatio: "3 / 2", background: "#0b1020" }}>
+                        {post.coverImageUrl ? (
+                          <img
+                            src={post.coverImageUrl}
+                            alt=""
+                            loading="lazy"
+                            onError={(e) => { e.currentTarget.style.visibility = "hidden"; }}
+                            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                          />
+                        ) : (
+                          <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", fontSize: "1.6rem", opacity: 0.5 }}>🗺️</div>
+                        )}
+                        {post.kind === "vector" && (
+                          <span style={{ position: "absolute", left: 6, top: 6, background: "rgba(0,0,0,0.55)", borderRadius: "6px", fontSize: "0.6rem", fontWeight: 700, padding: "0.1rem 0.35rem", textTransform: "uppercase" }}>vector</span>
+                        )}
+                      </div>
+                      <div style={{ padding: "0.5rem 0.6rem", display: "flex", flexDirection: "column", gap: "0.4rem" }}>
+                        <div style={{ fontSize: "0.8rem", fontWeight: 700, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{post.title}</div>
+                        <div style={{ fontSize: "0.68rem", color: "rgba(255,255,255,0.5)" }}>by {post.author}</div>
+                        <button
+                          type="button"
+                          disabled={!post.bundleUrl || busyId === post.id}
+                          onClick={() => handleInstall(post)}
+                          title={post.bundleUrl ? "Install into Your basemaps" : "This post has no basemap file attached"}
+                          style={{
+                            ...tabBtn(false),
+                            background: post.bundleUrl ? "rgba(124,58,237,0.35)" : "rgba(255,255,255,0.04)",
+                            cursor: post.bundleUrl && busyId !== post.id ? "pointer" : "default",
+                            opacity: post.bundleUrl ? 1 : 0.5,
+                          }}
+                        >
+                          {busyId === post.id ? "Installing…" : "⬇ Install"}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/Editor/BottomBar.jsx
+++ b/src/Editor/BottomBar.jsx
@@ -4,19 +4,12 @@
  */
 
 // Bottom status bar: Regions / Features / Types counts (clickable to open their
-// managers), a Layers button, the reference-map (basemap) selector, the map name,
-// and the save-status dot — mirroring the official editor's bottom chrome.
+// managers), a Layers button, the Basemap picker button (opens the full basemap
+// overlay), the map name, and the save-status dot.
 
 import Icon from "./Icon.jsx";
 import { panelSurface, inputStyle } from "./editorStyles.js";
-import { EDITOR_BASEMAPS } from "./basemaps.js";
-import { BACKGROUND_ACCEPT } from "./customBackground.js";
-
-const BASEMAPS = [
-  ...EDITOR_BASEMAPS.map((b) => ({ v: b.id, l: b.label })),
-  { v: "osm", l: "OpenStreetMap" },
-  { v: "dark", l: "None (dark)" },
-];
+import { editorBasemapById } from "./basemaps.js";
 
 const SAVE = {
   saved: { color: "#22c55e", label: "All saved" },
@@ -51,10 +44,8 @@ const Chip = ({ icon, label, active, onClick }) => (
 const BottomBar = ({
   counts,
   basemap,
-  onBasemapChange,
-  onUploadBackground,
   hasCustomBackground,
-  onClearBackground,
+  onOpenBasemaps,
   name,
   onNameChange,
   saveStatus,
@@ -63,6 +54,7 @@ const BottomBar = ({
   search,
 }) => {
   const save = SAVE[saveStatus] || SAVE.saved;
+  const basemapLabel = hasCustomBackground ? "Custom" : editorBasemapById(basemap)?.label || "Basemap";
   return (
     <div
       style={{
@@ -87,48 +79,23 @@ const BottomBar = ({
 
       <div style={{ flex: 1 }} />
 
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        <Icon name="layers" size={15} style={{ opacity: 0.6 }} />
-        <select
-          value={basemap}
-          onChange={(e) => onBasemapChange(e.target.value)}
-          style={{ ...inputStyle, width: "auto", padding: "6px 8px", cursor: "pointer" }}
-        >
-          {BASEMAPS.map((b) => (
-            <option key={b.v} value={b.v} style={{ color: "#000" }}>
-              {b.l}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <label
-        title="Upload a custom background: GeoJSON, KML/KMZ, Shapefile, GeoTIFF, PMTiles, or an image (PNG/JPG/SVG)"
-        style={{ ...inputStyle, width: "auto", padding: "6px 9px", cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 5 }}
+      <button
+        type="button"
+        onClick={() => onOpenBasemaps?.()}
+        title="Choose a built-in basemap, one of your uploaded basemaps, or upload a new one"
+        style={{
+          ...inputStyle,
+          width: "auto",
+          padding: "6px 11px",
+          cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+        }}
       >
-        <Icon name="pin" size={13} style={{ opacity: 0.7 }} />
-        Upload
-        <input
-          type="file"
-          accept={BACKGROUND_ACCEPT}
-          style={{ display: "none" }}
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            e.target.value = "";
-            if (file) onUploadBackground?.(file);
-          }}
-        />
-      </label>
-      {hasCustomBackground && (
-        <button
-          type="button"
-          title="Remove the custom background"
-          onClick={() => onClearBackground?.()}
-          style={{ ...inputStyle, width: "auto", padding: "6px 9px", cursor: "pointer" }}
-        >
-          ✕
-        </button>
-      )}
+        <Icon name="layers" size={14} style={{ opacity: 0.75 }} />
+        Basemap: {basemapLabel}
+      </button>
 
       <input
         value={name}

--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -22,8 +22,10 @@ import SelectionInspector from "./SelectionInspector.jsx";
 import DocumentsMenu from "./DocumentsMenu.jsx";
 import CityPopup from "./CityPopup.jsx";
 import SearchBar from "./SearchBar.jsx";
+import BasemapPicker from "./BasemapPicker.jsx";
 import { useMapDocument, createDocument, newId } from "./useMapDocument.js";
-import { loadBackgroundFile, rebuildPersistedBackground } from "./customBackground.js";
+import { loadBackgroundFile, rebuildPersistedBackground, vectorLayerToGeoJSON } from "./customBackground.js";
+import { addBackgroundToLibrary, getBasemapPayload } from "../runtime/basemapLibrary.js";
 import { saveDocument, loadDocument, downloadJson } from "./documentIO.js";
 import { buildGameSeed } from "./exportPreset.js";
 import { panelSurface, inputStyle } from "./editorStyles.js";
@@ -40,22 +42,60 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
   const [history, setHistory] = useState({ canUndo: false, canRedo: false });
   const [applying, setApplying] = useState(false); // writing the map into the scenario
   const [cityPopup, setCityPopup] = useState(null); // {id, x, y, isNew} — inline city editor
-  const [customBg, setCustomBg] = useState(null); // live uploaded background descriptor
+  const [customBg, setCustomBg] = useState(null); // live background applied to the map
+  const [customBgId, setCustomBgId] = useState(null); // library basemap id applied (null = built-in / doc's own)
+  const [basemapPickerOpen, setBasemapPickerOpen] = useState(false);
 
   const togglePanel = (name) => setOpenPanel((cur) => (cur === name ? null : name));
 
-  const uploadBackground = async (file) => {
-    if (!file) return;
+  // An OpenLayers-loaded background in the persistable form the library stores.
+  const normalizeBackground = (bg) => {
+    if (bg?.kind === "image" && bg.dataUrl) return { kind: "image", dataUrl: bg.dataUrl, aspect: bg.aspect };
+    if (bg?.kind === "vector" && bg.layer) return { kind: "vector", geojson: vectorLayerToGeoJSON(bg.layer) };
+    return null;
+  };
+
+  // Pick a built-in ESRI preset: drop any custom background so the preset shows.
+  const selectBuiltinBasemap = (id) => {
+    d.setBasemap(id);
+    setCustomBg(null);
+    setCustomBgId(null);
+    d.patchMetadata({ customBackground: null });
+  };
+
+  // Pick one of the user's saved basemaps: fetch its payload and apply it.
+  const selectLibraryBasemap = async (bm) => {
     try {
-      setCustomBg(await loadBackgroundFile(file));
+      const payload = await getBasemapPayload(bm.id);
+      const saved =
+        bm.kind === "vector"
+          ? { kind: "vector", geojson: payload.geojson }
+          : { kind: "image", dataUrl: payload.dataUrl, aspect: bm.aspect };
+      setCustomBg(rebuildPersistedBackground(saved, { persisted: false }));
+      setCustomBgId(bm.id);
     } catch (e) {
-      console.warn("[editor] background upload failed:", e);
-      window.alert(`Could not load that background: ${e?.message || e}`);
+      window.alert(`Could not load that basemap: ${e?.message || e}`);
     }
   };
-  const clearBackground = () => {
-    setCustomBg(null);
-    d.patchMetadata({ customBackground: null });
+
+  // Upload a new basemap: apply it now AND save it to the library for reuse.
+  const uploadBasemap = async (file) => {
+    if (!file) return;
+    const bg = await loadBackgroundFile(file);
+    setCustomBg(bg); // applies immediately (image / vector / raster)
+    const normalized = normalizeBackground(bg);
+    if (!normalized) {
+      setCustomBgId(null); // raster (GeoTIFF/PMTiles) is session-only reference, not saved
+      return;
+    }
+    const name = file.name ? file.name.replace(/\.[^.]+$/, "") : "Custom basemap";
+    try {
+      const meta = await addBackgroundToLibrary(normalized, name, { author: d.author || "" });
+      setCustomBgId(meta?.id || null);
+    } catch (e) {
+      console.warn("[editor] save basemap to library failed:", e);
+      setCustomBgId(null);
+    }
   };
 
   const buildPayload = () => ({
@@ -102,6 +142,7 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     if (kind === "blank") api?.loadRegions({ type: "FeatureCollection", features: [] });
     else api?.reseedWorld();
     setCustomBg(null);
+    setCustomBgId(null);
     d.setSaveStatus("saved");
   };
 
@@ -118,6 +159,7 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
       });
       api?.loadRegions(doc.regions);
       setCustomBg(rebuildPersistedBackground(doc.metadata?.customBackground));
+      setCustomBgId(null);
       setDocId(doc.id);
       d.setSaveStatus("saved");
     } catch (e) {
@@ -169,6 +211,7 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     // shows the uploaded map, not a blank basemap. It's marked persisted, so the
     // OlMap effect renders it without re-emitting (no dirty/autosave on open).
     setCustomBg(initialMap.background ? rebuildPersistedBackground(initialMap.background) : null);
+    setCustomBgId(null);
     d.setSaveStatus("saved");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, initialMap]);
@@ -388,10 +431,8 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
       <BottomBar
         counts={d.counts}
         basemap={d.basemap}
-        onBasemapChange={d.setBasemap}
-        onUploadBackground={uploadBackground}
         hasCustomBackground={Boolean(customBg)}
-        onClearBackground={clearBackground}
+        onOpenBasemaps={() => setBasemapPickerOpen(true)}
         name={d.name}
         onNameChange={d.setName}
         saveStatus={d.saveStatus}
@@ -422,6 +463,16 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
             }}
           />
         }
+      />
+
+      <BasemapPicker
+        open={basemapPickerOpen}
+        onClose={() => setBasemapPickerOpen(false)}
+        currentBasemap={d.basemap}
+        currentCustomId={customBgId}
+        onSelectBuiltin={selectBuiltinBasemap}
+        onSelectCustom={selectLibraryBasemap}
+        onUpload={uploadBasemap}
       />
     </div>
   );

--- a/src/Editor/basemaps.js
+++ b/src/Editor/basemaps.js
@@ -22,3 +22,8 @@ export const editorBasemapById = (id) => EDITOR_BASEMAPS.find((b) => b.id === id
 // so these render without reprojection.
 export const esriXyzUrl = (service) =>
   `https://server.arcgisonline.com/ArcGIS/rest/services/${service}/MapServer/tile/{z}/{y}/{x}`;
+
+// The z0 tile is the whole world in a single ~20 KB image — a perfect low-res
+// preview for the basemap picker (no extra generation, cached by the browser).
+export const esriPreviewUrl = (service) =>
+  `https://server.arcgisonline.com/ArcGIS/rest/services/${service}/MapServer/tile/0/0/0`;

--- a/src/Editor/customBackground.js
+++ b/src/Editor/customBackground.js
@@ -145,18 +145,19 @@ export const vectorLayerFromGeoJSON = (geojson) =>
 // Rebuild a live background descriptor from what was saved in the document
 // (vector GeoJSON, or an image data URL + WGS84 placement). Raster (GeoTIFF/
 // PMTiles) is session-only, so it never round-trips through here.
-export const rebuildPersistedBackground = (saved) => {
+// `persisted` (default true) marks a background restored from a saved doc/scenario
+// so the OlMap effect renders it WITHOUT re-emitting it into the document (which
+// would dirty it and trigger a stray autosave). Pass persisted:false when the user
+// deliberately picks a basemap — that IS an edit and should save.
+export const rebuildPersistedBackground = (saved, { persisted = true } = {}) => {
   if (!saved) return null;
-  // `persisted` marks a background restored from a saved doc/scenario (vs a fresh
-  // upload) so the OlMap effect doesn't re-emit it back into the document and mark
-  // it dirty on open — which would trigger an autosave and create a stray doc.
   if (saved.kind === "vector") {
-    return { kind: "vector", persisted: true, layer: vectorLayerFromGeoJSON(saved.geojson) };
+    return { kind: "vector", persisted, layer: vectorLayerFromGeoJSON(saved.geojson) };
   }
   if (saved.kind === "image") {
     return {
       kind: "image",
-      persisted: true,
+      persisted,
       url: saved.dataUrl,
       dataUrl: saved.dataUrl,
       aspect: saved.aspect || 1,

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -16,6 +16,7 @@ import {
   useLibraryState,
 } from "../../runtime/library.js";
 import { enqueueStrings } from "../../runtime/translator.js";
+import { dedupeScenarioBundleBackground, resolveScenarioBundleBackground } from "../../runtime/communityBasemaps.js";
 
 // The one and only hub. Not configurable by design.
 const HUB_OWNER = "Arkniem";
@@ -456,6 +457,9 @@ const CommunityPanel = ({ onImported }) => {
         throw new Error(payload.error || `Download failed (HTTP ${response.status}).`);
       }
       const bundle = await response.json();
+      // A shared scenario may reference a community basemap instead of embedding
+      // it — fetch and inline it before importing so the map isn't blank.
+      await resolveScenarioBundleBackground(bundle);
       const details = await importScenarioBundle(bundle);
       // The user may have navigated to a different post's detail view while
       // this was in flight — don't attribute this result to whatever happens
@@ -485,6 +489,9 @@ const CommunityPanel = ({ onImported }) => {
     setError(null);
     try {
       const bundle = await exportScenarioBundle(scenario.id, "light");
+      // If this scenario's custom basemap is already on the community hub,
+      // reference it instead of re-embedding the whole image (smaller bundle).
+      const dedup = await dedupeScenarioBundleBackground(bundle).catch(() => ({ referenced: false, needsPublish: false }));
       const fileName = `${scenario.id}-scenario.json`;
       saveJsonToDisk(bundle, fileName);
       window.open(
@@ -492,8 +499,13 @@ const CommunityPanel = ({ onImported }) => {
         "_blank",
         "noopener",
       );
+      const extra = dedup.referenced
+        ? " Its custom basemap was reused from the community hub, so the file stays small."
+        : dedup.needsPublish
+          ? " Tip: this map uses a custom basemap that isn't shared yet — open the editor's Basemap picker and hit ⤴ on it to publish it, so future scenarios can reuse it instead of re-bundling the image."
+          : "";
       setNotice(
-        `"${fileName}" was downloaded. On the GitHub page that just opened, drag that file into the Description box, then submit.`,
+        `"${fileName}" was downloaded. On the GitHub page that just opened, drag that file into the Description box, then submit.${extra}`,
       );
     } catch (nextError) {
       setError(`Publish failed: ${nextError.message}`);

--- a/src/runtime/basemapLibrary.js
+++ b/src/runtime/basemapLibrary.js
@@ -1,0 +1,105 @@
+/*! Open Historia — basemap library client © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Client for the server-side basemap library ("Your basemaps"). Kept free of any
+// OpenLayers/MapLibre deps so it stays light; the editor converts a library
+// basemap's payload into the map layer it needs. Thumbnails are generated small
+// so the picker can show many previews without lag.
+
+const API = "/api/basemaps";
+
+export const listBasemaps = async () => {
+  try {
+    const r = await fetch(API);
+    return r.ok ? await r.json() : [];
+  } catch {
+    return [];
+  }
+};
+
+export const getBasemapPayload = async (id) => {
+  const r = await fetch(`${API}/${encodeURIComponent(id)}/payload`);
+  if (!r.ok) throw new Error(`Basemap payload ${id}: HTTP ${r.status}`);
+  return r.json();
+};
+
+export const createBasemap = async (body) => {
+  const r = await fetch(API, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) throw new Error(`Save basemap failed: HTTP ${r.status}`);
+  return r.json();
+};
+
+export const deleteBasemap = async (id) => {
+  const r = await fetch(`${API}/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!r.ok) throw new Error(`Delete basemap failed: HTTP ${r.status}`);
+  return r.json();
+};
+
+// SHA-256 hex of a string — the basemap's content hash, used to dedupe identical
+// uploads locally and (later) to reference a matching community basemap.
+export const sha256Hex = async (str) => {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(String(str)));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+// Downscale an image data URL to a small JPEG thumbnail (low-res preview so the
+// picker can render lots of them cheaply). Returns null on failure.
+export const makeImageThumbnail = (dataUrl, maxDim = 200) =>
+  new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = Math.min(1, maxDim / Math.max(img.naturalWidth || 1, img.naturalHeight || 1));
+      const w = Math.max(1, Math.round((img.naturalWidth || 1) * scale));
+      const h = Math.max(1, Math.round((img.naturalHeight || 1) * scale));
+      try {
+        const c = document.createElement("canvas");
+        c.width = w;
+        c.height = h;
+        c.getContext("2d").drawImage(img, 0, 0, w, h);
+        resolve(c.toDataURL("image/jpeg", 0.7));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    img.src = dataUrl;
+  });
+
+// Persist a normalized background into the library. `normalized` is
+// { kind:"image", dataUrl, aspect } or { kind:"vector", geojson }. Returns the
+// stored basemap metadata (deduped server-side by content hash).
+export const addBackgroundToLibrary = async (normalized, name, extra = {}) => {
+  if (!normalized) return null;
+  if (normalized.kind === "image" && normalized.dataUrl) {
+    const [thumbnail, contentHash] = await Promise.all([
+      makeImageThumbnail(normalized.dataUrl),
+      sha256Hex(normalized.dataUrl),
+    ]);
+    return createBasemap({
+      name,
+      kind: "image",
+      aspect: normalized.aspect || null,
+      thumbnail,
+      contentHash,
+      payload: { dataUrl: normalized.dataUrl },
+      ...extra,
+    });
+  }
+  if (normalized.kind === "vector" && normalized.geojson) {
+    const contentHash = await sha256Hex(JSON.stringify(normalized.geojson));
+    return createBasemap({
+      name,
+      kind: "vector",
+      thumbnail: null,
+      contentHash,
+      payload: { geojson: normalized.geojson },
+      ...extra,
+    });
+  }
+  return null;
+};

--- a/src/runtime/communityBasemaps.js
+++ b/src/runtime/communityBasemaps.js
@@ -1,0 +1,245 @@
+/*! Open Historia — community basemaps client © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Browse + install + publish basemaps shared through the community hub. Mirrors
+// the scenario hub (src/Game/GameUI/communityHub.jsx): each community basemap is
+// a GitHub issue labeled "basemap" whose body links a bundle .json (and, ideally,
+// an attached preview image used as the card cover). A content hash in the body
+// lets a scenario reference an existing community basemap instead of re-uploading
+// it. Publishing is the same safe, token-less flow scenarios use: the app exports
+// the bundle to disk and opens a prefilled issue for the author to submit.
+
+import { createBasemap, sha256Hex } from "./basemapLibrary.js";
+
+// UTF-8-safe base64 <-> string (the scenario bundle base64-encodes the
+// background.json file bytes; plain atob/btoa mangle non-Latin1 vector data).
+const utf8ToBase64 = (str) => btoa(unescape(encodeURIComponent(str)));
+const base64ToUtf8 = (b64) => decodeURIComponent(escape(atob(b64)));
+
+const HUB_OWNER = "Arkniem";
+const HUB_REPO = "pax-historia-scenarios";
+const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
+const HUB_API_BASEMAPS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=basemap&per_page=100`;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const BUNDLE_LINK_PATTERN =
+  /https:\/\/(?:github\.com\/[^\s)<>"']+\/releases\/download\/[^\s)<>"']+\.json|github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+\.json)/i;
+const COVER_IMAGE_PATTERN = /!\[[^\]]*\]\((https:\/\/[^\s)]+)\)|<img[^>]+src=["']([^"']+)["']/i;
+const HASH_PATTERN = /Basemap-Hash:\s*([a-f0-9]{16,64})/i;
+const KIND_PATTERN = /Basemap-Kind:\s*(image|vector)/i;
+const OFFICIAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+let cache = { at: 0, posts: null };
+
+const parseBasemapPost = (issue) => {
+  const body = String(issue.body ?? "");
+  const coverMatch = body.match(COVER_IMAGE_PATTERN);
+  return {
+    id: issue.number,
+    title: String(issue.title ?? "").replace(/^\[Basemap\]\s*/i, "").trim() || `Basemap #${issue.number}`,
+    author: issue.user?.login ?? "unknown",
+    avatarUrl: issue.user?.avatar_url ?? null,
+    url: issue.html_url,
+    createdAt: issue.created_at,
+    official: OFFICIAL_ASSOCIATIONS.has(issue.author_association),
+    upvotes: issue.reactions?.["+1"] ?? 0,
+    bundleUrl: body.match(BUNDLE_LINK_PATTERN)?.[0] ?? null,
+    coverImageUrl: coverMatch ? coverMatch[1] ?? coverMatch[2] ?? null : null,
+    contentHash: body.match(HASH_PATTERN)?.[1]?.toLowerCase() ?? null,
+    kind: body.match(KIND_PATTERN)?.[1]?.toLowerCase() ?? "image",
+  };
+};
+
+export const fetchCommunityBasemaps = async ({ force = false } = {}) => {
+  if (!force && cache.posts && Date.now() - cache.at < CACHE_TTL_MS) return cache.posts;
+  const r = await fetch(HUB_API_BASEMAPS, { headers: { Accept: "application/vnd.github+json" } });
+  if (!r.ok) {
+    throw new Error(
+      r.status === 403
+        ? "GitHub rate limit reached — try again in a few minutes."
+        : `Could not reach the basemap hub (HTTP ${r.status}).`,
+    );
+  }
+  const issues = await r.json();
+  const posts = (Array.isArray(issues) ? issues : []).filter((i) => !i.pull_request).map(parseBasemapPost);
+  cache = { at: Date.now(), posts };
+  return posts;
+};
+
+// Dedup lookup — reads the issue list only (no bundle downloads), matching the
+// content hash embedded in each post body.
+export const findCommunityBasemapByHash = async (hash) => {
+  if (!hash) return null;
+  try {
+    const posts = await fetchCommunityBasemaps();
+    return posts.find((p) => p.contentHash === String(hash).toLowerCase() && p.bundleUrl) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export const fetchBasemapBundle = async (bundleUrl) => {
+  const r = await fetch(`/api/hub/file?url=${encodeURIComponent(bundleUrl)}`);
+  if (!r.ok) {
+    const p = await r.json().catch(() => ({}));
+    throw new Error(p.error || `Download failed (HTTP ${r.status}).`);
+  }
+  return r.json();
+};
+
+// Install a community basemap into the local "Your basemaps" library.
+export const installCommunityBasemap = async (post) => {
+  if (!post?.bundleUrl) throw new Error("This basemap post has no bundle file attached.");
+  const bundle = await fetchBasemapBundle(post.bundleUrl);
+  const bm = bundle?.basemap ?? {};
+  const payload = bundle?.payload ?? {};
+  const kind = bm.kind === "vector" ? "vector" : "image";
+  if ((kind === "image" && !payload.dataUrl) || (kind === "vector" && !payload.geojson)) {
+    throw new Error("That basemap bundle is missing its payload.");
+  }
+  return createBasemap({
+    name: bm.name || post.title,
+    kind,
+    aspect: bm.aspect || null,
+    thumbnail: bm.thumbnail || post.coverImageUrl || null,
+    contentHash: bm.contentHash || post.contentHash || null,
+    author: bm.author || post.author,
+    source: { community: true, hash: bm.contentHash || post.contentHash || null, bundleUrl: post.bundleUrl, url: post.url },
+    payload,
+  });
+};
+
+// The JSON bundle a published basemap ships as.
+export const buildBasemapBundle = (meta, payload) => ({
+  schema: "pax-historia-basemap-bundle",
+  version: 1,
+  basemap: {
+    name: meta.name,
+    kind: meta.kind === "vector" ? "vector" : "image",
+    aspect: meta.aspect ?? null,
+    contentHash: meta.contentHash ?? null,
+    thumbnail: meta.thumbnail ?? null,
+    author: meta.author ?? "",
+  },
+  payload,
+});
+
+const downloadFile = (blob, fileName) => {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
+const dataUrlToBlob = (dataUrl) => {
+  try {
+    const [head, b64] = String(dataUrl).split(",");
+    const mime = head.match(/data:([^;]+)/)?.[1] || "image/jpeg";
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+    return new Blob([bytes], { type: mime });
+  } catch {
+    return null;
+  }
+};
+
+// Publish: download the bundle (and a preview image to attach as the cover), then
+// open a prefilled hub issue for the author to drag the files into and submit.
+export const publishBasemap = (meta, payload) => {
+  const safe = (meta.name || "basemap").replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase() || "basemap";
+  const bundle = buildBasemapBundle(meta, payload);
+  downloadFile(new Blob([JSON.stringify(bundle)], { type: "application/json" }), `${safe}.basemap.json`);
+  if (meta.thumbnail && String(meta.thumbnail).startsWith("data:image")) {
+    const thumbBlob = dataUrlToBlob(meta.thumbnail);
+    if (thumbBlob) downloadFile(thumbBlob, `${safe}-preview.jpg`);
+  }
+  const title = `[Basemap] ${meta.name || "Untitled basemap"}`;
+  const body = [
+    `Basemap-Hash: ${meta.contentHash || ""}`,
+    `Basemap-Kind: ${meta.kind === "vector" ? "vector" : "image"}`,
+    "",
+    `Drag the downloaded **${safe}.basemap.json** into this box (and the **${safe}-preview.jpg** so it shows a preview), then submit.`,
+    "",
+    "Do not remove the two lines at the top — they let the game find and dedupe this basemap.",
+  ].join("\n");
+  window.open(
+    `${HUB_URL}/issues/new?labels=basemap&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`,
+    "_blank",
+    "noopener",
+  );
+};
+
+// ---- Scenario-bundle background dedup ------------------------------------
+// A scenario's custom background embeds the full image/vector in its bundle. If
+// that same basemap is already a community basemap, the bundle can reference it
+// (by hash) instead of re-embedding it, saving space — resolved back on import.
+
+// Decode the bundle's embedded backgroundData into { kind, payload, hash }.
+const readBundleBackground = async (bundle) => {
+  const asset = bundle?.assets?.backgroundData;
+  if (!asset || asset.mode !== "embedded" || !asset.data) return null;
+  let payload;
+  try {
+    payload = JSON.parse(base64ToUtf8(asset.data));
+  } catch {
+    return null;
+  }
+  const kind = bundle?.data?.world?.background?.kind === "vector" ? "vector" : "image";
+  const canonical = kind === "vector" ? (payload.geojson ? JSON.stringify(payload.geojson) : null) : payload.dataUrl;
+  if (!canonical) return null;
+  return { kind, payload, hash: await sha256Hex(canonical) };
+};
+
+// If the scenario's background is already a community basemap, swap the embedded
+// copy for a reference. Returns { referenced, needsPublish } (needsPublish = the
+// background is custom but not yet shared, so it can't be deduped).
+export const dedupeScenarioBundleBackground = async (bundle) => {
+  let bg = null;
+  try {
+    bg = await readBundleBackground(bundle);
+  } catch {
+    bg = null;
+  }
+  if (!bg) return { referenced: false, needsPublish: false };
+  const match = await findCommunityBasemapByHash(bg.hash);
+  if (match) {
+    bundle.assets.backgroundData = {
+      mode: "communityRef",
+      hash: bg.hash,
+      bundleUrl: match.bundleUrl,
+      fileName: "background.json",
+    };
+    return { referenced: true, needsPublish: false };
+  }
+  return { referenced: false, needsPublish: true };
+};
+
+// On import: turn a community reference back into an embedded background by
+// fetching the referenced basemap, so the server import writes it normally.
+export const resolveScenarioBundleBackground = async (bundle) => {
+  const asset = bundle?.assets?.backgroundData;
+  if (!asset || asset.mode !== "communityRef" || !asset.bundleUrl) return bundle;
+  try {
+    const bmBundle = await fetchBasemapBundle(asset.bundleUrl);
+    const payload = bmBundle?.payload;
+    if (payload && (payload.dataUrl || payload.geojson)) {
+      bundle.assets.backgroundData = {
+        mode: "embedded",
+        data: utf8ToBase64(JSON.stringify(payload)),
+        fileName: "background.json",
+        contentType: "application/json",
+      };
+    } else {
+      delete bundle.assets.backgroundData;
+    }
+  } catch {
+    // Couldn't resolve the reference — import without the background rather than
+    // failing the whole scenario import.
+    delete bundle.assets.backgroundData;
+  }
+  return bundle;
+};


### PR DESCRIPTION
Reworks the editor's basemap menu into a Netflix-style picker with built-in maps, a personal basemap library, and a community tab. Targets **`alpha`**. Two commits (picker + library, then community).

## The picker
One **"Basemap"** button opens an overlay styled like the community hub:
- **Built-in maps** shelf — the 10 ESRI presets, each previewed by its whole-world **z0 tile** (~20 KB, cached) so lots of previews render with no lag.
- **Your basemaps** shelf — basemaps you've uploaded, **stored server-side** so they persist and reuse across maps. Uploading auto-generates a small thumbnail + content hash; **identical uploads dedupe**. Cards show an "In use" marker, delete (✕), and share (⤴).
- **Community** tab — browse + install basemaps others have shared.

## Community (same safe, token-less model as scenarios)
- **Browse**: reads issues labeled `basemap` on the hub repo; **Install** pulls the bundle into Your basemaps.
- **Publish** (⤴): downloads the basemap bundle + a preview image and opens a **prefilled `basemap` issue** (content hash embedded) for you to submit — no token, no write access needed.
- **Scenario bundles now embed the custom background** (they silently dropped it before — a bug), so a shared/imported custom map isn't blank.
- **Dedup**: publishing a scenario whose basemap is already on the hub makes the bundle **reference it by hash** instead of re-embedding the image (smaller file); import resolves the reference. If it isn't shared yet, the publish notice points you to ⤴.

## Verified live (screenshots taken)
- ✅ Overlay opens; **built-in previews load** (10 × 256px whole-world tiles).
- ✅ **Upload** → thumbnail + hash + server library + applied to map; **dedup** (identical re-upload doesn't duplicate).
- ✅ **Built-in select** (Satellite) loads tiles, clears custom bg, closes overlay.
- ✅ **Community tab** fetches the hub and shows its (currently empty) state, no errors.
- ✅ **Publish** downloads `*.basemap.json` + `*-preview.jpg` and opens a `basemap`-labeled issue with `Basemap-Hash`/`Basemap-Kind`.
- ✅ **Scenario export** now includes `backgroundData` (confirmed via the export endpoint).
- ✅ Build + lint clean.

Install and the dedup-reference round-trip need a real published basemap to fully exercise (the hub has none yet), but the code mirrors the proven scenario flow and the hashing is consistent (both sides hash the same data URL).
