### PR TITLE
fix(hub): point at the renamed Open-Historia/Open-historia-scenarios …

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Then open **http://localhost:3000** in your browser.
 
 **Modern Day** is the only built-in scenario. All other official presets — *WWII 1939*,
 *Medieval 1200*, *Rome 117 AD*, *Mongol World 1300*, *New World 1650* — live on the
-[**Scenario Hub**](https://github.com/Arkniem/pax-historia-scenarios), pinned at the top of
+[**Scenario Hub**](https://github.com/Open-Historia/Open-historia-scenarios), pinned at the top of
 the in-game **Community** tab. Import any of them with one click, or publish your own.
 
 To rebuild an official preset from source (specs live in `scripts/presets/`):

--- a/hub-templates/README.md
+++ b/hub-templates/README.md
@@ -7,7 +7,7 @@ alongside the client code that links to them.
 To take effect, copy them into the hub repo:
 
 ```
-Arkniem/pax-historia-scenarios/.github/ISSUE_TEMPLATE/basemap.yml
+Open-Historia/Open-historia-scenarios/.github/ISSUE_TEMPLATE/basemap.yml
 ```
 
 - **`basemap.yml`** — the "Share a basemap" form. The editor's Basemap picker links

--- a/src/Editor/BasemapPicker.jsx
+++ b/src/Editor/BasemapPicker.jsx
@@ -319,7 +319,7 @@ const BasemapPicker = ({
                 <div style={{ ...rowTitle, margin: 0 }}>Community basemaps</div>
                 <div style={{ flex: 1 }} />
                 <a
-                  href="https://github.com/Arkniem/pax-historia-scenarios/issues?q=is%3Aissue+is%3Aopen+label%3Abasemap"
+                  href="https://github.com/Open-Historia/Open-historia-scenarios/issues?q=is%3Aissue+is%3Aopen+label%3Abasemap"
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{ ...tabBtn(false), textDecoration: "none" }}

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -25,8 +25,8 @@ import {
 import { unzipBundle, zipBundle } from "../../runtime/bundleZip.js";
 
 // The one and only hub. Not configurable by design.
-const HUB_OWNER = "Arkniem";
-const HUB_REPO = "pax-historia-scenarios";
+const HUB_OWNER = "Open-Historia";
+const HUB_REPO = "Open-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 const HUB_API_ISSUES = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
 // Official bundles live as assets on the "bundles" release — GitHub counts

--- a/src/runtime/communityBasemaps.js
+++ b/src/runtime/communityBasemaps.js
@@ -17,8 +17,8 @@ import { unzipBundle } from "./bundleZip.js";
 const utf8ToBase64 = (str) => btoa(unescape(encodeURIComponent(str)));
 const base64ToUtf8 = (b64) => decodeURIComponent(escape(atob(b64)));
 
-const HUB_OWNER = "Arkniem";
-const HUB_REPO = "pax-historia-scenarios";
+const HUB_OWNER = "Open-Historia";
+const HUB_REPO = "Open-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 const HUB_API_BASEMAPS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=basemap&per_page=100`;
 // Scenario posts are scanned too: one shipped as a .zip carries a custom basemap,


### PR DESCRIPTION
…repo

The community hub was renamed from Arkniem/pax-historia-scenarios to Open-Historia/Open-historia-scenarios. The old name only resolved via GitHub's rename redirect; use the canonical owner/repo so the Community scenario and basemap tabs don't silently break if that redirect ever lapses.