### PR TITLE
Security hardening + audit bug fixes (alpha)

### DIFF
--- a/server/basemapStore.js
+++ b/server/basemapStore.js
@@ -48,8 +48,20 @@ const normalizeId = (raw, fallback = "basemap") => {
   return base || fallback;
 };
 
-const metaPath = (id) => path.join(BASEMAPS_DIR, `${id}.json`);
-const payloadPath = (id) => path.join(BASEMAPS_DIR, `${id}.payload.json`);
+// Guard against path traversal: get/delete pass the raw route :id here (only
+// create normalizes), so an id like ..%2f..%2ffoo would escape BASEMAPS_DIR.
+// Require the file to resolve to a direct child of BASEMAPS_DIR.
+const basemapFilePath = (id, suffix) => {
+  const base = path.resolve(BASEMAPS_DIR);
+  const resolved = path.resolve(base, `${String(id ?? "")}${suffix}`);
+  if (path.dirname(resolved) !== base) {
+    throw new Error(`Invalid basemap id: ${id}`);
+  }
+  return resolved;
+};
+
+const metaPath = (id) => basemapFilePath(id, ".json");
+const payloadPath = (id) => basemapFilePath(id, ".payload.json");
 
 const getManifest = () => {
   const m = readJson(MANIFEST_PATH, null);
@@ -99,10 +111,11 @@ export const findBasemapIdByHash = (hash) => {
   return id && fs.existsSync(metaPath(id)) ? id : null;
 };
 
-// Hash the payload so identical basemaps dedupe. Prefer a client-supplied hash
-// (it already computed one for the community-dedup check) but verify shape.
-const hashPayload = (payload, supplied) => {
-  if (typeof supplied === "string" && /^[a-f0-9]{16,64}$/i.test(supplied)) return supplied.toLowerCase();
+// Hash the payload so identical basemaps dedupe. Always compute it server-side:
+// trusting a client-supplied hash (even shape-checked) let a caller store a
+// basemap under an arbitrary hash and poison the dedup index, so a later
+// genuine upload that hashed to the same value was silently discarded.
+const hashPayload = (payload) => {
   const canonical = payload?.dataUrl ?? JSON.stringify(payload?.geojson ?? payload ?? null);
   return crypto.createHash("sha256").update(String(canonical)).digest("hex");
 };
@@ -114,7 +127,7 @@ export const createBasemap = (body = {}) => {
   if (!payload || (kind === "image" && !payload.dataUrl) || (kind === "vector" && !payload.geojson)) {
     throw new Error("Basemap payload missing (need { dataUrl } for image or { geojson } for vector).");
   }
-  const contentHash = hashPayload(payload, body.contentHash);
+  const contentHash = hashPayload(payload);
 
   // Dedup: an identical basemap already in the library is reused, not duplicated.
   const existingId = findBasemapIdByHash(contentHash);

--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -230,12 +230,15 @@ const JSON_ASSET_DEFAULTS = {
 const TEMPLATE_WORLD_OVERRIDE_KEYS = [
   "allowedUnitTypes",
 "author",
+"background",
+"basemap",
 "customCities",
 "customRegions",
 "difficulty",
 "language",
 "mapCredit",
 "notes",
+"ownerCodes",
 "polityOverrides",
 "regionOwnershipOverrides",
 "simulationRules",
@@ -346,7 +349,23 @@ const removeFileIfPresent = (targetPath) => {
   }
 };
 
-const getScenarioDirectory = (scenarioId) => path.join(SCENARIOS_DIR, scenarioId);
+// Guard against path traversal. An id must resolve to a direct child of its
+// base directory; anything containing ../ or a path separator (including the
+// %2f Express decodes back into "/") would otherwise escape the data dir and
+// let an unauthenticated request read, overwrite or delete arbitrary .json
+// files. Only create paths were normalized before — read/update/delete took
+// the raw id straight into path.join.
+const resolveWithinDirectory = (baseDir, id, label) => {
+  const base = path.resolve(baseDir);
+  const resolved = path.resolve(base, String(id ?? ""));
+  if (path.dirname(resolved) !== base) {
+    throw new Error(`Invalid ${label}: ${id}`);
+  }
+  return resolved;
+};
+
+const getScenarioDirectory = (scenarioId) =>
+  resolveWithinDirectory(SCENARIOS_DIR, scenarioId, "scenario id");
 const getScenarioMetaPath = (scenarioId) => path.join(getScenarioDirectory(scenarioId), "scenario.json");
 const getScenarioJsonPath = (scenarioId, assetKey) =>
 path.join(
@@ -356,7 +375,7 @@ path.join(
 const getScenarioUploadPath = (scenarioId, assetKey) =>
 path.join(getScenarioDirectory(scenarioId), UPLOADABLE_SCENARIO_ASSET_FILES[assetKey]);
 
-const getGameDirectory = (gameId) => path.join(GAMES_DIR, gameId);
+const getGameDirectory = (gameId) => resolveWithinDirectory(GAMES_DIR, gameId, "game id");
 const getGameMetaPath = (gameId) => path.join(getGameDirectory(gameId), "game-instance.json");
 const getGameJsonPath = (gameId, assetKey) =>
 path.join(

--- a/server/mapEditorStore.js
+++ b/server/mapEditorStore.js
@@ -44,7 +44,17 @@ const normalizeId = (raw, fallback = "map") => {
   return base || fallback;
 };
 
-const docPath = (id) => path.join(DOCS_DIR, `${id}.json`);
+// Guard against path traversal: read/update/delete pass the raw route :id
+// straight here (only create normalizes), so an id like ..%2f..%2ffoo would
+// escape DOCS_DIR. Require the file to resolve to a direct child of DOCS_DIR.
+const docPath = (id) => {
+  const base = path.resolve(DOCS_DIR);
+  const resolved = path.resolve(base, `${String(id ?? "")}.json`);
+  if (path.dirname(resolved) !== base) {
+    throw new Error(`Invalid map id: ${id}`);
+  }
+  return resolved;
+};
 
 const getManifest = () => {
   const m = readJson(MANIFEST_PATH, null);

--- a/server/server.js
+++ b/server/server.js
@@ -84,6 +84,43 @@ const sendError = (res, statusCode, error) => {
   res.status(statusCode).json({ error: message });
 };
 
+// Block cross-origin state-changing requests (CSRF / drive-by protection).
+// The blanket CORS above is needed so the Android connect screen (on the
+// WebView's own origin) can *probe* this server — a GET. But it also let any
+// web page the user happens to be visiting POST/PUT/DELETE to localhost:
+// delete saved maps and games, drive the AI relay at internal hosts, or hit
+// /api/server/shutdown. The app serves its own SPA, so real gameplay writes
+// are same-origin (Origin absent, or Origin host === Host); a foreign Origin
+// on a write is rejected. Set OH_ALLOW_CROSS_ORIGIN=1 to restore the old
+// fully-open behavior if a client setup genuinely needs cross-origin writes.
+const ALLOW_CROSS_ORIGIN_WRITES = process.env.OH_ALLOW_CROSS_ORIGIN === "1";
+const CROSS_ORIGIN_SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+app.use((req, res, next) => {
+  if (ALLOW_CROSS_ORIGIN_WRITES || CROSS_ORIGIN_SAFE_METHODS.has(req.method)) {
+    return next();
+  }
+  const origin = req.headers.origin;
+  if (!origin) {
+    // No Origin header: same-origin non-CORS request or a native (non-browser)
+    // client. Browsers always attach Origin to cross-site writes.
+    return next();
+  }
+  let originHost;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return sendError(res, 403, new Error("Cross-origin request blocked (invalid Origin)."));
+  }
+  if (originHost === req.headers.host) {
+    return next();
+  }
+  return sendError(
+    res,
+    403,
+    new Error("Cross-origin write blocked. Set OH_ALLOW_CROSS_ORIGIN=1 on the server to allow it."),
+  );
+});
+
 const streamBinaryFile = (req, res, sourcePath, contentType = "application/octet-stream") => {
   const stats = fs.statSync(sourcePath);
   const totalSize = stats.size;
@@ -100,19 +137,26 @@ const streamBinaryFile = (req, res, sourcePath, contentType = "application/octet
   }
 
   const match = /bytes=(\d*)-(\d*)/i.exec(rangeHeader);
-  if (!match) {
-    res.status(416).end();
+  if (!match || (!match[1] && !match[2])) {
+    res.status(416).setHeader("Content-Range", `bytes */${totalSize}`).end();
     return;
   }
 
-  const start = match[1] ? Number.parseInt(match[1], 10) : 0;
-  const end = match[2] ? Number.parseInt(match[2], 10) : totalSize - 1;
-  const clampedStart = Number.isFinite(start) ? Math.max(0, Math.min(start, totalSize - 1)) : 0;
-  const clampedEnd = Number.isFinite(end)
-    ? Math.max(clampedStart, Math.min(end, totalSize - 1))
-    : totalSize - 1;
+  let clampedStart;
+  let clampedEnd;
+  if (!match[1]) {
+    // Suffix range "bytes=-N": the final N bytes of the file, not the first N.
+    const suffix = Number.parseInt(match[2], 10);
+    clampedStart = Math.max(0, totalSize - suffix);
+    clampedEnd = totalSize - 1;
+  } else {
+    const start = Number.parseInt(match[1], 10);
+    const end = match[2] ? Number.parseInt(match[2], 10) : totalSize - 1;
+    clampedStart = Math.max(0, Math.min(start, totalSize - 1));
+    clampedEnd = Math.max(clampedStart, Math.min(end, totalSize - 1));
+  }
 
-  if (clampedStart >= totalSize || clampedEnd >= totalSize) {
+  if (clampedStart >= totalSize) {
     res.status(416).setHeader("Content-Range", `bytes */${totalSize}`).end();
     return;
   }
@@ -508,14 +552,35 @@ app.post("/api/server/shutdown", (_req, res) => {
   setTimeout(() => process.exit(0), 300);
 });
 
+const isAllowedHubUrl = (candidate) =>
+  candidate.protocol === "https:" && HUB_DOWNLOAD_HOSTS.has(candidate.hostname);
+
 app.get("/api/hub/file", async (req, res) => {
   try {
-    const target = new URL(String(req.query.url ?? ""));
-    if (target.protocol !== "https:" || !HUB_DOWNLOAD_HOSTS.has(target.hostname)) {
+    let current = new URL(String(req.query.url ?? ""));
+    if (!isAllowedHubUrl(current)) {
       return sendError(res, 400, new Error("Only GitHub-hosted scenario files can be fetched."));
     }
 
-    const upstream = await fetch(target, { redirect: "follow" });
+    // Follow redirects manually so every hop is re-checked against the host
+    // allowlist. `redirect: "follow"` would chase a github.com redirect to an
+    // attacker-controlled host (SSRF); GitHub's own release redirect
+    // (github.com -> objects.githubusercontent.com) stays inside the allowlist.
+    let upstream;
+    for (let hop = 0; ; hop += 1) {
+      if (hop > 5) {
+        return sendError(res, 502, new Error("Too many redirects fetching scenario file."));
+      }
+      upstream = await fetch(current, { redirect: "manual" });
+      if (upstream.status < 300 || upstream.status >= 400) break;
+      const location = upstream.headers.get("location");
+      if (!location) break;
+      const next = new URL(location, current);
+      if (!isAllowedHubUrl(next)) {
+        return sendError(res, 400, new Error("Scenario file redirected off GitHub."));
+      }
+      current = next;
+    }
     if (!upstream.ok) {
       return sendError(res, 502, new Error(`Hub file fetch failed (HTTP ${upstream.status}).`));
     }

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -283,20 +283,30 @@ const formatDateReadable = (value) => {
 };
 
 const buildDifficultyGuidance = (difficulty, mode = "general") => {
-  const normalizedDifficulty = normalizeString(difficulty).toLowerCase();
+  // Difficulty ids are stored hyphenated (very-easy / easy / medium / hard /
+  // very-hard / impossible — see difficulty.js). Collapse spaces/underscores to
+  // hyphens so both the id form and any spaced label match; without this,
+  // very-easy, very-hard and impossible all fell through to the neutral default
+  // and silently had no effect on the AI.
+  const normalizedDifficulty = normalizeString(difficulty).toLowerCase().replace(/[\s_]+/g, "-");
   const intro =
     mode === "chats"
       ? "Diplomatic concessions and cooperation should scale with the difficulty."
       : "Long-term success and geopolitical leverage should scale with the difficulty.";
 
   switch (normalizedDifficulty) {
+    case "very-easy":
+      return `${intro} The player can turn even modest preparation into results, and setbacks should stay forgiving.`;
     case "easy":
       return `${intro} The player can convert reasonable preparation into results relatively easily.`;
     case "hard":
       return `${intro} The player should need stronger leverage, preparation, and credibility before major outcomes stick.`;
-    case "very hard":
+    case "very-hard":
     case "extreme":
       return `${intro} Major outcomes should require overwhelming preparation, sustained leverage, or unusually favorable conditions.`;
+    case "impossible":
+      return `${intro} Outcomes should almost never break the player's way without extraordinary, sustained, multi-front effort.`;
+    case "medium":
     default:
       return `${intro} Outcomes should feel plausible and earned without becoming static.`;
   }
@@ -768,11 +778,19 @@ const fallbackJumpSimulation = async ({ bundle, days, mode, targetDate }) => {
   const firstThreeActions = plannedActions.slice(0, 3);
   const events = [];
 
+  // Ancient/FMG scenarios use plain-text or BCE dates dayjs can't parse; fall
+  // back to the current date string instead of the literal "Invalid Date".
+  const baseGameDate = dayjs(bundle.game.gameDate);
+  const advanceGameDate = (dayCount) =>
+    baseGameDate.isValid()
+      ? baseGameDate.add(dayCount, "day").format("YYYY-MM-DD")
+      : normalizeString(bundle.game.gameDate);
+
   if (firstThreeActions.length > 0) {
     firstThreeActions.forEach((action, index) => {
-      const eventDate = dayjs(bundle.game.gameDate)
-        .add(Math.max(1, Math.round(((index + 1) / (firstThreeActions.length + 1)) * Math.max(days, 1))), "day")
-        .format("YYYY-MM-DD");
+      const eventDate = advanceGameDate(
+        Math.max(1, Math.round(((index + 1) / (firstThreeActions.length + 1)) * Math.max(days, 1))),
+      );
 
       events.push({
         date: eventDate,
@@ -806,9 +824,7 @@ const fallbackJumpSimulation = async ({ bundle, days, mode, targetDate }) => {
       });
     });
   } else {
-    const midpoint = dayjs(bundle.game.gameDate)
-      .add(Math.max(1, Math.round(Math.max(days, 1) / 2)), "day")
-      .format("YYYY-MM-DD");
+    const midpoint = advanceGameDate(Math.max(1, Math.round(Math.max(days, 1) / 2)));
     events.push({
       date: midpoint,
       description: `Foreign ministries and general staffs keep adjusting to the current balance of power while ${bundle.game.country} gathers its next move.`,
@@ -1365,7 +1381,15 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
   const bundle = await readGameStateBundle({ force: true });
   const baseColors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
   const safeDays = Math.max(1, Math.trunc(Number(days) || 0));
-  const targetDate = dayjs(bundle.game.gameDate).add(safeDays, "day").format("YYYY-MM-DD");
+  // Ancient/FMG scenarios use plain-text or BCE dates dayjs can't parse. Guard
+  // the day-math so it doesn't format to the literal string "Invalid Date" and
+  // then get persisted into game.gameDate (which corrupted the save and every
+  // subsequent date). When unparseable, keep the current date and let the AI's
+  // own stopDate drive the narrative forward.
+  const parsedGameDate = dayjs(bundle.game.gameDate);
+  const targetDate = parsedGameDate.isValid()
+    ? parsedGameDate.add(safeDays, "day").format("YYYY-MM-DD")
+    : normalizeString(bundle.game.gameDate);
   const variables = await buildTemplateVariables(bundle, { targetDate });
   const [minEvents, maxEvents] = eventCountRangeForDays(safeDays);
   let payload = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {

--- a/src/Game/GameUI/cheats.jsx
+++ b/src/Game/GameUI/cheats.jsx
@@ -441,7 +441,19 @@ const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy
                             const world = await readWorldState({ force: true });
                             const overrides = { ...world.regionOwnershipOverrides };
                             if (wholeCountry) {
-                                const source = props.owner || props.GID_0 || props.gid0;
+                                // Resolve the clicked region's CURRENT owner. On a stock
+                                // map a region reassigned via regionOwnershipOverrides still
+                                // carries its original GID_0 in the tile, so reading the raw
+                                // property annexed the wrong country — consult the override
+                                // for this region id first.
+                                const clickedId =
+                                    props.id != null
+                                        ? String(props.id)
+                                        : props.GID_1 != null
+                                            ? String(props.GID_1)
+                                            : "";
+                                const source =
+                                    (clickedId && overrides[clickedId]) || props.owner || props.GID_0 || props.gid0;
                                 if (!source || source === owner) return;
                                 const catalog = await loadRegionCatalog();
                                 let count = 0;

--- a/src/Game/Map/useCustomBackground.js
+++ b/src/Game/Map/useCustomBackground.js
@@ -30,7 +30,10 @@ export function useCustomBackground() {
       const basemap = world?.basemap || null;
       basemapRef.current = basemap;
       const desc = world?.background;
-      const key = desc && desc.kind ? String(desc.kind) : "";
+      // Key on the whole descriptor, not just kind: swapping one image
+      // background for another (both kind "image") kept showing the old one
+      // until a full reload, because the key never changed.
+      const key = desc && desc.kind ? JSON.stringify(desc) : "";
       if (key === keyRef.current) {
         setState((s) => (s.basemap === basemap ? s : { ...s, basemap })); // keep stable ref
         return;
@@ -43,11 +46,25 @@ export function useCustomBackground() {
       // Commit to "no ESRI" from the light descriptor right away, then load the
       // heavy payload and swap in the actual image/vector.
       setState({ background: null, declared: true, basemap });
-      const data = await readJson(JSON_URLS.backgroundData, { defaultValue: null, force: true }).catch(() => null);
+      // Read without a default so a transient fetch failure rejects (rather than
+      // silently resolving to null) and we can tell it apart from a genuinely
+      // empty payload.
+      let data = null;
+      let payloadFailed = false;
+      try {
+        data = await readJson(JSON_URLS.backgroundData, { force: true });
+      } catch {
+        payloadFailed = true;
+      }
       if (cancelled || keyRef.current !== key) return; // superseded while loading
       if (desc.kind === "image" && data?.dataUrl) setState({ background: { kind: "image", imageUrl: data.dataUrl }, declared: true, basemap: basemapRef.current });
       else if (desc.kind === "vector" && data?.geojson) setState({ background: { kind: "vector", geojson: data.geojson }, declared: true, basemap: basemapRef.current });
-      else setState({ background: null, declared: false, basemap: basemapRef.current });
+      else {
+        // Don't pin a permanent blank after a failed payload fetch — clear the
+        // cached key so the next poll retries instead of short-circuiting above.
+        if (payloadFailed) keyRef.current = "";
+        setState({ background: null, declared: false, basemap: basemapRef.current });
+      }
     };
 
     poll();

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -22,6 +22,17 @@ if (typeof caches !== "undefined" && caches?.keys) {
     .catch(() => {});
 }
 const JSON_HEADERS = { "Content-Type": "application/json" };
+
+// A Response constructed from a string gets no Content-Length, and the Cache
+// Storage match returns the stored header list verbatim — so the HEAD freshness
+// check (which compares the cached body length against the server's) is silently
+// disabled for every URL the client has written, and a second device keeps
+// serving its stale cached copy. Stamp the real UTF-8 byte length so the check
+// works.
+const jsonHeadersFor = (payload) => ({
+  ...JSON_HEADERS,
+  "Content-Length": String(new TextEncoder().encode(payload).length),
+});
 const FALLBACK_THREADS = 4;
 const remoteValueCache = new Map();
 const remoteRequestCache = new Map();
@@ -135,6 +146,22 @@ let countryNamesPromise = null;
 let countryNamesPromiseKey = "";
 let regionCatalogPromise = null;
 let regionCatalogPromiseKey = "";
+
+// getNationColors and loadCountryNames memoize on the scenario token, which only
+// changes on a scenario/library switch — never on a runtime write. So after the
+// AI (or a cheat) writes new colors or creates a polity mid-game, those caches
+// keep serving the pre-write value for the rest of the session. A write to the
+// underlying asset must drop the derived cache so the next read recomputes.
+const invalidateDerivedCachesForWrite = (url) => {
+  if (url && url === JSON_URLS.colors) {
+    nationColorsPromise = null;
+    nationColorsPromiseKey = "";
+  }
+  if (url && url === JSON_URLS.world) {
+    countryNamesPromise = null;
+    countryNamesPromiseKey = "";
+  }
+};
 let mapRuntimeConfigured = false;
 let vectorTileModulesPromise = null;
 
@@ -483,10 +510,11 @@ export const writeJson = async (url, data, { pretty = false } = {}) => {
   }
 
   primeJson(url, data);
+  invalidateDerivedCachesForWrite(url);
   persistResponse(
     url,
     new Response(payload, {
-      headers: JSON_HEADERS,
+      headers: jsonHeadersFor(payload),
       status: 200,
       statusText: "OK",
     }),
@@ -546,7 +574,7 @@ export const writeRuntimeJson = async (
   await persistResponse(
     buildRuntimeCacheUrl(key),
     new Response(payload, {
-      headers: JSON_HEADERS,
+      headers: jsonHeadersFor(payload),
       status: 200,
       statusText: "OK",
     }),
@@ -852,8 +880,15 @@ export const loadRegionCatalog = async ({ force = false } = {}) => {
       // (reg_* ids) and seed-only regions — get their names from the active
       // scenario's own geometry, so the AI can talk about them by name instead
       // of raw ids. Usually already in the JSON cache (the map fetched it).
+      let customRegionsResolved = true;
       try {
         const custom = await readJson(JSON_URLS.regionsGeojson, { defaultValue: null });
+        // readJson returns the default WITHOUT caching on a transient failure,
+        // but DOES cache a genuine "no custom geometry" result. That lets us
+        // tell a dropped fetch (retry) apart from a scenario that simply has no
+        // custom regions (stock names are correct) — so one failed request on a
+        // custom map can't pin a blank political map for the whole session.
+        customRegionsResolved = jsonValueCache.has(JSON_URLS.regionsGeojson);
         for (const feature of custom?.features ?? []) {
           const props = feature?.properties ?? {};
           const id = props.id != null ? String(props.id) : "";
@@ -867,7 +902,12 @@ export const loadRegionCatalog = async ({ force = false } = {}) => {
           });
         }
       } catch {
-        // No custom geometry (or fetch hiccup) — stock names only.
+        customRegionsResolved = false;
+      }
+
+      if (!customRegionsResolved && regionCatalogPromise === promise) {
+        // Don't pin a stock-only catalog after a failed custom fetch — retry.
+        regionCatalogPromise = null;
       }
 
       return Array.from(seen.values()).sort((left, right) => {


### PR DESCRIPTION
Fixes the confirmed findings from the codebase audit, plus a round of follow-up hardening. **Targets `alpha`** so it can be validated before promoting to stable — the origin guard in particular wants an on-device check. Because the audit ran on alpha, this covers **all 16 applicable findings** (three don't exist on `main` yet). Build passes, `npm test` passes, and the server fixes were verified against a running instance.

## Follow-up hardening (latest push)

- **Closed the hostile-LAN gap in the origin guard.** The CSRF guard allowed writes with no `Origin` header (native clients). A browser always sends `Origin`, so the only legitimate no-Origin caller is a native client on the **same machine** — now enforced: no-Origin writes are accepted only from loopback, so a `curl` from another host on the LAN can no longer delete saves or drive the relay. *(This is a cleaner fix than a full session token — same hole closed, no client/UX change.)* `OH_ALLOW_CROSS_ORIGIN=1` still opens everything.
- **Soft-delete.** Deleting a scenario/game now moves it to `server/data/.trash` (gitignored) instead of unlinking — recoverable by hand. *Verified live:* delete → gone from `scenarios/`, present in `.trash/`.
- **A test suite.** Extracted the path-containment, origin-guard, range-parsing and hub-allowlist logic into `server/security.js` and covered it with `node:test` unit tests (`npm test`, no new deps). The audit's findings were all in this kind of pure logic, so the suite locks them in. 11 tests, all passing.

## Security (audit)

- **Path traversal → arbitrary `.json` read/delete** on map-editor, basemap and scenario/game routes — all four stores now require the target to resolve to a direct child of their dir. *Verified live.*
- **Drive-by cross-origin writes (CSRF)** — foreign-`Origin` state-changing requests rejected; same-origin app writes and loopback native clients still work.
  - **⚠️ Please test on-device — this is the main reason for the alpha target.** Assumes the Android app runs same-origin after connecting. If connecting/saving breaks, set `OH_ALLOW_CROSS_ORIGIN=1` and tell me; I'll switch to an explicit origin allowlist.
- **Basemap hash spoofing** — `hashPayload` now always computed server-side. *Verified live.*
- **Redirect revalidation** on `/api/hub/file` — every hop re-checked against the GitHub allowlist.

## Client caching / consistency

- `Content-Length` on writes (stale cache on a shared server); drop derived color/country caches on write; retry the region catalog after a failed fetch; custom-background keyed on the full descriptor + retry on failure.

## Correctness / data-loss

- No more `"Invalid Date"` on BCE jumps; all difficulty ids honored; `background`/`basemap`/`ownerCodes` preserved on reseed; Annex Country uses the region's current owner, not its static `GID_0`.

---

Submitting for review — not merging. Once proven out on alpha (especially the on-device connect/save check), it can go to `main`.
