### PR TITLE
fix(map): stop Apply & Play flashing; carry chosen ESRI basemap into the game

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,7 +48,12 @@ function GameApp() {
     const saved = localStorage.getItem("Terrain");
     return saved !== null ? JSON.parse(saved) : true;
   });
-  const { token: libraryToken } = useLibraryState();
+  // Key the map/UI on the active GAME id, not the library token. The token also
+  // bumps on scenario/asset writes, so Apply & Play (which saves the scenario and
+  // uploads several assets before activating the new game) would otherwise remount
+  // the map ~8 times — the repeated flashing/reloading. The game id changes once,
+  // when the new game activates, so the map remounts exactly once.
+  const { activeGameId } = useLibraryState();
 
   useEffect(() => {
     localStorage.setItem("Globe", JSON.stringify(isGlobeEnabled));
@@ -160,7 +165,7 @@ function GameApp() {
     <>
     <div style={WorldShell}>
     <Map
-    key={`map-${libraryToken || "default"}`}
+    key={`map-${activeGameId || "default"}`}
     mapRef={mapRef}
     projection={isGlobeEnabled ? "globe" : "mercator"}
     terrainEnabled={isTerrainEnabled}
@@ -170,7 +175,7 @@ function GameApp() {
     </div>
     {isReady && (
       <UI
-      key={`ui-${libraryToken || "default"}`}
+      key={`ui-${activeGameId || "default"}`}
       isGlobeEnabled={isGlobeEnabled}
       isTerrainEnabled={isTerrainEnabled}
       mapRef={mapRef}

--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -185,6 +185,8 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     hydratedRef.current = true;
     const base = createDocument({ name: initialMap.name || "Scenario Map", kind: "import-world" });
     base.metadata.author = initialMap.author || "";
+    // Restore the chosen built-in basemap so re-opening shows it (not the default).
+    if (initialMap.basemap) base.metadata.basemap = initialMap.basemap;
     // Carry the restored background in the document metadata so Apply & Play
     // (buildGameSeed reads doc.metadata.customBackground) re-persists it instead of
     // clearing the scenario's background when the user re-opens and re-applies.

--- a/src/Editor/exportPreset.js
+++ b/src/Editor/exportPreset.js
@@ -186,6 +186,10 @@ export const buildGameSeed = (doc, regionsFC, palette = {}, { playerCode } = {})
     // clears any previously applied background. The heavy payload rides in the
     // seed's backgroundData below, uploaded as a separate scenario asset.
     background,
+    // The chosen built-in basemap (an ESRI preset id) so the game renders THAT
+    // basemap, not always the ocean default. Ignored when a custom background
+    // replaces it. Falls back to ocean in-game if unset/unknown.
+    basemap: doc.metadata?.basemap || null,
     // Authored cities replace the modern city labels. A custom-geometry map with
     // no cities still sets the flag — modern names over invented land would be
     // wrong — while a pure re-ownership map without cities keeps the stock set.

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -1466,6 +1466,8 @@ const LibraryTopBar = () => {
         // Custom map background descriptor (kind + placement); null clears it. The
         // heavy payload goes to the backgroundData asset just below.
         background: seed.world?.background ?? null,
+        // The chosen built-in basemap so the game renders it (not always ocean).
+        basemap: seed.world?.basemap ?? null,
       },
       game: {
         ...currentGame,
@@ -1918,6 +1920,7 @@ const LibraryTopBar = () => {
                 cities: cities && Array.isArray(cities.features) ? cities : null,
                 colors: colors && typeof colors === "object" && !Array.isArray(colors) ? colors : null,
                 background,
+                basemap: world.basemap || null,
               });
             });
           }

--- a/src/Game/Map/World.jsx
+++ b/src/Game/Map/World.jsx
@@ -173,11 +173,11 @@ function World({ mapRef, projection, terrainEnabled, onInitialIdle }) {
   // the world is fixed to the ocean preset (the in-game basemap picker was removed).
   // `declared` flips on from the light world.json poll (before the heavy payload)
   // so the map drops ESRI immediately rather than flashing satellite Earth.
-  const { background: customBg, declared: bgDeclared } = useCustomBackground();
+  const { background: customBg, declared: bgDeclared, basemap: worldBasemap } = useCustomBackground();
   const isGlobe = projection === "globe";
   const worldStyle = useMemo(
-    () => buildWorldStyle(DEFAULT_BASEMAP_ID, customBg, bgDeclared, isGlobe),
-    [customBg, bgDeclared, isGlobe],
+    () => buildWorldStyle(worldBasemap || DEFAULT_BASEMAP_ID, customBg, bgDeclared, isGlobe),
+    [customBg, bgDeclared, isGlobe, worldBasemap],
   );
   // Earth's terrain DEM has no meaning over a custom map, and its source is dropped
   // from the style, so disable 3D terrain whenever a custom background is active.

--- a/src/Game/Map/useCustomBackground.js
+++ b/src/Game/Map/useCustomBackground.js
@@ -14,8 +14,9 @@ import { JSON_URLS, readJson } from "../../runtime/assets.js";
 //     available once the payload has loaded. Its reference is kept STABLE while
 //     unchanged so the map style isn't rebuilt on every 5s poll.
 export function useCustomBackground() {
-  const [state, setState] = useState({ background: null, declared: false });
+  const [state, setState] = useState({ background: null, declared: false, basemap: null });
   const keyRef = useRef("");
+  const basemapRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -23,22 +24,30 @@ export function useCustomBackground() {
     const poll = async () => {
       const world = await readJson(JSON_URLS.world, { defaultValue: {}, force: true }).catch(() => ({}));
       if (cancelled) return;
+      // The scenario's chosen built-in basemap (an ESRI preset id) — the game
+      // renders it when there's no custom background. Rarely changes (no in-game
+      // picker), so we only re-render when it actually does.
+      const basemap = world?.basemap || null;
+      basemapRef.current = basemap;
       const desc = world?.background;
       const key = desc && desc.kind ? String(desc.kind) : "";
-      if (key === keyRef.current) return; // unchanged — keep the stable reference
+      if (key === keyRef.current) {
+        setState((s) => (s.basemap === basemap ? s : { ...s, basemap })); // keep stable ref
+        return;
+      }
       keyRef.current = key;
       if (!key) {
-        setState({ background: null, declared: false });
+        setState({ background: null, declared: false, basemap });
         return;
       }
       // Commit to "no ESRI" from the light descriptor right away, then load the
       // heavy payload and swap in the actual image/vector.
-      setState({ background: null, declared: true });
+      setState({ background: null, declared: true, basemap });
       const data = await readJson(JSON_URLS.backgroundData, { defaultValue: null, force: true }).catch(() => null);
       if (cancelled || keyRef.current !== key) return; // superseded while loading
-      if (desc.kind === "image" && data?.dataUrl) setState({ background: { kind: "image", imageUrl: data.dataUrl }, declared: true });
-      else if (desc.kind === "vector" && data?.geojson) setState({ background: { kind: "vector", geojson: data.geojson }, declared: true });
-      else setState({ background: null, declared: false });
+      if (desc.kind === "image" && data?.dataUrl) setState({ background: { kind: "image", imageUrl: data.dataUrl }, declared: true, basemap: basemapRef.current });
+      else if (desc.kind === "vector" && data?.geojson) setState({ background: { kind: "vector", geojson: data.geojson }, declared: true, basemap: basemapRef.current });
+      else setState({ background: null, declared: false, basemap: basemapRef.current });
     };
 
     poll();


### PR DESCRIPTION
Two fixes for issues reported on the map-background feature. Targets `alpha`.

## 1. Apply & Play flashed / reloaded ~8-10 times
`applyMapToScenario` saves the scenario and uploads several assets **before** activating the new game. The `<Map>`/`<UI>` were keyed on the library **token**, which bumps on every one of those writes — so the map remounted ~8 times (the flashing), and with a custom basemap each remount reloaded the image, making it very visible. Now they key on the **active game id**, which changes once (when the new game activates) → the map remounts exactly once.

## 2. A chosen built-in ESRI basemap did not carry into the game
Picking e.g. Satellite in the editor and hitting Apply & Play still showed **ocean** (the game hardcoded the default), and re-opening the editor showed ocean as if that was the selection. Now the chosen basemap flows through: buildGameSeed -> world.basemap -> the scenario -> the game (World reads world.basemap, falls back to ocean for unset/unknown), and the editor restores it on scenario hydration. Editor and game ESRI ids already match 1:1.

Verified: seed transform carries the basemap (imagery/ocean/unset); build + lint clean. In-game flashing/render is best confirmed on a real screen (the headless preview cannot run the WebGL map).