### PR TITLE
feat(editor): generate worlds with Azgaar's Fantasy Map Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+
+# Vendored Fantasy Map Generator (fetched at runtime by scripts/fetch-fmg.mjs)
+/fmg/
 server/data/*
 !server/data/scenarios/
 .key

--- a/Update Open Historia.bat
+++ b/Update Open Historia.bat
@@ -177,6 +177,16 @@ REM Force a rebuild on next launch so the update actually takes effect.
 if exist "dist" rmdir /s /q "dist"
 
 :finish
+REM Refresh the vendored Fantasy Map Generator from its repo (the map editor's
+REM world generator). Best-effort - needs Node + deps (the launcher keeps those
+REM installed); a failure never blocks the update.
+where node >nul 2>&1
+if not errorlevel 1 (
+    if exist "scripts\fetch-fmg.mjs" (
+        echo Refreshing the Fantasy Map Generator ^(map editor world generator^)...
+        node "scripts\fetch-fmg.mjs"
+    )
+)
 echo.
 echo ===================================================
 echo   Update complete.

--- a/Update Open Historia.sh
+++ b/Update Open Historia.sh
@@ -182,6 +182,13 @@ finish() {
     # ZIP extraction can lose the executable bit - restore it.
     chmod +x "Launch Open Historia.sh" "Update Open Historia.sh" \
              "Launch Open Historia.command" "Update Open Historia.command" 2>/dev/null
+    # Refresh the vendored Fantasy Map Generator from its repo (the map editor's
+    # world generator). Best-effort - needs Node + deps, which the launcher keeps
+    # installed; a failure here never blocks the update.
+    if command -v node >/dev/null 2>&1 && [ -f "scripts/fetch-fmg.mjs" ]; then
+        echo "Refreshing the Fantasy Map Generator (map editor world generator)..."
+        node "scripts/fetch-fmg.mjs" || true
+    fi
     echo ""
     echo "==================================================="
     echo "  Update complete."

--- a/scripts/fetch-fmg.mjs
+++ b/scripts/fetch-fmg.mjs
@@ -1,0 +1,74 @@
+/*! Open Historia — vendor Azgaar's Fantasy Map Generator © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Vendors Azgaar's Fantasy Map Generator (MIT) into ./fmg/dist, served same-origin
+// at /fmg/ so the map editor's "Generate" console can run it headlessly and read
+// its data. PINNED to v1.109 — the NEWEST release that still runs as plain static
+// files (no build) and keeps its state (pack, grid, biomesData, mapCoordinates…) in
+// the classic global scope where the importer can reach it. FMG v1.110+ moved to
+// ES modules, where that state is module-scoped and no longer reachable.
+//
+// To move the pin forward, bump FMG_TAG and re-test the editor's Generate console.
+// Run by the updater so a missing/broken copy self-heals. Best-effort: any failure
+// prints a clear message and exits 0 so the game still launches.
+
+import fs from "fs";
+import path from "path";
+import url from "url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+const DIST_DIR = path.join(ROOT, "fmg", "dist");
+const STAMP = path.join(ROOT, "fmg", ".version");
+
+const FMG_REPO = "Azgaar/Fantasy-Map-Generator";
+const FMG_TAG = "v1.109";
+const ZIP_URL = `https://codeload.github.com/${FMG_REPO}/zip/refs/tags/${FMG_TAG}`;
+
+const log = (m) => console.log(`[fmg] ${m}`);
+
+async function main() {
+  // Already at the pinned version? nothing to do (keeps updates fast).
+  if (fs.existsSync(path.join(DIST_DIR, "index.html")) && fs.existsSync(STAMP)) {
+    if (fs.readFileSync(STAMP, "utf8").trim() === FMG_TAG) {
+      log(`already at ${FMG_TAG}.`);
+      return;
+    }
+  }
+
+  log(`downloading Fantasy Map Generator ${FMG_TAG}…`);
+  const res = await fetch(ZIP_URL);
+  if (!res.ok) throw new Error(`download failed (HTTP ${res.status})`);
+  const buf = Buffer.from(await res.arrayBuffer());
+
+  log("extracting (static — no build needed)…");
+  const JSZip = (await import("jszip")).default;
+  const zip = await JSZip.loadAsync(buf);
+  const names = Object.keys(zip.files);
+  const rootPrefix = names[0]?.includes("/") ? `${names[0].split("/")[0]}/` : "";
+
+  // Extract into a temp dir, then swap into place, so a failed extract never
+  // leaves a half-written /fmg/dist that the server would serve.
+  const tmp = path.join(ROOT, "fmg", ".dist-tmp");
+  fs.rmSync(tmp, { recursive: true, force: true });
+  for (const entry of Object.values(zip.files)) {
+    if (entry.dir) continue;
+    const rel = entry.name.startsWith(rootPrefix) ? entry.name.slice(rootPrefix.length) : entry.name;
+    if (!rel) continue;
+    const out = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    fs.writeFileSync(out, Buffer.from(await entry.async("nodebuffer")));
+  }
+  if (!fs.existsSync(path.join(tmp, "index.html"))) throw new Error("downloaded FMG has no index.html");
+
+  fs.rmSync(DIST_DIR, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(DIST_DIR), { recursive: true });
+  fs.renameSync(tmp, DIST_DIR);
+  fs.writeFileSync(STAMP, FMG_TAG);
+  log(`Fantasy Map Generator ${FMG_TAG} vendored → /fmg/ ✓`);
+}
+
+main().catch((e) => {
+  console.error(`[fmg] vendoring skipped: ${e?.message || e}`);
+  console.error("[fmg] the game still runs; the map editor's Generate console will report FMG isn't ready.");
+  process.exit(0); // never block launch/update
+});

--- a/server/server.js
+++ b/server/server.js
@@ -611,6 +611,14 @@ app.delete("/api/basemaps/:id", (req, res) => {
   }
 });
 
+// Vendored Fantasy Map Generator (Azgaar, MIT), built to ../fmg/dist by the
+// updater (scripts/fetch-fmg.mjs) and served same-origin so the map editor's
+// "Generate" console can run it in a hidden iframe and read its data. Present
+// only after it's been vendored — otherwise /fmg 404s and the editor says so.
+// Mounted before the SPA fallback so /fmg/* isn't swallowed by index.html.
+const fmgDistDir = path.join(__dirname, "../fmg/dist");
+if (fs.existsSync(fmgDistDir)) app.use("/fmg", express.static(fmgDistDir));
+
 app.use(express.static(distDir));
 
 app.get("*splat", (_req, res) => {

--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -29,6 +29,9 @@ import { addBackgroundToLibrary, getBasemapPayload } from "../runtime/basemapLib
 import { saveDocument, loadDocument, downloadJson } from "./documentIO.js";
 import { buildGameSeed } from "./exportPreset.js";
 import { panelSurface, inputStyle } from "./editorStyles.js";
+import FmgPanel from "./fmg/FmgPanel.jsx";
+import { generateFmgWorld } from "./fmg/fmgDriver.js";
+import { fmgToEditorSeed } from "./fmg/fmgImport.js";
 
 const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}) => {
   const d = useMapDocument();
@@ -45,6 +48,9 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
   const [customBg, setCustomBg] = useState(null); // live background applied to the map
   const [customBgId, setCustomBgId] = useState(null); // library basemap id applied (null = built-in / doc's own)
   const [basemapPickerOpen, setBasemapPickerOpen] = useState(false);
+  const [fmgOpen, setFmgOpen] = useState(false); // FMG "Generate" drawer
+  const [fmgBusy, setFmgBusy] = useState(false);
+  const [fmgLog, setFmgLog] = useState([]);
 
   const togglePanel = (name) => setOpenPanel((cur) => (cur === name ? null : name));
 
@@ -95,6 +101,49 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     } catch (e) {
       console.warn("[editor] save basemap to library failed:", e);
       setCustomBgId(null);
+    }
+  };
+
+  // ---- Fantasy Map Generator: generate a world and import it into this map ----
+  const fmgLogLine = (msg) => setFmgLog((l) => [...l, msg]);
+  const generateFromFmg = async (params) => {
+    if (!api || fmgBusy) return;
+    setFmgBusy(true);
+    setFmgLog([]);
+    try {
+      const raw = await generateFmgWorld(params, fmgLogLine);
+      fmgLogLine("Building regions, countries and cities…");
+      const seed = fmgToEditorSeed(raw, { groupBy: params.useProvinces ? "province" : "state" });
+      api.loadRegions(seed.regions);
+      d.setFeatures(
+        seed.cities.features
+          .map((f) => ({
+            id: newId("feat"),
+            name: f.properties?.city || "",
+            type: "Coordinate",
+            symbol: "square",
+            coord: Array.isArray(f.geometry?.coordinates) ? f.geometry.coordinates.slice(0, 2) : null,
+            country: "",
+            owner: null,
+            regionId: null,
+            population: f.properties?.population || 0,
+            tags: f.properties?.capital === "primary" ? ["city", "capital"] : ["city"],
+          }))
+          .filter((f) => Array.isArray(f.coord)),
+      );
+      d.mergeColors(seed.colors);
+      const savedBg = { kind: "vector", geojson: seed.background.geojson };
+      setCustomBg(rebuildPersistedBackground(savedBg, { persisted: false }));
+      d.patchMetadata({ customBackground: savedBg });
+      setCustomBgId(null);
+      d.setSaveStatus("dirty");
+      fmgLogLine(`✓ Imported ${seed.stats.regions} regions, ${seed.stats.polities} countries, ${seed.stats.cities} cities.`);
+      api.fitToData?.();
+    } catch (e) {
+      fmgLogLine(`✗ ${e?.message || e}`);
+      console.warn("[editor] FMG generate failed:", e);
+    } finally {
+      setFmgBusy(false);
     }
   };
 
@@ -475,6 +524,14 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
         onSelectBuiltin={selectBuiltinBasemap}
         onSelectCustom={selectLibraryBasemap}
         onUpload={uploadBasemap}
+      />
+
+      <FmgPanel
+        open={fmgOpen}
+        onToggle={() => setFmgOpen((o) => !o)}
+        busy={fmgBusy}
+        log={fmgLog}
+        onGenerate={generateFromFmg}
       />
     </div>
   );

--- a/src/Editor/fmg/FmgPanel.jsx
+++ b/src/Editor/fmg/FmgPanel.jsx
@@ -1,0 +1,184 @@
+/*! Open Historia — Fantasy Map Generator console © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Right-edge drawer for the map editor: a tab that expands into a console where
+// you enter a few values (seed, template, size, #states…) and hit Generate. It
+// hands those to the FMG driver, which runs Azgaar's generator headlessly and
+// imports the result (regions + countries + cities + a vector basemap) into the
+// editor. Pure presentation — the generation itself lives in fmgDriver.js.
+
+import React, { useState } from "react";
+import { panelSurface, inputStyle } from "../editorStyles.js";
+
+// FMG's heightmap templates (drive its landmass shape). Kept in sync with the
+// driver's template mapping; "random" lets FMG pick.
+const TEMPLATES = [
+  "random", "continents", "archipelago", "pangea", "isthmus", "atoll",
+  "mediterranean", "peninsula", "volcano", "highIsland", "lowIsland",
+];
+const SIZES = [
+  { id: "small", label: "Small (fast)", points: 4000 },
+  { id: "medium", label: "Medium", points: 10000 },
+  { id: "large", label: "Large (detailed)", points: 20000 },
+];
+
+const field = { display: "flex", flexDirection: "column", gap: 3, fontSize: 12 };
+const label = { color: "rgba(255,255,255,0.6)", fontSize: 11, letterSpacing: "0.02em" };
+
+const FmgPanel = ({ open, onToggle, busy, log = [], onGenerate }) => {
+  const [seed, setSeed] = useState("");
+  const [template, setTemplate] = useState("random");
+  const [size, setSize] = useState("medium");
+  const [states, setStates] = useState(12);
+  const [cultures, setCultures] = useState(8);
+  const [useProvinces, setUseProvinces] = useState(true);
+
+  const run = () => {
+    if (busy) return;
+    onGenerate?.({
+      seed: seed.trim(),
+      template,
+      points: SIZES.find((s) => s.id === size)?.points || 10000,
+      states: Math.max(1, Number(states) || 12),
+      cultures: Math.max(1, Number(cultures) || 8),
+      useProvinces,
+    });
+  };
+
+  return (
+    <>
+      {/* right-edge tab — always visible, toggles the drawer */}
+      <button
+        type="button"
+        onClick={onToggle}
+        title="Generate a world with the Fantasy Map Generator"
+        style={{
+          ...panelSurface,
+          position: "fixed",
+          top: "50%",
+          right: open ? 340 : 0,
+          transform: "translateY(-50%)",
+          zIndex: 36,
+          writingMode: "vertical-rl",
+          padding: "14px 7px",
+          border: "1px solid rgba(147,197,253,0.4)",
+          borderRight: open ? "1px solid rgba(147,197,253,0.4)" : "none",
+          borderRadius: open ? "10px 0 0 10px" : "10px 0 0 10px",
+          cursor: "pointer",
+          color: "white",
+          fontWeight: 700,
+          fontSize: 12,
+          letterSpacing: "0.06em",
+          transition: "right 160ms ease",
+          background: "rgba(59,130,246,0.85)",
+        }}
+      >
+        🗺 GENERATE {open ? "▸" : "◂"}
+      </button>
+
+      {open && (
+        <div
+          style={{
+            ...panelSurface,
+            position: "fixed",
+            top: 0,
+            right: 0,
+            bottom: 0,
+            width: 340,
+            zIndex: 35,
+            borderRadius: 0,
+            borderLeft: "1px solid rgba(147,197,253,0.35)",
+            display: "flex",
+            flexDirection: "column",
+            padding: "16px 16px 12px",
+            gap: 12,
+            overflowY: "auto",
+          }}
+        >
+          <div style={{ fontSize: 15, fontWeight: 800 }}>Generate a world</div>
+          <div style={{ ...label, marginTop: -6 }}>
+            Azgaar's Fantasy Map Generator builds the land, countries and cities; they
+            import straight into your map as vector regions + a biome basemap.
+          </div>
+
+          <div style={field}>
+            <span style={label}>Seed (blank = random)</span>
+            <input value={seed} onChange={(e) => setSeed(e.target.value)} placeholder="e.g. 174920" style={inputStyle} />
+          </div>
+
+          <div style={field}>
+            <span style={label}>Landmass template</span>
+            <select value={template} onChange={(e) => setTemplate(e.target.value)} style={inputStyle}>
+              {TEMPLATES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+
+          <div style={field}>
+            <span style={label}>Detail</span>
+            <select value={size} onChange={(e) => setSize(e.target.value)} style={inputStyle}>
+              {SIZES.map((s) => <option key={s.id} value={s.id}>{s.label}</option>)}
+            </select>
+          </div>
+
+          <div style={{ display: "flex", gap: 10 }}>
+            <div style={{ ...field, flex: 1 }}>
+              <span style={label}>Countries</span>
+              <input type="number" min={1} max={100} value={states} onChange={(e) => setStates(e.target.value)} style={inputStyle} />
+            </div>
+            <div style={{ ...field, flex: 1 }}>
+              <span style={label}>Cultures</span>
+              <input type="number" min={1} max={40} value={cultures} onChange={(e) => setCultures(e.target.value)} style={inputStyle} />
+            </div>
+          </div>
+
+          <label style={{ ...field, flexDirection: "row", alignItems: "center", gap: 8, cursor: "pointer" }}>
+            <input type="checkbox" checked={useProvinces} onChange={(e) => setUseProvinces(e.target.checked)} />
+            <span style={{ fontSize: 12 }}>Regions from provinces (finer than whole countries)</span>
+          </label>
+
+          <button
+            type="button"
+            onClick={run}
+            disabled={busy}
+            style={{
+              ...panelSurface,
+              marginTop: 2,
+              padding: "10px 14px",
+              cursor: busy ? "default" : "pointer",
+              color: "white",
+              fontWeight: 800,
+              fontSize: 14,
+              border: "1px solid rgba(147,197,253,0.5)",
+              background: busy ? "rgba(59,130,246,0.35)" : "rgba(59,130,246,0.85)",
+              opacity: busy ? 0.85 : 1,
+            }}
+          >
+            {busy ? "Generating…" : "⚙ Generate & import"}
+          </button>
+
+          {/* console log */}
+          <div
+            style={{
+              flex: 1,
+              minHeight: 120,
+              marginTop: 4,
+              padding: "8px 10px",
+              borderRadius: 8,
+              background: "rgba(0,0,0,0.35)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              fontFamily: "ui-monospace, Menlo, Consolas, monospace",
+              fontSize: 11,
+              lineHeight: 1.55,
+              color: "rgba(180,230,190,0.92)",
+              overflowY: "auto",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {log.length ? log.map((line, i) => <div key={i}>{line}</div>) : <span style={{ color: "rgba(255,255,255,0.3)" }}>Console output appears here…</span>}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default FmgPanel;

--- a/src/Editor/fmg/fmgDriver.js
+++ b/src/Editor/fmg/fmgDriver.js
@@ -1,0 +1,214 @@
+/*! Open Historia — Fantasy Map Generator driver © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Runs Azgaar's Fantasy Map Generator (pinned v1.109, vendored at /fmg/) headlessly
+// in a hidden same-origin iframe, drives a generation from a few inputs, and pulls
+// out the data fmgImport needs.
+//
+// Hard-won details this handles:
+//  • FMG state (pack, grid, …) are `let` globals in classic scripts — global lexical
+//    bindings, NOT window.pack — so we read them via the frame's own eval().
+//  • A hidden/headless frame reports innerWidth 0, so we set the map size explicitly
+//    (else FMG builds an empty 0×0 map and crashes).
+//  • We call FMG's generate() DIRECTLY (the data pipeline) — NOT regenerateMap, whose
+//    undraw()/drawLayers()/fitMapToScreen() rendering hangs in a zero-layout frame.
+//  • FMG's randomizeOptions() keeps LOCKED options and randomizes the rest, so we set
+//    AND lock our options to make them stick. Crucially we force a SYNCHRONOUS heightmap
+//    template: the "precreated" real-world heightmaps load a PNG whose onload never
+//    fires on a 404 (no onerror handler), hanging generate() at the heightmap forever.
+//  • The FMG frame shares this origin's localStorage; a prior session can persist a bad
+//    template there, so we reset it before loading.
+
+const FMG_PATH = "/fmg/index.html";
+const READY_TIMEOUT_MS = 90000;
+const MAP_W = 1920;
+const MAP_H = 1080;
+// Synchronous, in-memory heightmap templates (no image load → never hang).
+const SYNC_TEMPLATES = ["continents", "archipelago", "pangea", "mediterranean", "peninsula", "isthmus", "atoll", "highIsland", "lowIsland", "volcano", "shattered", "fractious"];
+// For "random" (or an unknown template) pick only from world-scale shapes — skip the
+// tiny-island templates (atoll/volcano/lowIsland) that make poor whole-world basemaps.
+// Deterministic for a given seed so re-running the same seed reproduces the same map.
+const WORLD_TEMPLATES = ["continents", "archipelago", "pangea", "mediterranean", "peninsula", "isthmus", "highIsland", "fractious"];
+const resolveTemplate = (params) => {
+  if (SYNC_TEMPLATES.includes(params.template)) return params.template;
+  const s = String(params.seed || "").replace(/[^0-9]/g, "");
+  const idx = s ? Number(s.slice(-4)) % WORLD_TEMPLATES.length : Math.floor(Math.random() * WORLD_TEMPLATES.length);
+  return WORLD_TEMPLATES[idx];
+};
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const evalIn = (win, expr) => { try { return win.eval(expr); } catch { return undefined; } };
+
+const cellCount = (win) =>
+  Number(evalIn(win, "typeof pack!=='undefined' && pack.cells && pack.cells.i ? pack.cells.i.length : 0")) || 0;
+const fmgReady = (win) =>
+  evalIn(win, "typeof generate==='function' && typeof d3!=='undefined' && typeof pack!=='undefined'") === true;
+const mapValid = (win) =>
+  cellCount(win) > 0 &&
+  Number(evalIn(win, "typeof pack!=='undefined' && pack.states ? pack.states.length : 0")) > 1 &&
+  Number(evalIn(win, "typeof mapCoordinates!=='undefined' && mapCoordinates.lonT ? mapCoordinates.lonT : 0")) > 0;
+
+const waitUntil = async (win, pred, timeout = READY_TIMEOUT_MS) => {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (pred(win)) return true;
+    await wait(300);
+  }
+  return false;
+};
+
+const need = (cond, what) => {
+  if (!cond) throw new Error(`FMG data shape changed — ${what} not found. The v1.109 adapter needs updating.`);
+};
+
+// Set our options and LOCK them so randomizeOptions() (which keeps locked options
+// and randomizes/resets the rest) uses them. Every id/mechanism here was verified
+// against FMG v1.109's own source:
+//  • template  — the <select> is populated LAZILY by the options UI, so it's EMPTY
+//    when we run headless. Setting .value to a template key would fail silently (no
+//    matching <option>) leaving value="" → generate() takes the fromPrecreated()
+//    branch and loads ./heightmaps/.png, which 404s and hangs forever (onload never
+//    fires, there's no onerror). So we ADD the option first (what applyOption does).
+//  • points    — the real cell count is pointsInput.dataset.cells, set by
+//    changeCellsDensity(level); randomizeOptions() resets it to 10k unless locked.
+//  • states    — a <slider-input> custom element whose .value setter updates both
+//    inner inputs; clamped to FMG's 1–100 range (120 silently fails).
+const setup = (win, params) => {
+  const states = Math.min(100, Math.max(1, Math.round(Number(params.states) || 12)));
+  const cultures = Math.min(30, Math.max(1, Math.round(Number(params.cultures) || 8)));
+  const points = Number(params.points) || 0;
+  const density = points >= 20000 ? 5 : points >= 10000 ? 4 : 3; // cellsDensityMap level
+  const template = resolveTemplate(params);
+  evalIn(
+    win,
+    `(function(){
+      function byId(id){return document.getElementById(id);}
+      function set(id,v){var el=byId(id); if(el&&v!=null){el.value=v; try{el.dispatchEvent(new Event('change',{bubbles:true}));}catch(e){}}}
+      function lk(id){try{ if(typeof lock==='function') lock(id); }catch(e){}}
+      // A hidden/headless frame reports innerWidth 0 → FMG builds a 0×0 map and crashes.
+      set('mapWidthInput',${MAP_W}); set('mapHeightInput',${MAP_H});
+      try{ if(typeof changeCellsDensity==='function') changeCellsDensity(${density}); }catch(e){}
+      lk('points');
+      set('statesNumber',${states}); lk('statesNumber');
+      set('culturesInput',${cultures}); set('culturesOutput',${cultures}); lk('cultures');
+      (function(){var s=byId('templateInput'); if(!s) return; var v=${JSON.stringify(template)};
+        if(typeof applyOption==='function'){ applyOption(s,v,v); }
+        else { if(!Array.from(s.options).some(function(o){return o.value===v;})) s.options.add(new Option(v,v)); s.value=v; }
+      })();
+      lk('template');
+    })()`,
+  );
+};
+
+// Clear the current cells (so mapValid only turns true once OUR generate rebuilds
+// the map, not the leftover on-load one), fire generate(), and POLL for completion.
+// We don't await generate()'s promise — awaiting a cross-realm iframe promise from
+// the parent doesn't resolve reliably. Retries a couple of times.
+const runGenerate = async (win, params, onLog) => {
+  const seed = params.seed ? String(params.seed).replace(/[^0-9]/g, "") : "";
+  const arg = seed ? `{seed:${JSON.stringify(seed)}}` : "";
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    evalIn(win, "try{ if(pack && pack.cells) pack.cells.i = []; }catch(e){}");
+    evalIn(win, `try{ generate(${arg}); }catch(e){}`);
+    const start = Date.now();
+    while (Date.now() - start < 20000) {
+      await wait(400);
+      if (mapValid(win)) return;
+    }
+    onLog?.(`attempt ${attempt}: no map yet (cells=${cellCount(win)}) — retrying…`);
+  }
+  throw new Error("FMG didn't produce a valid map. If it keeps failing, clear this site's data (localStorage) and retry.");
+};
+
+// Read all needed globals in one eval, then copy everything into plain JS.
+const extract = (win, onLog) => {
+  const G = evalIn(win, "({pack:pack, biomesData:biomesData, mapCoordinates:mapCoordinates, graphWidth:graphWidth, graphHeight:graphHeight})");
+  need(G && G.pack && G.pack.cells && G.pack.vertices?.p, "pack.cells / pack.vertices");
+  const { cells, vertices } = G.pack;
+  need(cells.v && cells.h && cells.biome && cells.state, "cell arrays (v/h/biome/state)");
+  const mc = G.mapCoordinates, gw = G.graphWidth, gh = G.graphHeight;
+  need(mc && gw && gh && mc.lonT != null && mc.latT != null, "mapCoordinates / graph dimensions");
+
+  const toGeo = (x, y) => [
+    +(mc.lonW + (x / gw) * mc.lonT).toFixed(4),
+    +(mc.latN - (y / gh) * mc.latT).toFixed(4),
+  ];
+
+  const features = [];
+  const n = cells.i.length;
+  for (let i = 0; i < n; i += 1) {
+    const vs = cells.v[i];
+    if (!vs || vs.length < 3) continue;
+    const ring = vs.map((v) => { const p = vertices.p[v]; return toGeo(p[0], p[1]); });
+    ring.push(ring[0]);
+    features.push({
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [ring] },
+      properties: {
+        height: cells.h[i],
+        biome: cells.biome[i],
+        type: G.pack.features?.[cells.f?.[i]]?.type,
+        state: cells.state[i],
+        province: cells.province ? cells.province[i] : 0,
+        population: cells.pop ? Math.round(cells.pop[i]) : 0,
+      },
+    });
+  }
+  need(features.length, "any cells");
+
+  const states = Array.from(G.pack.states || []).map((s) => ({ i: s.i, name: s.name, color: s.color, removed: s.removed }));
+  const provinces = Array.from(G.pack.provinces || []).map((p) => ({ i: p.i, name: p.name, color: p.color, state: p.state, removed: p.removed }));
+  const burgs = Array.from(G.pack.burgs || [])
+    .filter((b) => b && b.i && !b.removed && b.x != null && b.y != null)
+    .map((b) => { const [lon, lat] = toGeo(b.x, b.y); return { i: b.i, name: b.name, population: b.population, capital: b.capital, lon, lat }; });
+
+  const bd = G.biomesData;
+  const biomes = bd && bd.name ? Array.from(bd.name).map((name, idx) => ({ i: idx, name, color: bd.color?.[idx] || "#8aa66a" })) : [];
+
+  onLog?.(`Extracted ${features.length} cells, ${states.length} states, ${burgs.length} burgs.`);
+  return { cells: { type: "FeatureCollection", features }, states, provinces, burgs, biomes };
+};
+
+// Public entry: generate a world and return the raw bundle for fmgImport.
+export const generateFmgWorld = async (params = {}, onLog = () => {}) => {
+  // The FMG frame shares this origin's localStorage; a prior session can persist a
+  // heightmap template (or "load last saved") that hangs the on-load generation.
+  // Reset the risky keys before the frame loads.
+  try {
+    window.localStorage.removeItem("template");
+    window.localStorage.removeItem("onloadBehavior");
+  } catch { /* ignore */ }
+
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("aria-hidden", "true");
+  iframe.style.cssText = `position:fixed;left:-10000px;top:0;width:${MAP_W}px;height:${MAP_H}px;border:0;visibility:hidden;`;
+  iframe.src = new URL(FMG_PATH, window.location.origin).toString();
+
+  onLog("Loading Fantasy Map Generator…");
+  const loaded = new Promise((resolve, reject) => {
+    iframe.onload = resolve;
+    iframe.onerror = () => reject(new Error("Could not load /fmg/ — is FMG vendored and the server restarted?"));
+  });
+  document.body.appendChild(iframe);
+
+  try {
+    await loaded;
+    const win = iframe.contentWindow;
+    if (!win) throw new Error("No access to the FMG frame (must be served same-origin).");
+    onLog("Starting the generator…");
+    if (!(await waitUntil(win, fmgReady))) {
+      if (evalIn(win, "typeof d3!=='undefined'") !== true) {
+        throw new Error("The /fmg/ page isn't the Fantasy Map Generator — it isn't vendored yet. Run the updater (or `node scripts/fetch-fmg.mjs`), then restart the server.");
+      }
+      throw new Error("FMG scripts didn't finish loading in time.");
+    }
+    // Let FMG's own on-load generation settle (or fail fast) before we drive ours.
+    await waitUntil(win, (w) => cellCount(w) > 0, 12000);
+    await wait(800);
+    onLog("Generating the world…");
+    setup(win, params);
+    await runGenerate(win, params, onLog);
+    return extract(win, onLog);
+  } finally {
+    iframe.remove();
+  }
+};

--- a/src/Editor/fmg/fmgImport.js
+++ b/src/Editor/fmg/fmgImport.js
@@ -1,0 +1,216 @@
+/*! Open Historia — Fantasy Map Generator import adapter © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Turns a Fantasy Map Generator (Azgaar, MIT) generation into Open Historia
+// editor pieces: land regions dissolved by province/state, polities + colours
+// from states, cities from burgs, and a vector "basemap" (biome-coloured land)
+// that stays crisp at any zoom. Pure + framework-free so it's unit-testable; the
+// live FMG driver extracts the raw data and feeds it here.
+//
+// Input contract (all coordinates GEOGRAPHIC lon/lat — the driver converts FMG's
+// pixel space via FMG's own toGeoCoordinates before handing data over):
+//   cells:     GeoJSON FeatureCollection from FMG saveGeoJsonCells — each cell
+//              Polygon carries { height, biome, type, state, province, population }.
+//   states:    [{ i, name, color, removed }]        (pack.states)
+//   provinces: [{ i, name, color, state, removed }] (pack.provinces, optional)
+//   burgs:     [{ i, name, population, capital, lon, lat, removed }] (pack.burgs)
+//   biomes:    [{ i, name, color }]                 (biomesData)
+
+import polygonClipping from "polygon-clipping";
+
+const SEA_LEVEL = 20; // FMG convention: cell height >= 20 is land, below is water
+
+// The editor renders in Web Mercator (EPSG:3857). FMG's map is a FLAT
+// (equirectangular) rectangle, so to show it undistorted we place it in Mercator
+// space — where the editor's screen actually lives — preserving its flat aspect,
+// then hand the placed points back as lon/lat (the editor reprojects 4326 -> 3857
+// to draw). Fitting straight into a lat/lon box instead (the old way) let Mercator
+// stretch the latitudes, squashing the whole map horizontally.
+const MERC_R = 6378137; // EPSG:3857 sphere radius
+const MERC_MAX = Math.PI * MERC_R; // 20037508.34 — the 3857 world half-extent
+const WORLD_FILL = 0.92; // fraction of the Mercator world the map fills (leaves an ocean margin)
+const mercXToLon = (x) => (x / MERC_R) * (180 / Math.PI);
+const mercYToLat = (y) => (2 * Math.atan(Math.exp(y / MERC_R)) - Math.PI / 2) * (180 / Math.PI);
+
+const hexToRgb = (hex) => {
+  const h = String(hex || "").replace(/^#/, "");
+  if (h.length < 6) return [136, 136, 136];
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+};
+
+// A short, unique, stable owner code for a state — the editor keys ownership by code.
+const stateCode = (state) => `${(String(state.name || "").replace(/[^A-Za-z]/g, "").toUpperCase().slice(0, 3) || "ST")}${state.i}`;
+
+// ---- coordinate fit: FMG lon/lat bbox -> target extent, aspect-preserving ----
+const boundsOf = (features) => {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  const scan = (rings) => {
+    for (const ring of rings) for (const [x, y] of ring) {
+      if (x < minX) minX = x; if (x > maxX) maxX = x;
+      if (y < minY) minY = y; if (y > maxY) maxY = y;
+    }
+  };
+  for (const f of features) {
+    const g = f.geometry;
+    if (!g) continue;
+    if (g.type === "Polygon") scan(g.coordinates);
+    else if (g.type === "MultiPolygon") for (const p of g.coordinates) scan(p);
+  }
+  if (minX === Infinity) return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+  return { minX, minY, maxX, maxY };
+};
+
+// Place the source bbox (FMG equirectangular degrees — 1° lon == 1° lat in pixels,
+// so its width:height IS the map's true flat aspect) into Mercator space, centred
+// and preserving that aspect, then convert back to lon/lat. The landmass keeps its
+// proportions at any latitude instead of being squashed by the projection.
+const makeFit = (src) => {
+  const sw = src.maxX - src.minX || 1, sh = src.maxY - src.minY || 1;
+  const aspect = sw / sh;
+  const avail = 2 * MERC_MAX * WORLD_FILL;
+  let mw = avail, mh = avail / aspect; // fill width first…
+  if (mh > avail) { mh = avail; mw = avail * aspect; } // …unless that overflows the height
+  return ([x, y]) => {
+    const mx = -mw / 2 + ((x - src.minX) / sw) * mw; // west → east
+    const my = -mh / 2 + ((y - src.minY) / sh) * mh; // south → north
+    return [+mercXToLon(mx).toFixed(4), +mercYToLat(my).toFixed(4)];
+  };
+};
+
+const mapGeom = (geom, fit) => {
+  if (geom.type === "Polygon") return { type: "Polygon", coordinates: geom.coordinates.map((r) => r.map(fit)) };
+  if (geom.type === "MultiPolygon") return { type: "MultiPolygon", coordinates: geom.coordinates.map((p) => p.map((r) => r.map(fit))) };
+  return geom;
+};
+
+// Union GeoJSON Polygon/MultiPolygon geometries into one MultiPolygon. FMG cells
+// can have tiny gaps/overlaps, and union can throw on degenerate input — fall back
+// to the undissolved cells rather than dropping the region.
+const dissolve = (geoms) => {
+  const polys = [];
+  for (const g of geoms) {
+    if (g.type === "Polygon") polys.push(g.coordinates);
+    else if (g.type === "MultiPolygon") polys.push(...g.coordinates);
+  }
+  if (!polys.length) return null;
+  try {
+    return { type: "MultiPolygon", coordinates: polygonClipping.union(...polys) };
+  } catch {
+    return { type: "MultiPolygon", coordinates: polys };
+  }
+};
+
+export const fmgToEditorSeed = (data, options = {}) => {
+  const { cells = { features: [] }, states = [], provinces = [], burgs = [], biomes = [] } = data || {};
+  const groupBy = options.groupBy === "state" ? "state" : provinces.length ? "province" : "state";
+
+  const stateById = new Map(states.map((s) => [s.i, s]));
+  const provinceById = new Map(provinces.map((p) => [p.i, p]));
+  const biomeById = new Map(biomes.map((b) => [b.i, b]));
+
+  // Land cells only (drop ocean/lake), so water never becomes a region.
+  const landCells = (cells.features || []).filter((f) => {
+    const p = f.properties || {};
+    return Number(p.height) >= SEA_LEVEL && p.type !== "ocean" && p.type !== "lake";
+  });
+
+  const fit = makeFit(boundsOf(landCells));
+
+  // ---- regions: dissolve land cells by province (or state) ----
+  const regionGroups = new Map();
+  for (const f of landCells) {
+    const p = f.properties || {};
+    const stateId = Number(p.state) || 0;
+    const provinceId = Number(p.province) || 0;
+    const key = groupBy === "province" ? `p${provinceId}_s${stateId}` : `s${stateId}`;
+    const g = regionGroups.get(key) || { geoms: [], stateId, provinceId };
+    g.geoms.push(mapGeom(f.geometry, fit));
+    regionGroups.set(key, g);
+  }
+
+  const regionFeatures = [];
+  for (const [key, g] of regionGroups) {
+    const state = stateById.get(g.stateId);
+    if (!state || state.i === 0) continue; // neutral/unclaimed land isn't a region
+    const geometry = dissolve(g.geoms);
+    if (!geometry) continue;
+    const owner = stateCode(state);
+    const province = provinceById.get(g.provinceId);
+    regionFeatures.push({
+      type: "Feature",
+      geometry,
+      properties: {
+        id: `reg_fmg_${key}`,
+        owner,
+        gid0: owner,
+        name: province?.name || state.name || owner,
+        country: state.name || owner,
+        typeId: "land",
+      },
+    });
+  }
+
+  // ---- polities + colours from states ----
+  const polities = [];
+  const colors = {};
+  for (const s of states) {
+    if (!s || s.i === 0 || s.removed) continue;
+    const code = stateCode(s);
+    colors[code] = hexToRgb(s.color);
+    polities.push({ code, name: s.name || code, color: s.color || "#888888" });
+  }
+
+  // ---- cities from burgs ----
+  const cityFeatures = [];
+  for (const b of burgs) {
+    if (!b || b.removed || b.lon == null || b.lat == null) continue;
+    const pop = Number(b.population) || 0; // FMG population is in thousands
+    const capital = Boolean(b.capital);
+    cityFeatures.push({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: fit([b.lon, b.lat]) },
+      properties: {
+        city: b.name || "",
+        population: Math.round(pop * 1000),
+        capital: capital ? "primary" : "",
+        tier: capital ? 4 : pop >= 20 ? 3 : pop >= 5 ? 2 : 1,
+      },
+    });
+  }
+
+  // ---- vector basemap: land dissolved by biome, each feature carries its fill ----
+  // A data-driven renderer paints these biome colours; a plain vector renderer just
+  // shows land vs sea. Either way it's sharp at any zoom (no raster to pixelate).
+  const biomeGroups = new Map();
+  for (const f of landCells) {
+    const bid = Number((f.properties || {}).biome) || 0;
+    const g = biomeGroups.get(bid) || [];
+    g.push(mapGeom(f.geometry, fit));
+    biomeGroups.set(bid, g);
+  }
+  const bgFeatures = [];
+  for (const [bid, geoms] of biomeGroups) {
+    const geometry = dissolve(geoms);
+    if (!geometry) continue;
+    const biome = biomeById.get(bid);
+    bgFeatures.push({
+      type: "Feature",
+      geometry,
+      properties: { biome: biome?.name || String(bid), fill: biome?.color || "#8aa66a" },
+    });
+  }
+
+  return {
+    regions: { type: "FeatureCollection", features: regionFeatures },
+    polities,
+    colors,
+    cities: { type: "FeatureCollection", features: cityFeatures },
+    background: { kind: "vector", geojson: { type: "FeatureCollection", features: bgFeatures } },
+    stats: {
+      regions: regionFeatures.length,
+      polities: polities.length,
+      cities: cityFeatures.length,
+      biomes: bgFeatures.length,
+      landCells: landCells.length,
+    },
+  };
+};


### PR DESCRIPTION
Add a "Generate" console to the map editor (a right-edge tab) that runs a vendored copy of Azgaar's Fantasy Map Generator (FMG, MIT) headlessly and imports its output as a full, editable world: provinces/states become regions, each country keeps its colour, burgs become cities, and biomes become a vector basemap - all from a seed and a few inputs.

- fmgDriver.js runs FMG (pinned v1.109) in a hidden same-origin iframe, drives one generation and reads its data. It forces a synchronous heightmap template (the "precreated" ones load a PNG that hangs forever on a 404), sets and locks the options so randomizeOptions keeps them, and clamps states to FMG's 1-100 range.
- fmgImport.js transforms FMG cells/states/provinces/burgs/biomes into the editor's regions, country colours, cities and vector background.
- FMG itself is vendored at /fmg by scripts/fetch-fmg.mjs (run by the updater), served same-origin by the server, and gitignored.