### PR TITLE
fix(launcher): always run npm install so updates get new dependencies

### DIFF
--- a/Launch Open Historia.bat
+++ b/Launch Open Historia.bat
@@ -71,14 +71,13 @@ call :ensure_asset "server\data\scenarios\default\regions.geojson" "server/data/
 echo.
 
 REM ---- 3. Install dependencies -----------------------------
-if not exist "node_modules" (
-    echo Installing dependencies ^(first run - this can take a few minutes^)...
-    call npm install
-    if errorlevel 1 goto :fail
-) else (
-    echo [OK] Dependencies already installed.
-    echo      ^(Delete the "node_modules" folder to force a clean reinstall.^)
-)
+REM Always run npm install: it's a fast no-op when nothing changed, but it also
+REM installs any NEW dependency a code update added. Gating this on "node_modules
+REM missing" skipped those, so a newly-required package (e.g. jszip) never got
+REM installed and the production build failed to resolve it.
+echo Installing / updating dependencies ^(fast if already up to date^)...
+call npm install
+if errorlevel 1 goto :fail
 echo.
 
 REM ---- 4. Build the client ---------------------------------

--- a/Launch Open Historia.sh
+++ b/Launch Open Historia.sh
@@ -117,13 +117,12 @@ ensure_asset "server/data/scenarios/default/regions.geojson"
 echo ""
 
 # ---- 3. Install dependencies -----------------------------
-if [ ! -d "node_modules" ]; then
-    echo "Installing dependencies (first run - this can take a few minutes)..."
-    npm install || { echo ""; echo "[ERROR] Setup failed - see the messages above for details."; exit 1; }
-else
-    echo "[OK] Dependencies already installed."
-    echo "     (Delete the \"node_modules\" folder to force a clean reinstall.)"
-fi
+# Always run npm install: it's a fast no-op when nothing changed, but it also
+# installs any NEW dependency a code update added. Gating this on "node_modules
+# missing" skipped those, so a newly-required package (e.g. jszip) never got
+# installed and the production build failed to resolve it.
+echo "Installing / updating dependencies (fast if already up to date)..."
+npm install || { echo ""; echo "[ERROR] Setup failed - see the messages above for details."; exit 1; }
 echo ""
 
 # ---- 4. Build the client ---------------------------------


### PR DESCRIPTION
The launcher only ran `npm install` when node_modules was absent, so a code update that added a new dependency (e.g. jszip, pulled in by the new bundleZip.js) never installed it — and the production build then failed to resolve the import. Run npm install every launch; it's a fast no-op when nothing changed. The macOS .command wrapper delegates to the .sh, so both platforms are covered.