### PR TITLE
feat(hub): share basemaps as real image files + one-zip scenario bundles

### DIFF
--- a/hub-templates/README.md
+++ b/hub-templates/README.md
@@ -1,0 +1,56 @@
+# Community hub issue templates
+
+These GitHub **issue-form templates** live in the community hub repo, **not** in this
+app repo. They are kept here only as source-of-truth copies so changes are reviewed
+alongside the client code that links to them.
+
+To take effect, copy them into the hub repo:
+
+```
+Arkniem/pax-historia-scenarios/.github/ISSUE_TEMPLATE/basemap.yml
+```
+
+- **`basemap.yml`** — the "Share a basemap" form. The editor's Basemap picker links
+  to it via `…/issues/new?template=basemap.yml`. The form declares `labels: [basemap]`,
+  which is applied for every submitter (a `?labels=` URL param is silently dropped for
+  users without push access — the form is the reliable way to label community posts).
+
+  **One-time setup:** create a label named exactly `basemap` in the hub repo (Issues →
+  Labels → New label). A form can only apply a label that already exists; without it the
+  posts submit unlabeled and the editor's Community → Basemaps tab (which queries
+  `labels=basemap`) stays empty.
+
+The existing `scenario.yml` already lives in the hub repo. Its file-drop field also
+accepts the new `.zip` bundle a scenario with a custom basemap now downloads — no change
+required, though you may want to reword its help text to mention "(.json or .zip)".
+
+## Basemaps carried by scenarios
+
+The editor's Community → Basemaps browser lists **two** sources:
+
+1. Dedicated `basemap`-labeled posts (from `basemap.yml`).
+2. `scenario`-labeled posts whose bundle is a **`.zip`** — a zip scenario carries a
+   custom basemap, so the browser surfaces it as a "from scenario" basemap and installs
+   it by extracting `basemap.<ext>` from that zip. **No second upload is needed** — sharing
+   the scenario is enough to make its basemap browsable.
+
+**Optional (recommended) `scenario.yml` tweak for dedup:** add a hidden-ish textarea so a
+scenario post can record its basemap hash — then a basemap shared via a scenario dedupes
+against a dedicated basemap post (shown once) and can be referenced by future scenarios.
+Add this field to `scenario.yml` (the app already prefills it):
+
+```yaml
+  - type: textarea
+    id: technical
+    attributes:
+      label: Technical info (do not edit)
+      description: Auto-filled when the scenario has a custom basemap. Lets the game dedupe it.
+      value: |
+        Basemap-Hash:
+        Basemap-Kind: image
+    validations:
+      required: false
+```
+
+Without this field everything still works; scenario-carried basemaps just can't be deduped
+(they may appear alongside an identical dedicated post).

--- a/hub-templates/basemap.yml
+++ b/hub-templates/basemap.yml
@@ -1,0 +1,43 @@
+name: Basemap
+description: Share a custom map background others can use in the map editor.
+title: "[Basemap] "
+labels: ["basemap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a basemap! **Drag your image file into the "Basemap image" box below** — that image is both the map itself and the preview shown in the community grid.
+
+        The two lines under **Technical info** are filled in for you. Please don't edit them — they let the game find and dedupe this basemap.
+  - type: input
+    id: name
+    attributes:
+      label: Basemap name
+      placeholder: e.g. Fantasy Pangaea
+    validations:
+      required: true
+  - type: input
+    id: author
+    attributes:
+      label: Author / credit
+      placeholder: Your name (optional)
+    validations:
+      required: false
+  - type: textarea
+    id: image
+    attributes:
+      label: Basemap image
+      description: Drag your basemap image (.png or .jpg) here. For a vector basemap, drag the .geojson file instead.
+      placeholder: Drop your image (or .geojson) file here…
+    validations:
+      required: true
+  - type: textarea
+    id: technical
+    attributes:
+      label: Technical info (do not edit)
+      description: Auto-filled. Lets the game find and dedupe this basemap.
+      value: |
+        Basemap-Hash:
+        Basemap-Kind: image
+    validations:
+      required: true

--- a/server/server.js
+++ b/server/server.js
@@ -520,14 +520,18 @@ app.get("/api/hub/file", async (req, res) => {
       return sendError(res, 502, new Error(`Hub file fetch failed (HTTP ${upstream.status}).`));
     }
 
-    const text = await upstream.text();
-    if (text.length > HUB_MAX_BUNDLE_BYTES) {
+    const buffer = Buffer.from(await upstream.arrayBuffer());
+    if (buffer.length > HUB_MAX_BUNDLE_BYTES) {
       return sendError(res, 413, new Error("Scenario bundle is too large."));
     }
 
     res.setHeader("Cache-Control", "no-store");
-    res.type("application/json");
-    res.send(text);
+    // Pass the upstream content type through untouched. JSON bundles still parse
+    // via response.json() (which ignores the header), while binary bundles (.zip)
+    // and raw basemap images (.png/.jpg) arrive byte-for-byte — the old text()
+    // path UTF-8-decoded them and corrupted every non-text byte.
+    res.setHeader("Content-Type", upstream.headers.get("content-type") || "application/octet-stream");
+    res.send(buffer);
   } catch (error) {
     sendError(res, 502, error);
   }

--- a/src/Editor/BasemapPicker.jsx
+++ b/src/Editor/BasemapPicker.jsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { EDITOR_BASEMAPS, esriPreviewUrl } from "./basemaps.js";
 import { BACKGROUND_ACCEPT } from "./customBackground.js";
 import { listBasemaps, deleteBasemap as deleteBasemapApi, getBasemapPayload } from "../runtime/basemapLibrary.js";
-import { fetchCommunityBasemaps, installCommunityBasemap, publishBasemap } from "../runtime/communityBasemaps.js";
+import { basemapPostInstallable, fetchCommunityBasemaps, installCommunityBasemap, publishBasemap } from "../runtime/communityBasemaps.js";
 
 const overlay = {
   position: "fixed",
@@ -225,7 +225,10 @@ const BasemapPicker = ({
   const handlePublish = async (bm) => {
     try {
       const payload = await getBasemapPayload(bm.id);
-      publishBasemap(bm, payload);
+      const { fileName } = publishBasemap(bm, payload);
+      window.alert(
+        `"${fileName}" was downloaded. On the GitHub page that opened, drag that file into the "Basemap image" box, then submit.`,
+      );
     } catch (e) {
       window.alert(`Could not prepare that basemap for publishing: ${e?.message || e}`);
     }
@@ -332,7 +335,9 @@ const BasemapPicker = ({
                 <div style={dim}>No community basemaps yet — share one of yours with the ⤴ button on a “Your basemaps” card.</div>
               ) : (
                 <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(11rem, 1fr))", gap: "0.8rem" }}>
-                  {community.map((post) => (
+                  {community.map((post) => {
+                    const canInstall = basemapPostInstallable(post);
+                    return (
                     <div key={post.id} style={{ ...cardSurface, flex: "unset", cursor: "default" }}>
                       <div style={{ position: "relative", aspectRatio: "3 / 2", background: "#0b1020" }}>
                         {post.coverImageUrl ? (
@@ -349,27 +354,31 @@ const BasemapPicker = ({
                         {post.kind === "vector" && (
                           <span style={{ position: "absolute", left: 6, top: 6, background: "rgba(0,0,0,0.55)", borderRadius: "6px", fontSize: "0.6rem", fontWeight: 700, padding: "0.1rem 0.35rem", textTransform: "uppercase" }}>vector</span>
                         )}
+                        {post.fromScenario && (
+                          <span title="Shared as part of a scenario — installing pulls the map out of that scenario's file" style={{ position: "absolute", right: 6, top: 6, background: "rgba(0,0,0,0.55)", borderRadius: "6px", fontSize: "0.6rem", fontWeight: 700, padding: "0.1rem 0.35rem", textTransform: "uppercase" }}>from scenario</span>
+                        )}
                       </div>
                       <div style={{ padding: "0.5rem 0.6rem", display: "flex", flexDirection: "column", gap: "0.4rem" }}>
                         <div style={{ fontSize: "0.8rem", fontWeight: 700, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{post.title}</div>
                         <div style={{ fontSize: "0.68rem", color: "rgba(255,255,255,0.5)" }}>by {post.author}</div>
                         <button
                           type="button"
-                          disabled={!post.bundleUrl || busyId === post.id}
+                          disabled={!canInstall || busyId === post.id}
                           onClick={() => handleInstall(post)}
-                          title={post.bundleUrl ? "Install into Your basemaps" : "This post has no basemap file attached"}
+                          title={canInstall ? "Install into Your basemaps" : "This post has no basemap file attached"}
                           style={{
                             ...tabBtn(false),
-                            background: post.bundleUrl ? "rgba(124,58,237,0.35)" : "rgba(255,255,255,0.04)",
-                            cursor: post.bundleUrl && busyId !== post.id ? "pointer" : "default",
-                            opacity: post.bundleUrl ? 1 : 0.5,
+                            background: canInstall ? "rgba(124,58,237,0.35)" : "rgba(255,255,255,0.04)",
+                            cursor: canInstall && busyId !== post.id ? "pointer" : "default",
+                            opacity: canInstall ? 1 : 0.5,
                           }}
                         >
                           {busyId === post.id ? "Installing…" : "⬇ Install"}
                         </button>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -16,7 +16,13 @@ import {
   useLibraryState,
 } from "../../runtime/library.js";
 import { enqueueStrings } from "../../runtime/translator.js";
-import { dedupeScenarioBundleBackground, resolveScenarioBundleBackground } from "../../runtime/communityBasemaps.js";
+import {
+  dedupeScenarioBundleBackground,
+  embedScenarioBundleImage,
+  resolveScenarioBundleBackground,
+  splitScenarioBundleImage,
+} from "../../runtime/communityBasemaps.js";
+import { unzipBundle, zipBundle } from "../../runtime/bundleZip.js";
 
 // The one and only hub. Not configurable by design.
 const HUB_OWNER = "Arkniem";
@@ -33,7 +39,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 // body = the bundle. Release links come first in official posts so imports go
 // through the download-counted URL; the raw mirror below it serves old clients.
 const BUNDLE_LINK_PATTERN =
-  /https:\/\/(?:github\.com\/[^\s)<>"']+\/releases\/download\/[^\s)<>"']+\.json|github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+\.json)/i;
+  /https:\/\/(?:github\.com\/[^\s)<>"']+\/releases\/download\/[^\s)<>"']+\.(?:json|zip)|github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+\.json)/i;
 
 // First image in the issue body — markdown ![alt](url) or GitHub's own
 // <img src="..."> attachment markup (issue bodies mix both depending on how
@@ -125,8 +131,7 @@ export const fetchHubPosts = async ({ force = false } = {}) => {
   return posts;
 };
 
-const saveJsonToDisk = (data, fileName) => {
-  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+const saveBlobToDisk = (blob, fileName) => {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
@@ -136,6 +141,9 @@ const saveJsonToDisk = (data, fileName) => {
   anchor.remove();
   URL.revokeObjectURL(url);
 };
+
+const saveJsonToDisk = (data, fileName) =>
+  saveBlobToDisk(new Blob([JSON.stringify(data, null, 2)], { type: "application/json" }), fileName);
 
 const cardSurface = {
   background: "rgba(255,255,255,0.04)",
@@ -456,7 +464,19 @@ const CommunityPanel = ({ onImported }) => {
         const payload = await response.json().catch(() => ({}));
         throw new Error(payload.error || `Download failed (HTTP ${response.status}).`);
       }
-      const bundle = await response.json();
+      // A scenario with a custom basemap ships as a .zip (scenario.json + the raw
+      // basemap image + preview); everything else is a plain JSON bundle.
+      let bundle;
+      if (/\.zip(\?|$)/i.test(post.bundleUrl)) {
+        const zip = await unzipBundle(await response.arrayBuffer());
+        const scenarioText = await zip.text("scenario.json");
+        if (!scenarioText) throw new Error("That .zip is missing scenario.json.");
+        bundle = JSON.parse(scenarioText);
+        const imageName = zip.names().find((n) => /(^|\/)basemap\.(png|jpe?g|webp|gif)$/i.test(n));
+        if (imageName) embedScenarioBundleImage(bundle, await zip.bytes(imageName), imageName);
+      } else {
+        bundle = await response.json();
+      }
       // A shared scenario may reference a community basemap instead of embedding
       // it — fetch and inline it before importing so the map isn't blank.
       await resolveScenarioBundleBackground(bundle);
@@ -492,18 +512,36 @@ const CommunityPanel = ({ onImported }) => {
       // If this scenario's custom basemap is already on the community hub,
       // reference it instead of re-embedding the whole image (smaller bundle).
       const dedup = await dedupeScenarioBundleBackground(bundle).catch(() => ({ referenced: false, needsPublish: false }));
-      const fileName = `${scenario.id}-scenario.json`;
-      saveJsonToDisk(bundle, fileName);
-      window.open(
-        `${HUB_NEW_POST_URL}&title=${encodeURIComponent(`[Scenario] ${scenario.name}`)}`,
-        "_blank",
-        "noopener",
-      );
-      const extra = dedup.referenced
-        ? " Its custom basemap was reused from the community hub, so the file stays small."
-        : dedup.needsPublish
-          ? " Tip: this map uses a custom basemap that isn't shared yet — open the editor's Basemap picker and hit ⤴ on it to publish it, so future scenarios can reuse it instead of re-bundling the image."
+      // A not-yet-shared custom image basemap ships bundled as ONE .zip
+      // (scenario.json + the raw basemap image + a preview) so the author drags a
+      // single file and the image travels as real bytes, not a bloated data URL.
+      const split = dedup.referenced ? null : await splitScenarioBundleImage(bundle).catch(() => null);
+      let fileName;
+      let extra;
+      if (split) {
+        delete bundle.assets.backgroundData; // the image now rides in the zip as a real file
+        const files = { "scenario.json": JSON.stringify(bundle), [split.imageName]: split.imageBytes };
+        if (split.previewBytes) files[split.previewName] = split.previewBytes;
+        fileName = `${scenario.id}-scenario.zip`;
+        saveBlobToDisk(await zipBundle(files), fileName);
+        extra =
+          " Its custom basemap is bundled inside the .zip, so the scenario is self-contained — just drag the one file." +
+          " (To also list the basemap on its own in the community Basemaps tab, open the editor's Basemap picker and hit ⤴ on it.)";
+      } else {
+        fileName = `${scenario.id}-scenario.json`;
+        saveJsonToDisk(bundle, fileName);
+        extra = dedup.referenced
+          ? " Its custom basemap was reused from the community hub, so the file stays small."
           : "";
+      }
+      // When the scenario carries a basemap, tag the post with the basemap hash so
+      // the community Basemaps browser (which surfaces scenario-carried basemaps) can
+      // dedupe it against dedicated posts. Harmless if the scenario form has no such
+      // field — GitHub just ignores the unknown prefill param.
+      const scenarioUrl =
+        `${HUB_NEW_POST_URL}&title=${encodeURIComponent(`[Scenario] ${scenario.name}`)}` +
+        (split ? `&technical=${encodeURIComponent(`Basemap-Hash: ${split.hash}\nBasemap-Kind: image`)}` : "");
+      window.open(scenarioUrl, "_blank", "noopener");
       setNotice(
         `"${fileName}" was downloaded. On the GitHub page that just opened, drag that file into the Description box, then submit.${extra}`,
       );

--- a/src/runtime/bundleZip.js
+++ b/src/runtime/bundleZip.js
@@ -1,0 +1,43 @@
+/*! Open Historia — zip bundle helpers © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Thin wrappers over JSZip for the community hub's "one file to upload" bundles.
+// A scenario that carries a custom basemap ships as a single .zip (scenario JSON +
+// the raw basemap image + a small preview) instead of one bloated base64 JSON, so
+// the author drags a single file into the hub post and the image travels as real
+// bytes rather than a ~33%-larger data URL.
+
+import JSZip from "jszip";
+
+// Build a .zip Blob from a { path: data } map. String entries are DEFLATE-compressed
+// (JSON/GeoJSON shrink a lot); binary entries (already-compressed PNG/JPEG) are STOREd
+// so we don't waste CPU re-compressing them for near-zero gain. null/undefined skipped.
+export const zipBundle = async (files) => {
+  const zip = new JSZip();
+  for (const [path, data] of Object.entries(files || {})) {
+    if (data == null) continue;
+    const isBinary = data instanceof Uint8Array || data instanceof ArrayBuffer;
+    zip.file(path, data, { compression: isBinary ? "STORE" : "DEFLATE" });
+  }
+  return zip.generateAsync({ type: "blob" });
+};
+
+// Load a .zip (ArrayBuffer / Uint8Array / Blob) and return typed accessors. Each
+// getter returns null when the entry is absent so callers can probe optional files.
+export const unzipBundle = async (input) => {
+  const zip = await JSZip.loadAsync(input);
+  const entry = (p) => zip.file(p);
+  return {
+    has: (p) => Boolean(entry(p)),
+    names: () => Object.keys(zip.files).filter((n) => !zip.files[n].dir),
+    text: async (p) => (entry(p) ? entry(p).async("string") : null),
+    base64: async (p) => (entry(p) ? entry(p).async("base64") : null),
+    bytes: async (p) => (entry(p) ? entry(p).async("uint8array") : null),
+  };
+};
+
+// A .zip always starts with the local-file-header magic "PK\x03\x04". Used to tell a
+// zip bundle from a JSON bundle when the URL/extension is ambiguous.
+export const looksLikeZip = (bytes) => {
+  const b = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes || []);
+  return b.length >= 4 && b[0] === 0x50 && b[1] === 0x4b && b[2] === 0x03 && b[3] === 0x04;
+};

--- a/src/runtime/communityBasemaps.js
+++ b/src/runtime/communityBasemaps.js
@@ -2,13 +2,15 @@
 
 // Browse + install + publish basemaps shared through the community hub. Mirrors
 // the scenario hub (src/Game/GameUI/communityHub.jsx): each community basemap is
-// a GitHub issue labeled "basemap" whose body links a bundle .json (and, ideally,
-// an attached preview image used as the card cover). A content hash in the body
-// lets a scenario reference an existing community basemap instead of re-uploading
-// it. Publishing is the same safe, token-less flow scenarios use: the app exports
-// the bundle to disk and opens a prefilled issue for the author to submit.
+// a GitHub issue labeled "basemap" (via the basemap.yml issue form) whose body
+// carries the raw basemap image as an attachment — GitHub renders that image as
+// the card cover for free, and install reads the same image back. A content hash
+// in the body lets a scenario reference an existing community basemap instead of
+// re-embedding it. Publishing is the token-less flow scenarios use: the app hands
+// the author the real image file and opens a prefilled issue form to drag it into.
 
-import { createBasemap, sha256Hex } from "./basemapLibrary.js";
+import { createBasemap, makeImageThumbnail, sha256Hex } from "./basemapLibrary.js";
+import { unzipBundle } from "./bundleZip.js";
 
 // UTF-8-safe base64 <-> string (the scenario bundle base64-encodes the
 // background.json file bytes; plain atob/btoa mangle non-Latin1 vector data).
@@ -19,16 +21,82 @@ const HUB_OWNER = "Arkniem";
 const HUB_REPO = "pax-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 const HUB_API_BASEMAPS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=basemap&per_page=100`;
+// Scenario posts are scanned too: one shipped as a .zip carries a custom basemap,
+// which we surface in the basemap browser so a basemap shared via a scenario is
+// usable on its own without a second upload.
+const HUB_API_SCENARIOS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
+const SCENARIO_ZIP_PATTERN =
+  /https:\/\/github\.com\/(?:[^\s)<>"']+\/releases\/download\/[^\s)<>"']+\.zip|user-attachments\/files\/[^\s)<>"']+\.zip)/i;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
+// A non-image data file linked in an issue body: an old .basemap.json bundle or a
+// new vector's .geojson attachment. Inline images (the new image payload/cover)
+// are NOT matched here — they live in coverImageUrl instead.
 const BUNDLE_LINK_PATTERN =
-  /https:\/\/(?:github\.com\/[^\s)<>"']+\/releases\/download\/[^\s)<>"']+\.json|github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+\.json)/i;
+  /https:\/\/(?:github\.com\/[^\s)<>"']+\/releases\/download\/[^\s)<>"']+\.(?:json|geojson|zip)|github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+\.(?:json|geojson))/i;
 const COVER_IMAGE_PATTERN = /!\[[^\]]*\]\((https:\/\/[^\s)]+)\)|<img[^>]+src=["']([^"']+)["']/i;
 const HASH_PATTERN = /Basemap-Hash:\s*([a-f0-9]{16,64})/i;
 const KIND_PATTERN = /Basemap-Kind:\s*(image|vector)/i;
 const OFFICIAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 let cache = { at: 0, posts: null };
+
+// ---- data URL <-> bytes ---------------------------------------------------
+const MIME_TO_EXT = { "image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif", "image/svg+xml": "svg" };
+const EXT_TO_MIME = { png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp", gif: "image/gif", svg: "image/svg+xml" };
+const mimeToExt = (mime) => MIME_TO_EXT[String(mime || "").toLowerCase()] || "png";
+const extToMime = (ext) => EXT_TO_MIME[String(ext || "").toLowerCase()] || "image/png";
+// A URL/name whose extension is an image. Most render inline, but some (notably
+// SVG) GitHub attaches as a file with a bundle-style URL — those must still be
+// fetched as an image, not parsed as JSON.
+const IMAGE_EXT_PATTERN = /\.(?:png|jpe?g|webp|gif|svg)(?:[?#]|$)/i;
+
+const dataUrlParts = (dataUrl) => {
+  const [head = "", b64 = ""] = String(dataUrl).split(",");
+  return { mime: head.match(/data:([^;]+)/)?.[1] || "image/png", b64 };
+};
+
+const base64ToBytes = (b64) => {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+};
+
+const bytesToBase64 = (bytes) => {
+  let bin = "";
+  const arr = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  for (let i = 0; i < arr.length; i += 1) bin += String.fromCharCode(arr[i]);
+  return btoa(bin);
+};
+
+const dataUrlToBytes = (dataUrl) => {
+  const { mime, b64 } = dataUrlParts(dataUrl);
+  return { bytes: base64ToBytes(b64), mime };
+};
+
+const bytesToDataUrl = (bytes, mime) => `data:${mime || "image/png"};base64,${bytesToBase64(bytes)}`;
+
+// ---- hub fetch through the CORS proxy -------------------------------------
+// The proxy passes the upstream content type through, so JSON/geojson come back
+// as text and images as bytes; callers pick the accessor they need.
+const fetchHubResponse = async (url) => {
+  const r = await fetch(`/api/hub/file?url=${encodeURIComponent(url)}`);
+  if (!r.ok) {
+    const p = await r.json().catch(() => ({}));
+    throw new Error(p.error || `Download failed (HTTP ${r.status}).`);
+  }
+  return r;
+};
+
+const fetchHubText = async (url) => (await fetchHubResponse(url)).text();
+const fetchHubImage = async (url) => {
+  const r = await fetchHubResponse(url);
+  const buf = await r.arrayBuffer();
+  const ctype = (r.headers.get("content-type") || "").split(";")[0].trim();
+  const mime = ctype.startsWith("image/") ? ctype : extToMime(url.split(".").pop());
+  return bytesToDataUrl(new Uint8Array(buf), mime);
+};
 
 const parseBasemapPost = (issue) => {
   const body = String(issue.body ?? "");
@@ -42,86 +110,167 @@ const parseBasemapPost = (issue) => {
     createdAt: issue.created_at,
     official: OFFICIAL_ASSOCIATIONS.has(issue.author_association),
     upvotes: issue.reactions?.["+1"] ?? 0,
+    // A non-image data file (old .basemap.json bundle, or a new vector .geojson).
     bundleUrl: body.match(BUNDLE_LINK_PATTERN)?.[0] ?? null,
+    // The attached image: card cover AND, for new image basemaps, the payload.
     coverImageUrl: coverMatch ? coverMatch[1] ?? coverMatch[2] ?? null : null,
     contentHash: body.match(HASH_PATTERN)?.[1]?.toLowerCase() ?? null,
     kind: body.match(KIND_PATTERN)?.[1]?.toLowerCase() ?? "image",
   };
 };
 
+// A scenario post that shipped as a .zip carries a custom image basemap. Surface it
+// as a basemap entry so basemaps shared via scenarios show up in the basemap browser
+// too — installed by pulling basemap.<ext> out of the scenario zip.
+const parseScenarioAsBasemap = (issue) => {
+  const body = String(issue.body ?? "");
+  const zipUrl = body.match(SCENARIO_ZIP_PATTERN)?.[0] ?? null;
+  if (!zipUrl) return null;
+  const rawTitle = String(issue.title ?? "").replace(/^\[Scenario\]\s*/i, "").trim();
+  return {
+    id: `scenario-${issue.number}`,
+    title: `${rawTitle || `Scenario #${issue.number}`} (basemap)`,
+    author: issue.user?.login ?? "unknown",
+    avatarUrl: issue.user?.avatar_url ?? null,
+    url: issue.html_url,
+    createdAt: issue.created_at,
+    official: OFFICIAL_ASSOCIATIONS.has(issue.author_association),
+    upvotes: issue.reactions?.["+1"] ?? 0,
+    fromScenario: true,
+    scenarioZipUrl: zipUrl,
+    // Present only if the scenario body carries the basemap hash (lets it dedupe
+    // against a dedicated basemap post); harmless when absent.
+    contentHash: body.match(HASH_PATTERN)?.[1]?.toLowerCase() ?? null,
+    kind: "image",
+    coverImageUrl: null,
+    bundleUrl: null,
+  };
+};
+
+// A post is installable if we can find a payload: a scenario zip, a data file, or
+// (image kind) the attached image itself. Old JSON-bundle, new image/vector, and
+// scenario-carried basemaps all pass.
+export const basemapPostInstallable = (post) =>
+  Boolean(post?.fromScenario || post?.bundleUrl || (post?.kind === "image" && post?.coverImageUrl));
+
 export const fetchCommunityBasemaps = async ({ force = false } = {}) => {
   if (!force && cache.posts && Date.now() - cache.at < CACHE_TTL_MS) return cache.posts;
-  const r = await fetch(HUB_API_BASEMAPS, { headers: { Accept: "application/vnd.github+json" } });
-  if (!r.ok) {
+  const headers = { Accept: "application/vnd.github+json" };
+  // Dedicated basemap posts, plus scenario posts (scanned so their basemaps show up
+  // here too). The scenarios call is best-effort — a failure just hides those.
+  const [bmRes, scRes] = await Promise.all([
+    fetch(HUB_API_BASEMAPS, { headers }),
+    fetch(HUB_API_SCENARIOS, { headers }).catch(() => null),
+  ]);
+  if (!bmRes.ok) {
     throw new Error(
-      r.status === 403
+      bmRes.status === 403
         ? "GitHub rate limit reached — try again in a few minutes."
-        : `Could not reach the basemap hub (HTTP ${r.status}).`,
+        : `Could not reach the basemap hub (HTTP ${bmRes.status}).`,
     );
   }
-  const issues = await r.json();
-  const posts = (Array.isArray(issues) ? issues : []).filter((i) => !i.pull_request).map(parseBasemapPost);
+  const bmIssues = await bmRes.json();
+  const dedicated = (Array.isArray(bmIssues) ? bmIssues : []).filter((i) => !i.pull_request).map(parseBasemapPost);
+  let fromScenarios = [];
+  if (scRes && scRes.ok) {
+    const scIssues = await scRes.json().catch(() => []);
+    fromScenarios = (Array.isArray(scIssues) ? scIssues : [])
+      .filter((i) => !i.pull_request)
+      .map(parseScenarioAsBasemap)
+      .filter(Boolean);
+  }
+  // A basemap that also exists as a dedicated post is shown once (prefer the
+  // dedicated post — real cover image, cheaper install). Scenario-carried basemaps
+  // without a hash can't be deduped, so they always appear.
+  const seen = new Set(dedicated.map((p) => p.contentHash).filter(Boolean));
+  const posts = [...dedicated];
+  for (const s of fromScenarios) {
+    if (s.contentHash && seen.has(s.contentHash)) continue;
+    if (s.contentHash) seen.add(s.contentHash);
+    posts.push(s);
+  }
   cache = { at: Date.now(), posts };
   return posts;
 };
 
-// Dedup lookup — reads the issue list only (no bundle downloads), matching the
-// content hash embedded in each post body.
+// Dedup lookup — reads the issue list only (no downloads), matching the content
+// hash embedded in each post body. Returns the post so callers can reference the
+// right payload URL (image vs data file).
 export const findCommunityBasemapByHash = async (hash) => {
   if (!hash) return null;
   try {
     const posts = await fetchCommunityBasemaps();
-    return posts.find((p) => p.contentHash === String(hash).toLowerCase() && p.bundleUrl) ?? null;
+    // Only dedicated posts are cheaply referenceable (a stable image/data URL). A
+    // scenario-carried basemap lives inside a zip, so don't reference those.
+    return posts.find((p) => p.contentHash === String(hash).toLowerCase() && !p.fromScenario && basemapPostInstallable(p)) ?? null;
   } catch {
     return null;
   }
 };
 
-export const fetchBasemapBundle = async (bundleUrl) => {
-  const r = await fetch(`/api/hub/file?url=${encodeURIComponent(bundleUrl)}`);
-  if (!r.ok) {
-    const p = await r.json().catch(() => ({}));
-    throw new Error(p.error || `Download failed (HTTP ${r.status}).`);
+// Resolve a post to its payload: { kind, dataUrl } | { kind:"vector", geojson }.
+// New image basemaps carry the image inline; new vectors carry a .geojson file;
+// old posts carry a { basemap, payload } .basemap.json bundle.
+const loadBasemapPayload = async (post) => {
+  // A basemap carried inside a scenario .zip: download the zip, pull basemap.<ext>.
+  if (post.fromScenario && post.scenarioZipUrl) {
+    const r = await fetchHubResponse(post.scenarioZipUrl);
+    const zip = await unzipBundle(await r.arrayBuffer());
+    const imageName = zip.names().find((n) => /(^|\/)basemap\.(?:png|jpe?g|webp|gif|svg)$/i.test(n));
+    if (!imageName) throw new Error("That scenario has no basemap image inside it.");
+    const dataUrl = bytesToDataUrl(await zip.bytes(imageName), extToMime(imageName.split(".").pop()));
+    return { meta: {}, kind: "image", payload: { dataUrl } };
   }
-  return r.json();
+  // An image the post links as a file (e.g. an .svg GitHub attaches rather than
+  // rendering inline) is the image payload, not a data file.
+  const imageFileUrl = post.bundleUrl && IMAGE_EXT_PATTERN.test(post.bundleUrl) ? post.bundleUrl : null;
+  // Old .basemap.json bundle, or a new vector .geojson file (a non-image data file).
+  if (post.bundleUrl && !imageFileUrl) {
+    const text = await fetchHubText(post.bundleUrl);
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error("That basemap file isn't valid JSON.");
+    }
+    if (parsed && parsed.payload) {
+      // Old bundle: { basemap:{…}, payload:{ dataUrl | geojson } }.
+      const kind = parsed.basemap?.kind === "vector" ? "vector" : "image";
+      return { meta: parsed.basemap ?? {}, kind, payload: parsed.payload ?? {} };
+    }
+    if (parsed && (parsed.type === "FeatureCollection" || Array.isArray(parsed.features))) {
+      return { meta: {}, kind: "vector", payload: { geojson: parsed } };
+    }
+    throw new Error("That basemap file is missing its data.");
+  }
+  // New image basemap: the attached cover image (or an image file link) is the payload.
+  const imageUrl = post.coverImageUrl || imageFileUrl;
+  if (post.kind !== "vector" && imageUrl) {
+    const dataUrl = await fetchHubImage(imageUrl);
+    return { meta: {}, kind: "image", payload: { dataUrl } };
+  }
+  throw new Error("This basemap post has no file attached.");
 };
 
 // Install a community basemap into the local "Your basemaps" library.
 export const installCommunityBasemap = async (post) => {
-  if (!post?.bundleUrl) throw new Error("This basemap post has no bundle file attached.");
-  const bundle = await fetchBasemapBundle(post.bundleUrl);
-  const bm = bundle?.basemap ?? {};
-  const payload = bundle?.payload ?? {};
-  const kind = bm.kind === "vector" ? "vector" : "image";
+  const { meta, kind, payload } = await loadBasemapPayload(post);
   if ((kind === "image" && !payload.dataUrl) || (kind === "vector" && !payload.geojson)) {
-    throw new Error("That basemap bundle is missing its payload.");
+    throw new Error("That basemap is missing its payload.");
   }
+  const thumbnail =
+    kind === "image" ? await makeImageThumbnail(payload.dataUrl).catch(() => null) : null;
   return createBasemap({
-    name: bm.name || post.title,
+    name: meta.name || post.title,
     kind,
-    aspect: bm.aspect || null,
-    thumbnail: bm.thumbnail || post.coverImageUrl || null,
-    contentHash: bm.contentHash || post.contentHash || null,
-    author: bm.author || post.author,
-    source: { community: true, hash: bm.contentHash || post.contentHash || null, bundleUrl: post.bundleUrl, url: post.url },
+    aspect: meta.aspect || null,
+    thumbnail: thumbnail || meta.thumbnail || null,
+    contentHash: meta.contentHash || post.contentHash || null,
+    author: meta.author || post.author,
+    source: { community: true, hash: meta.contentHash || post.contentHash || null, url: post.url },
     payload,
   });
 };
-
-// The JSON bundle a published basemap ships as.
-export const buildBasemapBundle = (meta, payload) => ({
-  schema: "pax-historia-basemap-bundle",
-  version: 1,
-  basemap: {
-    name: meta.name,
-    kind: meta.kind === "vector" ? "vector" : "image",
-    aspect: meta.aspect ?? null,
-    contentHash: meta.contentHash ?? null,
-    thumbnail: meta.thumbnail ?? null,
-    author: meta.author ?? "",
-  },
-  payload,
-});
 
 const downloadFile = (blob, fileName) => {
   const url = URL.createObjectURL(blob);
@@ -134,43 +283,34 @@ const downloadFile = (blob, fileName) => {
   URL.revokeObjectURL(url);
 };
 
-const dataUrlToBlob = (dataUrl) => {
-  try {
-    const [head, b64] = String(dataUrl).split(",");
-    const mime = head.match(/data:([^;]+)/)?.[1] || "image/jpeg";
-    const bin = atob(b64);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
-    return new Blob([bytes], { type: mime });
-  } catch {
-    return null;
-  }
-};
+const safeName = (name) =>
+  (name || "basemap").replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase() || "basemap";
 
-// Publish: download the bundle (and a preview image to attach as the cover), then
-// open a prefilled hub issue for the author to drag the files into and submit.
+// Publish: hand the author the real basemap file (image, or .geojson for a vector)
+// and open the prefilled basemap issue form to drag it into. The image doubles as
+// the card cover, so there's no separate preview file and no base64 bloat.
 export const publishBasemap = (meta, payload) => {
-  const safe = (meta.name || "basemap").replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase() || "basemap";
-  const bundle = buildBasemapBundle(meta, payload);
-  downloadFile(new Blob([JSON.stringify(bundle)], { type: "application/json" }), `${safe}.basemap.json`);
-  if (meta.thumbnail && String(meta.thumbnail).startsWith("data:image")) {
-    const thumbBlob = dataUrlToBlob(meta.thumbnail);
-    if (thumbBlob) downloadFile(thumbBlob, `${safe}-preview.jpg`);
+  const kind = meta.kind === "vector" ? "vector" : "image";
+  const safe = safeName(meta.name);
+  if (kind === "image") {
+    if (!payload?.dataUrl) throw new Error("This basemap has no image to publish.");
+    const { bytes, mime } = dataUrlToBytes(payload.dataUrl);
+    downloadFile(new Blob([bytes], { type: mime }), `${safe}.${mimeToExt(mime)}`);
+  } else {
+    if (!payload?.geojson) throw new Error("This vector basemap has no geometry to publish.");
+    downloadFile(new Blob([JSON.stringify(payload.geojson)], { type: "application/geo+json" }), `${safe}.geojson`);
   }
-  const title = `[Basemap] ${meta.name || "Untitled basemap"}`;
-  const body = [
-    `Basemap-Hash: ${meta.contentHash || ""}`,
-    `Basemap-Kind: ${meta.kind === "vector" ? "vector" : "image"}`,
-    "",
-    `Drag the downloaded **${safe}.basemap.json** into this box (and the **${safe}-preview.jpg** so it shows a preview), then submit.`,
-    "",
-    "Do not remove the two lines at the top — they let the game find and dedupe this basemap.",
-  ].join("\n");
-  window.open(
-    `${HUB_URL}/issues/new?labels=basemap&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`,
-    "_blank",
-    "noopener",
-  );
+  const dropWhat = kind === "image" ? `${safe}.${mimeToExt(dataUrlParts(payload.dataUrl).mime)}` : `${safe}.geojson`;
+  const technical = `Basemap-Hash: ${meta.contentHash || ""}\nBasemap-Kind: ${kind}`;
+  const query = [
+    "template=basemap.yml",
+    `title=${encodeURIComponent(`[Basemap] ${meta.name || "Untitled basemap"}`)}`,
+    `name=${encodeURIComponent(meta.name || "")}`,
+    `author=${encodeURIComponent(meta.author || "")}`,
+    `technical=${encodeURIComponent(technical)}`,
+  ].join("&");
+  window.open(`${HUB_URL}/issues/new?${query}`, "_blank", "noopener");
+  return { fileName: dropWhat };
 };
 
 // ---- Scenario-bundle background dedup ------------------------------------
@@ -207,13 +347,21 @@ export const dedupeScenarioBundleBackground = async (bundle) => {
   if (!bg) return { referenced: false, needsPublish: false };
   const match = await findCommunityBasemapByHash(bg.hash);
   if (match) {
-    bundle.assets.backgroundData = {
-      mode: "communityRef",
-      hash: bg.hash,
-      bundleUrl: match.bundleUrl,
-      fileName: "background.json",
-    };
-    return { referenced: true, needsPublish: false };
+    // A data file (old .basemap.json bundle, or a vector .geojson) is fetched and
+    // parsed as JSON on import; an image link (incl. an .svg attached as a file) or
+    // an inline image is fetched as the raw image.
+    const viaDataFile = Boolean(match.bundleUrl) && !IMAGE_EXT_PATTERN.test(match.bundleUrl);
+    const url = viaDataFile ? match.bundleUrl : match.coverImageUrl || match.bundleUrl;
+    if (url) {
+      bundle.assets.backgroundData = {
+        mode: "communityRef",
+        hash: bg.hash,
+        via: viaDataFile ? "dataFile" : "image",
+        url,
+        fileName: "background.json",
+      };
+      return { referenced: true, needsPublish: false };
+    }
   }
   return { referenced: false, needsPublish: true };
 };
@@ -222,10 +370,21 @@ export const dedupeScenarioBundleBackground = async (bundle) => {
 // fetching the referenced basemap, so the server import writes it normally.
 export const resolveScenarioBundleBackground = async (bundle) => {
   const asset = bundle?.assets?.backgroundData;
-  if (!asset || asset.mode !== "communityRef" || !asset.bundleUrl) return bundle;
+  if (!asset || asset.mode !== "communityRef" || !asset.url) return bundle;
   try {
-    const bmBundle = await fetchBasemapBundle(asset.bundleUrl);
-    const payload = bmBundle?.payload;
+    let payload = null;
+    // Drive the fetch by how it was referenced, not by kind: an old .basemap.json
+    // bundle has kind "image" yet must be parsed as JSON, not fetched as an image.
+    const viaImage = asset.via ? asset.via === "image" : asset.kind === "image";
+    if (viaImage) {
+      payload = { dataUrl: await fetchHubImage(asset.url) };
+    } else {
+      // A referenced data file: old .basemap.json bundle or a raw .geojson.
+      const text = await fetchHubText(asset.url);
+      const parsed = JSON.parse(text);
+      if (parsed?.payload) payload = parsed.payload;
+      else if (parsed?.type === "FeatureCollection" || Array.isArray(parsed?.features)) payload = { geojson: parsed };
+    }
     if (payload && (payload.dataUrl || payload.geojson)) {
       bundle.assets.backgroundData = {
         mode: "embedded",
@@ -241,5 +400,41 @@ export const resolveScenarioBundleBackground = async (bundle) => {
     // failing the whole scenario import.
     delete bundle.assets.backgroundData;
   }
+  return bundle;
+};
+
+// ---- Scenario zip bundle (image travels as a real file, not base64) -------
+// Split a scenario bundle's embedded background image out into raw bytes so the
+// scenario can ship as a .zip (json + png + preview) instead of one base64 blob.
+// Returns null when there's nothing to split (no background, or a vector/ref).
+export const splitScenarioBundleImage = async (bundle) => {
+  const bg = await readBundleBackground(bundle).catch(() => null);
+  if (!bg || bg.kind !== "image" || !bg.payload?.dataUrl) return null;
+  const { bytes, mime } = dataUrlToBytes(bg.payload.dataUrl);
+  const ext = mimeToExt(mime);
+  const preview = await makeImageThumbnail(bg.payload.dataUrl, 320).catch(() => null);
+  return {
+    imageBytes: bytes,
+    imageName: `basemap.${ext}`,
+    imageMime: mime,
+    previewBytes: preview ? dataUrlToBytes(preview).bytes : null,
+    previewName: "preview.jpg",
+    hash: bg.hash,
+  };
+};
+
+// Re-embed a zip's basemap image back into the scenario bundle before import, so
+// the server sees a normal embedded-background bundle. `imageName` is the zip
+// entry name (e.g. "basemap.png") — its extension gives the mime.
+export const embedScenarioBundleImage = (bundle, imageBytes, imageName) => {
+  if (!bundle?.assets) return bundle;
+  const mime = extToMime(String(imageName || "").split(".").pop());
+  const dataUrl = bytesToDataUrl(imageBytes, mime);
+  bundle.assets.backgroundData = {
+    mode: "embedded",
+    data: utf8ToBase64(JSON.stringify({ dataUrl })),
+    fileName: "background.json",
+    contentType: "application/json",
+  };
   return bundle;
 };


### PR DESCRIPTION
Basemaps now publish as the actual image (png/jpg/svg/gif/webp) via a basemap.yml issue form instead of a base64 .basemap.json — GitHub renders it as the card cover and there's no ~33% base64 bloat. Scenarios that carry a custom basemap ship as a single .zip (scenario.json + the raw image + a preview); import unzips and rebuilds the bundle. Vectors still export as .geojson; images keep their original format.

The community Basemaps browser also aggregates basemaps carried by scenario .zip posts, so sharing a scenario makes its basemap browsable on its own with no second upload. The hub proxy now passes binary through so png/zip survive intact.

Adds hub-templates/basemap.yml (issue form for the scenarios repo) and src/runtime/bundleZip.js (jszip wrappers).