### PR TITLE
Roll-back-turn cheat, event-camera toggle, and related fixes

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -171,6 +171,15 @@ const OPTIONAL_JSON_ASSET_FILES = {
   colors: "colors.json",
 };
 
+// Roll-back restore points, captured client-side each turn (see the "Roll back
+// turn" cheat). A per-game runtime asset kept deliberately OUT of JSON_ASSET_FILES
+// so it is never copied into new games, embedded in scenario exports, or dragged
+// into the polled details bundle — a snapshot list holds full prior state and can
+// be large. Read/written only through the /api/runtime/json/snapshots endpoint.
+const RUNTIME_ONLY_JSON_ASSET_FILES = {
+  snapshots: "storage/snapshots.json",
+};
+
 const PMTILES_ASSET_FILES = {
   cities: "cities.pmtiles",
   countries: "countries.pmtiles",
@@ -220,6 +229,7 @@ const JSON_ASSET_DEFAULTS = {
   game: {},
   prompts: {},
   world: {},
+  snapshots: [],
 };
 
 const TEMPLATE_WORLD_OVERRIDE_KEYS = [
@@ -356,7 +366,7 @@ const getGameMetaPath = (gameId) => path.join(getGameDirectory(gameId), "game-in
 const getGameJsonPath = (gameId, assetKey) =>
 path.join(
   getGameDirectory(gameId),
-          JSON_ASSET_FILES[assetKey] ?? OPTIONAL_JSON_ASSET_FILES[assetKey],
+          JSON_ASSET_FILES[assetKey] ?? OPTIONAL_JSON_ASSET_FILES[assetKey] ?? RUNTIME_ONLY_JSON_ASSET_FILES[assetKey],
 );
 const getGameUploadPath = (gameId, assetKey) =>
 path.join(getGameDirectory(gameId), UPLOADABLE_GAME_ASSET_FILES[assetKey]);
@@ -1785,7 +1795,7 @@ const readRuntimeJsonAsset = (assetKey) => {
   // No games yet — runtime data resolves from the scenario below.
   const activeGame = getActiveGameSummary();
   const gamePath =
-  activeGame && (assetKey in JSON_ASSET_FILES || assetKey in OPTIONAL_JSON_ASSET_FILES)
+  activeGame && (assetKey in JSON_ASSET_FILES || assetKey in OPTIONAL_JSON_ASSET_FILES || assetKey in RUNTIME_ONLY_JSON_ASSET_FILES)
   ? getGameJsonPath(activeGame.id, assetKey)
   : null;
 
@@ -1838,7 +1848,7 @@ const readRuntimeJsonAsset = (assetKey) => {
 const writeRuntimeJsonAsset = (assetKey, value) => {
   ensureGameStore();
 
-  if (!(assetKey in JSON_ASSET_FILES) && !(assetKey in OPTIONAL_JSON_ASSET_FILES)) {
+  if (!(assetKey in JSON_ASSET_FILES) && !(assetKey in OPTIONAL_JSON_ASSET_FILES) && !(assetKey in RUNTIME_ONLY_JSON_ASSET_FILES)) {
     throw new Error(`Unsupported JSON asset key: ${assetKey}`);
   }
 

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -863,6 +863,37 @@ const normalizeGeneratedEvent = (entry, index = 0) => {
   };
 };
 
+const MAX_ROLLBACK_SNAPSHOTS = 12;
+
+// Persist the PRE-turn state so the cheats menu's "Roll back turn" can restore it.
+// A dedicated per-game runtime asset (storage/snapshots.json) — never bundled with
+// a scenario or dragged through the 5s poll — capped so a long game can't grow it
+// without bound. Purely best-effort: a snapshot failure must never break a turn.
+const captureRollbackSnapshot = async ({ round, fromDate, toDate, game, world, events, actions, chat, colors }) => {
+  try {
+    const prior = await readJson(JSON_URLS.snapshots, { defaultValue: [], force: true }).catch(() => []);
+    const list = Array.isArray(prior) ? prior : [];
+    const snapshot = {
+      id: `snap-${round}-${Date.now()}`,
+      round,
+      fromDate,
+      toDate,
+      capturedAt: new Date().toISOString(),
+      state: {
+        game: cloneValue(game),
+        world: cloneValue(world),
+        events: cloneValue(events),
+        actions: cloneValue(actions),
+        chat: cloneValue(chat),
+        colors: cloneValue(colors),
+      },
+    };
+    await writeJson(JSON_URLS.snapshots, [snapshot, ...list].slice(0, MAX_ROLLBACK_SNAPSHOTS));
+  } catch (error) {
+    console.warn("[rollback] snapshot capture failed:", error);
+  }
+};
+
 const applySimulationResult = async ({
   baseActions,
   baseChats,
@@ -932,6 +963,19 @@ const applySimulationResult = async ({
     writeJson(JSON_URLS.colors, nextColors, { pretty: true }),
     writeWorldState(worldWithImpacts),
   ]);
+
+  // Snapshot the state we just replaced so it can be rolled back to (best-effort).
+  await captureRollbackSnapshot({
+    round: baseGame.round || 1,
+    fromDate: baseGame.gameDate || baseGame.startDate || "",
+    toDate: nextGame.gameDate || "",
+    game: baseGame,
+    world: baseWorld,
+    events: baseEvents,
+    actions: baseActions,
+    chat: baseChats,
+    colors: baseColors,
+  });
 
   return {
     actions: nextActions,

--- a/src/Game/GameUI/cheats.jsx
+++ b/src/Game/GameUI/cheats.jsx
@@ -24,6 +24,7 @@ const EMPTY_FEATURES = { type: "FeatureCollection", features: [] };
 
 const TOOLS = [
     { id: "master-ai", title: "Master AI", subtitle: "Full control over the game with AI assistance" },
+    { id: "roll-back-turn", title: "Roll Back Turn", subtitle: "Restore the game to the start of an earlier turn" },
     { id: "your-country", title: "Your Country", subtitle: "Change which country you're playing as" },
     { id: "difficulty", title: "Difficulty", subtitle: "Adjust the game difficulty level" },
     { id: "annex-country", title: "Annex Country", subtitle: "Click a country to annex it into another" },
@@ -92,24 +93,53 @@ const rgbToHex = (rgb) =>
         ? `#${rgb.map((part) => Math.max(0, Math.min(255, Math.round(part))).toString(16).padStart(2, "0")).join("")}`
         : "#888888";
 
-// Every country the game knows: the base map list, plus era polities from the
-// world (which win the name when both exist).
+// The countries that ACTUALLY exist in the current game — enumerated from the map,
+// not a fixed world list. Every defined polity, every current region owner, and the
+// owners of the rendered geometry (the scenario's own custom regions when it has
+// them, else the stock catalog), each resolved to its display NAME. On a fantasy
+// map this yields the invented nations only, never real-Earth countries; a country
+// you just created shows up too (it's in polityOverrides).
 const loadPolities = async () => {
-    const [countries, world] = await Promise.all([
-        loadCountryNames().catch(() => []),
-        readWorldState({ force: true }),
-    ]);
-    const merged = new Map();
-    for (const entry of countries ?? []) {
-        if (entry?.code) merged.set(entry.code, { code: entry.code, name: entry.name || entry.code });
+    const world = await readWorldState({ force: true });
+    const overrides = world.regionOwnershipOverrides ?? {};
+    const polityOverrides = world.polityOverrides ?? {};
+
+    // identifier -> display name (stock ISO names first, era/custom polity names win).
+    const nameByCode = new Map();
+    for (const entry of (await loadCountryNames().catch(() => [])) ?? []) {
+        if (entry?.code) nameByCode.set(String(entry.code), entry.name || String(entry.code));
     }
-    for (const polity of Object.values(world.polityOverrides ?? {})) {
-        if (polity?.code) merged.set(polity.code, { code: polity.code, name: polity.name || polity.code });
+    for (const [code, polity] of Object.entries(polityOverrides)) {
+        if (code && polity?.name) nameByCode.set(String(code), polity.name);
     }
-    return {
-        polities: Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name)),
-        world,
-    };
+
+    const owners = new Set();
+    for (const code of Object.keys(polityOverrides)) if (code) owners.add(String(code));
+    for (const owner of Object.values(overrides)) if (owner) owners.add(String(owner));
+    for (const code of world.ownerCodes ?? []) if (code) owners.add(String(code));
+
+    // Owners of the actually-rendered geometry, with current overrides applied: the
+    // scenario's own custom regions when present, otherwise the stock GADM catalog.
+    const custom = await readJson(JSON_URLS.regionsGeojson, { defaultValue: null }).catch(() => null);
+    if (Array.isArray(custom?.features) && custom.features.length) {
+        for (const feature of custom.features) {
+            const props = feature?.properties ?? {};
+            const id = props.id != null ? String(props.id) : "";
+            const owner = overrides[id] ?? props.owner ?? props.gid0;
+            if (owner) owners.add(String(owner));
+        }
+    } else {
+        for (const region of await loadRegionCatalog().catch(() => [])) {
+            const owner = overrides[region.id] ?? region.countryCode;
+            if (owner) owners.add(String(owner));
+        }
+    }
+
+    const polities = Array.from(owners)
+        .filter((code) => code && code.toLowerCase() !== "unclaimed")
+        .map((code) => ({ code, name: nameByCode.get(code) || code }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+    return { polities, world };
 };
 
 const PolitySelect = ({ polities, value, onChange, placeholder = "Pick a country…" }) => (
@@ -301,6 +331,11 @@ const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy
         if (tool === "events") {
             readEventsState({ force: true }).then(setItems).catch(() => setItems([]));
         }
+        if (tool === "roll-back-turn") {
+            readJson(JSON_URLS.snapshots, { defaultValue: [], force: true })
+                .then((list) => setItems(Array.isArray(list) ? list : []))
+                .catch(() => setItems([]));
+        }
         if (tool === "edit-feature" || tool === "clear-features") {
             readJson(JSON_URLS.citiesGeojson, { defaultValue: EMPTY_FEATURES, force: true })
                 .then((geojson) => setItems(geojson?.features ?? []))
@@ -347,6 +382,79 @@ const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy
             </button>
             <div style={{ color: "rgba(255,255,255,0.45)", fontSize: "0.72rem", marginTop: "0.5rem" }}>
             The AI interprets the command, applies its impacts to the map and countries, and records it as a game-master event.
+            </div>
+            {statusLine}
+            </div>
+            </>
+        );
+    }
+
+    if (tool === "roll-back-turn") {
+        const snapshots = items ?? [];
+        return (
+            <>
+            {header(meta.title, meta.subtitle)}
+            <div style={{ display: "flex", flexDirection: "column", minHeight: 0 }}>
+            <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.76rem", marginBottom: "0.5rem" }}>
+            Restore the game to how it was at the start of an earlier turn. This permanently discards every turn played after the one you pick.
+            </div>
+            {items === null && (
+                <div style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.76rem" }}>Loading restore points…</div>
+            )}
+            {items !== null && snapshots.length === 0 && (
+                <div style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.76rem" }}>
+                No restore points yet — one is captured automatically at the start of each turn. Play a turn, then come back.
+                </div>
+            )}
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.3rem", overflowY: "auto" }}>
+            {snapshots.map((snap, index) => {
+                const confirming = editingId === snap.id;
+                const dateLabel = snap.fromDate ? String(snap.fromDate) : "";
+                return (
+                    <div key={snap.id} style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 8, padding: "0.5rem 0.6rem" }}>
+                    <div style={{ alignItems: "center", display: "flex", gap: "0.4rem", justifyContent: "space-between" }}>
+                    <div style={{ minWidth: 0 }}>
+                    <div style={{ fontSize: "0.82rem", fontWeight: 700 }}>Round {snap.round}{dateLabel ? ` · ${dateLabel}` : ""}</div>
+                    <div style={{ color: "rgba(255,255,255,0.45)", fontSize: "0.68rem" }}>
+                    {index === 0 ? "undoes the most recent turn" : `undoes the last ${index + 1} turns`}
+                    </div>
+                    </div>
+                    {confirming ? (
+                        <div style={{ display: "flex", flexShrink: 0, gap: "0.3rem" }}>
+                        <button
+                        type="button"
+                        disabled={busy}
+                        style={{ ...primaryButtonStyle, padding: "0.25rem 0.55rem" }}
+                        onClick={() => runBusy(async () => {
+                            const s = snap.state ?? {};
+                            await Promise.all([
+                                writeJson(JSON_URLS.game, s.game ?? {}, { pretty: true }),
+                                writeJson(JSON_URLS.world, s.world ?? {}, { pretty: true }),
+                                writeJson(JSON_URLS.events, s.events ?? [], { pretty: true }),
+                                writeJson(JSON_URLS.actions, s.actions ?? [], { pretty: true }),
+                                writeJson(JSON_URLS.chat, s.chat ?? [], { pretty: true }),
+                                writeJson(JSON_URLS.colors, s.colors ?? {}, { pretty: true }),
+                            ]);
+                            // Drop this restore point and every newer one — those turns no longer happened.
+                            const remaining = snapshots.slice(index + 1);
+                            await writeJson(JSON_URLS.snapshots, remaining);
+                            setItems(remaining);
+                            setEditingId(null);
+                            await refresh();
+                            return `Rolled back to Round ${snap.round}. The map, date and panels catch up within a few seconds.`;
+                        })}
+                        >
+                        Confirm
+                        </button>
+                        <button type="button" style={{ ...buttonStyle, padding: "0.25rem 0.55rem" }} onClick={() => setEditingId(null)}>Cancel</button>
+                        </div>
+                    ) : (
+                        <button type="button" disabled={busy} style={{ ...buttonStyle, flexShrink: 0, padding: "0.25rem 0.55rem" }} onClick={() => setEditingId(snap.id)}>Roll back</button>
+                    )}
+                    </div>
+                    </div>
+                );
+            })}
             </div>
             {statusLine}
             </div>
@@ -486,11 +594,8 @@ const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy
         const adding = tool === "add-country";
         const applyCountry = () => runBusy(async () => {
             const name = (fields.name ?? "").trim();
-            // One naming scheme: the full name alone is enough — it becomes
-            // the identifier when no short code is given.
-            const code = adding
-                ? ((fields.code ?? "").trim().toUpperCase() || name)
-                : (target || "").trim();
+            // One naming scheme, no codes: the country's NAME is its identifier.
+            const code = adding ? name : (target || "").trim();
             const colorHex = (fields.color ?? "").trim();
             if (!code) throw new Error(adding ? "Give the country a name." : "Pick a country first.");
             const world = await readWorldState({ force: true });
@@ -512,20 +617,15 @@ const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy
             }
             await refresh();
             return adding
-                ? `${nextOverride.name} (${code}) created. Use Annex Country/Regions to give it territory.`
-                : `${nextOverride.name} (${code}) updated. The map picks up colors within a few seconds.`;
+                ? `${nextOverride.name} created. Use Annex Country or Annex Regions to give it territory.`
+                : `${nextOverride.name} updated. The map picks up colors within a few seconds.`;
         });
 
         return (
             <>
             {header(meta.title, meta.subtitle)}
             <div style={{ overflowY: "auto" }}>
-            {adding ? (
-                <>
-                <label style={labelStyle}>Code (optional — the name works on its own)</label>
-                <input style={inputStyle} value={fields.code ?? ""} maxLength={5} onChange={(event) => setFields({ ...fields, code: event.target.value.toUpperCase() })} placeholder="ATL" />
-                </>
-            ) : (
+            {!adding && (
                 <>
                 <label style={labelStyle}>Country</label>
                 <PolitySelect polities={polities} value={target} onChange={(code) => { setTarget(code); setFields({}); }} />

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -913,18 +913,11 @@ const EditorDrawer = ({
       {editorSection === "bundles" && kind === "scenario" && (
         <div style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "18px", marginBottom: "0.95rem", padding: "0.9rem" }}>
           <div style={{ color: "rgba(255,255,255,0.58)", fontSize: "0.82rem", lineHeight: 1.5, marginBottom: "0.85rem" }}>
-            Download the scenario as one JSON file. Use the lightweight export for quick sharing on default assets, or embed PMTiles when you want a fully portable bundle.
+            Download the scenario as one self-contained JSON file — any custom map geometry, cities and basemap travel inside it, so it's ready to share or re-import.
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.55rem" }}>
             <button onClick={() => onExportBundle("light")} style={actionButtonStyle} type="button">
               Download JSON
-            </button>
-            <button
-              onClick={() => onExportBundle("full")}
-              style={{ ...actionButtonStyle, background: "rgba(124,58,237,0.22)", borderColor: "rgba(124,58,237,0.36)" }}
-              type="button"
-            >
-              Download JSON + PMTiles
             </button>
           </div>
         </div>

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -750,6 +750,7 @@ const SettingsMenu = ({
     const [mapSettings, setMapSettingsState] = useState(() => ({
         hideCountryLabels: getMapSetting(MAP_SETTING_KEYS.hideCountryLabels),
         disableIdleRotation: getMapSetting(MAP_SETTING_KEYS.disableIdleRotation),
+        disableEventCamera: getMapSetting(MAP_SETTING_KEYS.disableEventCamera),
         basemapStyle: getMapSetting(MAP_SETTING_KEYS.basemapStyle),
     }));
 
@@ -832,6 +833,11 @@ const SettingsMenu = ({
         label="Disable idle globe rotation"
         enabled={mapSettings.disableIdleRotation}
         onToggle={() => updateMapSetting("disableIdleRotation", MAP_SETTING_KEYS.disableIdleRotation, !mapSettings.disableIdleRotation)}
+        />
+        <Toggle
+        label="Disable camera movement during events"
+        enabled={mapSettings.disableEventCamera}
+        onToggle={() => updateMapSetting("disableEventCamera", MAP_SETTING_KEYS.disableEventCamera, !mapSettings.disableEventCamera)}
         />
         <div style={{ marginBottom: "0.5rem" }}>
         <div style={{ fontSize: "0.9rem", marginBottom: "0.4rem" }}>Map style</div>

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -18,6 +18,7 @@ import {
     readWorldState,
 } from "../../runtime/gameState.js";
 import { useIsMobile } from "../../runtime/useIsMobile.js";
+import { MAP_SETTING_KEYS, useMapSetting } from "../../runtime/mapSettings.js";
 
 dayjs.extend(advancedFormat);
 
@@ -1061,6 +1062,7 @@ const DateWidget = ({
     const [visibleEventCount, setVisibleEventCount] = useState(1);
     const openPanel = typeof onSetPanel === "function" ? activePanel : localOpenPanel;
     const isMobile = useIsMobile();
+    const disableEventCamera = useMapSetting(MAP_SETTING_KEYS.disableEventCamera);
 
     useEffect(() => {
         ensureTimelineStyles();
@@ -1236,15 +1238,16 @@ const DateWidget = ({
     }, [latestTurnRecord?.id]);
 
     // The camera follows EVERY revealed event — impacts pin the exact spot,
-    // otherwise the countries the event involves do.
+    // otherwise the countries the event involves do. Opt out via the
+    // "Disable camera movement during events" map setting.
     useEffect(() => {
-        if (!activeVisibleEvent) {
+        if (!activeVisibleEvent || disableEventCamera) {
             return;
         }
 
         const bounds = deriveEventFocusBounds(activeVisibleEvent, { countryBounds, regionBounds, polityLookup });
         focusMapOnBounds(mapRef, bounds);
-    }, [activeVisibleEvent, countryBounds, mapRef, polityLookup, regionBounds]);
+    }, [activeVisibleEvent, countryBounds, disableEventCamera, mapRef, polityLookup, regionBounds]);
 
     const revealNextEvent = () => {
         setVisibleEventCount((current) => {
@@ -1283,9 +1286,14 @@ const DateWidget = ({
             ...widgetSurface,
             right: rightShift,
             top: topOffset,
-            // On phones the country name moves in here (the standalone pill
-            // would cover the date), so stretch up to the settings button.
-            ...(isMobile ? { width: "min(24rem, calc(100vw - 5.75rem))" } : null),
+            // The player's country sits beside the date. On phones the standalone
+            // pill would cover the date, so stretch the widget; on desktop cap the
+            // width so a long fantasy country name ellipsizes instead of sprawling.
+            ...(isMobile
+                ? { width: "min(24rem, calc(100vw - 5.75rem))" }
+                : playerCountry
+                ? { maxWidth: "min(28rem, calc(100vw - 8rem))" }
+                : null),
         }}
         >
         <button
@@ -1310,12 +1318,12 @@ const DateWidget = ({
         </button>
 
         <div style={{ alignItems: "center", display: "flex", flex: 1, flexDirection: "column", justifyContent: "center", minWidth: 0 }}>
-        {isMobile && playerCountry ? (
+        {playerCountry ? (
             <div style={{ alignItems: "baseline", display: "flex", gap: "0.5rem", justifyContent: "center", maxWidth: "100%", minWidth: 0 }}>
             <span
             style={{
                 color: "rgba(147,197,253,0.88)",
-                fontSize: "0.68rem",
+                fontSize: isMobile ? "0.68rem" : "0.8rem",
                 fontWeight: 700,
                 letterSpacing: "0.05em",
                 minWidth: 0,
@@ -1327,7 +1335,7 @@ const DateWidget = ({
             >
             {playerCountry}
             </span>
-            <span style={{ color: "rgba(255,255,255,0.94)", flexShrink: 0, fontSize: "0.82rem", letterSpacing: "0.02em", whiteSpace: "nowrap" }}>
+            <span style={{ color: "rgba(255,255,255,0.94)", flexShrink: 0, fontSize: isMobile ? "0.82rem" : "0.95rem", letterSpacing: "0.02em", whiteSpace: "nowrap" }}>
             {displayDate}
             </span>
             </div>

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -372,6 +372,18 @@ const WorldMap = ({ isGlobe = false }) => {
   // instead of showing a blank world.
   const customFlag = Boolean(worldState?.customRegions);
   const customActive = customFlag && Array.isArray(customRegionData?.features) && customRegionData.features.length > 0;
+  // True for maps with their OWN drawn/generated geometry (region ids like
+  // "reg_fmg_…", no dot) rather than re-ownership on the stock GADM tiles (ids like
+  // "USA.1_1"). On such a map the stock regions-fill layer is Earth left over
+  // underneath — clicking the fantasy ocean would otherwise resolve to whatever
+  // real country sits at that lat/lon (Russia, Canada…), so we must NOT query it.
+  const hasDrawnGeometry = useMemo(
+    () =>
+      customActive &&
+      Array.isArray(customRegionData?.features) &&
+      customRegionData.features.some((feature) => !/\./.test(String(feature?.properties?.id ?? ""))),
+    [customActive, customRegionData],
+  );
   // Re-read on each render so a runtime token change (switching games/scenarios)
   // refetches the geometry, mirroring the live-URL world poll below.
   const regionsGeojsonUrl = JSON_URLS.regionsGeojson;
@@ -458,10 +470,15 @@ const WorldMap = ({ isGlobe = false }) => {
     }
 
     dismissUnitPopup();
-    // Custom (editor) regions render on top of the stock regions; query both so a
-    // click resolves against whichever is present. Custom features carry
-    // id/owner/name/country; stock features carry GID_1/GID_0/NAME_1/COUNTRY.
-    const queryLayers = ["custom-regions-fill", "regions-fill"].filter((id) => map.getLayer(id));
+    // Custom (editor) regions render on top of the stock regions. On a map with its
+    // OWN drawn/generated geometry, query only the custom layers — a click on empty
+    // sea must resolve to nothing, not the leftover Earth country underneath. On a
+    // re-ownership map (stock GADM geometry), keep querying regions-fill: it IS the
+    // map, and its high-zoom hit-testing has no custom-layer equivalent.
+    const queryLayers = (hasDrawnGeometry
+      ? ["custom-regions-fill", "custom-regions-fill-far"]
+      : ["custom-regions-fill", "regions-fill"]
+    ).filter((id) => map.getLayer(id));
     const features = map.queryRenderedFeatures(event.point, { layers: queryLayers });
     if (!features.length) return;
 
@@ -481,7 +498,7 @@ const WorldMap = ({ isGlobe = false }) => {
       owner,
       lngLat: event.lngLat,
     });
-  }, [map]);
+  }, [hasDrawnGeometry, map]);
 
   useEffect(() => {
     if (!map) return;

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -147,6 +147,7 @@ export const setRuntimeAssetEndpoints = ({ token = "" } = {}) => {
   JSON_URLS.events = withRuntimeToken("/api/runtime/json/events");
   JSON_URLS.game = withRuntimeToken("/api/runtime/json/game");
   JSON_URLS.prompts = withRuntimeToken("/api/runtime/json/prompts");
+  JSON_URLS.snapshots = withRuntimeToken("/api/runtime/json/snapshots");
   JSON_URLS.regionsGeojson = withRuntimeToken("/api/runtime/json/regionsGeojson");
   JSON_URLS.citiesGeojson = withRuntimeToken("/api/runtime/json/citiesGeojson");
   JSON_URLS.world = withRuntimeToken("/api/runtime/json/world");

--- a/src/runtime/mapSettings.js
+++ b/src/runtime/mapSettings.js
@@ -12,12 +12,14 @@ const DEFAULT_BASEMAP_ID = "imagery";
 export const MAP_SETTING_KEYS = {
     hideCountryLabels: "map_hide_country_labels",
     disableIdleRotation: "map_disable_idle_rotation",
+    disableEventCamera: "map_disable_event_camera",
     basemapStyle: "map_basemap_style",
 };
 
 const BOOLEAN_KEYS = new Set([
     MAP_SETTING_KEYS.hideCountryLabels,
     MAP_SETTING_KEYS.disableIdleRotation,
+    MAP_SETTING_KEYS.disableEventCamera,
 ]);
 
 const STRING_DEFAULTS = {


### PR DESCRIPTION
Targets **main** (the stable release channel), per the request that the roll-back and event-camera features land in stable. Cherry-picked clean onto `main` (main and `alpha` have diverged, so this is the five commits only — not alpha's unmerged work). Production build passes.

## Explicitly requested for the stable release

- **Roll Back Turn cheat.** A new cheat tool lists captured turn snapshots (newest first) and restores the game to the start of a chosen turn, then trims later snapshots. Snapshots are captured server-side after each resolved turn as a runtime-only asset (kept out of the bulk asset loops, so it never bloats exports, clones, or scenario details), newest-first, capped at 12. Capture is best-effort and never throws into the turn pipeline.
- **"Disable camera movement during events" toggle** (Settings → Map). Suppresses the automatic fly-to when an event fires. Registered as a boolean map setting.

## Related fixes from the same batch

- **Ocean clicks on generated maps no longer resolve to Earth countries.** On drawn/FMG maps, region hit-testing used to fall back to the hidden stock Earth layer, so clicking open sea returned whatever GADM country sat underneath (Russia, Greenland, Canada…). Generated maps now query only the custom layers; empty ocean selects nothing.
- **Country name always shown beside the date**, not just on mobile.
- **Cheats country pickers now enumerate the scenario's actual countries** (from polity overrides, region ownership, and rendered geometry) instead of a fixed 240-entry Earth list — so fantasy maps show only their own nations. The raw country-code input is gone from Add Country (a country is identified by its name), and because the picker is now map-derived, a freshly created country immediately appears in the Annex tool.
- **Removed the vestigial "Download JSON + PMTiles" button** — it only embedded pmtiles for uploaded-pmtiles overrides the current vector editor never produces, so it was always identical to Download JSON.

---

Submitting for review — not merging.
