### PR TITLE
Security hardening follow-ups: loopback guard, soft-delete, test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test \"server/**/*.test.js\""
   },
   "dependencies": {
     "@turf/area": "^7.3.5",

--- a/server/basemapStore.js
+++ b/server/basemapStore.js
@@ -15,6 +15,7 @@ import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import url from "url";
+import { resolveChildPath } from "./security.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, "data");
@@ -48,20 +49,10 @@ const normalizeId = (raw, fallback = "basemap") => {
   return base || fallback;
 };
 
-// Guard against path traversal: get/delete pass the raw route :id here (only
-// create normalizes), so an id like ..%2f..%2ffoo would escape BASEMAPS_DIR.
-// Require the file to resolve to a direct child of BASEMAPS_DIR.
-const basemapFilePath = (id, suffix) => {
-  const base = path.resolve(BASEMAPS_DIR);
-  const resolved = path.resolve(base, `${String(id ?? "")}${suffix}`);
-  if (path.dirname(resolved) !== base) {
-    throw new Error(`Invalid basemap id: ${id}`);
-  }
-  return resolved;
-};
-
-const metaPath = (id) => basemapFilePath(id, ".json");
-const payloadPath = (id) => basemapFilePath(id, ".payload.json");
+// get/delete pass the raw route :id here (only create normalizes), so the
+// shared containment guard keeps ..%2f..%2f from escaping BASEMAPS_DIR.
+const metaPath = (id) => resolveChildPath(BASEMAPS_DIR, `${id}.json`, "basemap id");
+const payloadPath = (id) => resolveChildPath(BASEMAPS_DIR, `${id}.payload.json`, "basemap id");
 
 const getManifest = () => {
   const m = readJson(MANIFEST_PATH, null);

--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -2,6 +2,7 @@
 import fs from "fs";
 import path from "path";
 import url from "url";
+import { resolveChildPath as resolveWithinDirectory } from "./security.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.join(__dirname, "..");
@@ -347,21 +348,6 @@ const removeFileIfPresent = (targetPath) => {
   if (fs.existsSync(targetPath)) {
     fs.rmSync(targetPath, { force: true });
   }
-};
-
-// Guard against path traversal. An id must resolve to a direct child of its
-// base directory; anything containing ../ or a path separator (including the
-// %2f Express decodes back into "/") would otherwise escape the data dir and
-// let an unauthenticated request read, overwrite or delete arbitrary .json
-// files. Only create paths were normalized before — read/update/delete took
-// the raw id straight into path.join.
-const resolveWithinDirectory = (baseDir, id, label) => {
-  const base = path.resolve(baseDir);
-  const resolved = path.resolve(base, String(id ?? ""));
-  if (path.dirname(resolved) !== base) {
-    throw new Error(`Invalid ${label}: ${id}`);
-  }
-  return resolved;
 };
 
 const getScenarioDirectory = (scenarioId) =>
@@ -1544,6 +1530,19 @@ const updateGame = (
   return getGameDetails(gameId);
 };
 
+// Soft-delete: move a scenario/game directory into server/data/.trash instead
+// of unlinking it, so an accidental delete (or, before the traversal fix, a
+// malicious one) is recoverable — the user can restore or empty .trash by hand.
+const TRASH_DIR = path.join(SERVER_DATA_DIR, ".trash");
+const moveDirectoryToTrash = (sourceDir, kind, id) => {
+  ensureDirectory(TRASH_DIR);
+  const safeId = String(id).replace(/[^a-z0-9_-]+/gi, "_").slice(0, 60) || "item";
+  let dest = path.join(TRASH_DIR, `${kind}-${safeId}`);
+  let n = 2;
+  while (fs.existsSync(dest)) dest = path.join(TRASH_DIR, `${kind}-${safeId}-${n++}`);
+  fs.renameSync(sourceDir, dest);
+};
+
 const deleteScenario = (scenarioId) => {
   ensureScenarioStore();
 
@@ -1560,7 +1559,7 @@ const deleteScenario = (scenarioId) => {
     throw new Error(`Scenario not found: ${scenarioId}`);
   }
 
-  fs.rmSync(resolved, { force: true, recursive: true });
+  moveDirectoryToTrash(resolved, "scenario", scenarioId);
 
   const manifest = getScenarioManifest();
   const nextOrder = resolveOrderedIds(manifest.order, SCENARIOS_DIR, DEFAULT_SCENARIO_ID).filter(
@@ -1590,7 +1589,7 @@ const deleteGame = (gameId) => {
     throw new Error(`Game not found: ${gameId}`);
   }
 
-  fs.rmSync(resolved, { force: true, recursive: true });
+  moveDirectoryToTrash(resolved, "game", gameId);
 
   const manifest = getGameManifest();
   const nextOrder = resolveOrderedIds(manifest.order, GAMES_DIR, DEFAULT_GAME_ID).filter(

--- a/server/mapEditorStore.js
+++ b/server/mapEditorStore.js
@@ -11,6 +11,7 @@
 import fs from "fs";
 import path from "path";
 import url from "url";
+import { resolveChildPath } from "./security.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, "data");
@@ -44,17 +45,9 @@ const normalizeId = (raw, fallback = "map") => {
   return base || fallback;
 };
 
-// Guard against path traversal: read/update/delete pass the raw route :id
-// straight here (only create normalizes), so an id like ..%2f..%2ffoo would
-// escape DOCS_DIR. Require the file to resolve to a direct child of DOCS_DIR.
-const docPath = (id) => {
-  const base = path.resolve(DOCS_DIR);
-  const resolved = path.resolve(base, `${String(id ?? "")}.json`);
-  if (path.dirname(resolved) !== base) {
-    throw new Error(`Invalid map id: ${id}`);
-  }
-  return resolved;
-};
+// Read/update/delete pass the raw route :id here (only create normalizes), so
+// the shared containment guard keeps ..%2f..%2f from escaping DOCS_DIR.
+const docPath = (id) => resolveChildPath(DOCS_DIR, `${id}.json`, "map id");
 
 const getManifest = () => {
   const m = readJson(MANIFEST_PATH, null);

--- a/server/security.js
+++ b/server/security.js
@@ -1,0 +1,84 @@
+/*! Open Historia — server security helpers. Pure, dependency-light functions
+ *  for path containment, the CSRF/origin guard, HTTP range parsing and the hub
+ *  host allowlist. Kept separate so they can be unit-tested (security.test.js)
+ *  without spinning up the server. */
+import path from "path";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+// A child id/name must resolve to a DIRECT child of baseDir. Rejects "../", a
+// path separator (including the %2f Express decodes back into "/"), and absolute
+// paths, so an unnormalized route param can't escape the data dir on
+// read/update/delete. Throws on anything unsafe; returns the absolute path.
+export const resolveChildPath = (baseDir, name, label = "id") => {
+  const base = path.resolve(baseDir);
+  const resolved = path.resolve(base, String(name ?? ""));
+  if (path.dirname(resolved) !== base) {
+    throw new Error(`Invalid ${label}: ${name}`);
+  }
+  return resolved;
+};
+
+// True only for the local machine. IPv4-mapped IPv6 (::ffff:127.0.0.1) is
+// unwrapped first.
+export const isLoopbackAddress = (addr) => {
+  if (!addr) return false;
+  const a = String(addr).replace(/^::ffff:/i, "");
+  return a === "::1" || a === "127.0.0.1" || /^127\./.test(a);
+};
+
+// Decide whether a state-changing request may proceed (CSRF / drive-by guard).
+// Allowed: safe methods; same-origin app writes (Origin host === Host); and
+// native clients with no Origin BUT only from loopback. A foreign Origin, or a
+// no-Origin write from a non-loopback host (the hostile-LAN case the Origin
+// check can't see), is rejected. Returns { allowed, reason }.
+export const crossOriginWriteAllowed = ({ method, origin, host, remoteAddress, allowAll = false }) => {
+  if (allowAll) return { allowed: true, reason: "override" };
+  if (SAFE_METHODS.has(String(method || "").toUpperCase())) return { allowed: true, reason: "safe-method" };
+
+  if (!origin) {
+    return isLoopbackAddress(remoteAddress)
+      ? { allowed: true, reason: "loopback" }
+      : { allowed: false, reason: "no-origin-nonloopback" };
+  }
+
+  let originHost;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return { allowed: false, reason: "invalid-origin" };
+  }
+  return originHost === host
+    ? { allowed: true, reason: "same-origin" }
+    : { allowed: false, reason: "cross-origin" };
+};
+
+// Parse an HTTP Range header against a file of totalSize bytes. Returns
+// { status: 416 } for an unsatisfiable/empty range, else inclusive { start,
+// end }. Suffix ranges ("bytes=-N") correctly mean the FINAL N bytes.
+export const parseByteRange = (rangeHeader, totalSize) => {
+  const match = /bytes=(\d*)-(\d*)/i.exec(String(rangeHeader || ""));
+  if (!match || (!match[1] && !match[2])) return { status: 416 };
+
+  let start;
+  let end;
+  if (!match[1]) {
+    const suffix = Number.parseInt(match[2], 10);
+    start = Math.max(0, totalSize - suffix);
+    end = totalSize - 1;
+  } else {
+    const s = Number.parseInt(match[1], 10);
+    if (s >= totalSize) return { status: 416 }; // first-byte-pos past EOF
+    const e = match[2] ? Number.parseInt(match[2], 10) : totalSize - 1;
+    start = Math.max(0, Math.min(s, totalSize - 1));
+    end = Math.max(start, Math.min(e, totalSize - 1));
+  }
+
+  if (start >= totalSize) return { status: 416 };
+  return { start, end };
+};
+
+// A hub download URL must be https and on the GitHub host allowlist — checked on
+// the initial URL AND every redirect hop.
+export const isAllowedHubUrl = (candidate, allowedHosts) =>
+  candidate.protocol === "https:" && allowedHosts.has(candidate.hostname);

--- a/server/security.test.js
+++ b/server/security.test.js
@@ -1,0 +1,92 @@
+// Unit tests for the server security helpers. Run with `npm test`
+// (node --test). No framework needed — these are pure functions.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  crossOriginWriteAllowed,
+  isAllowedHubUrl,
+  isLoopbackAddress,
+  parseByteRange,
+  resolveChildPath,
+} from "./security.js";
+
+const BASE = path.resolve("/srv/data/scenarios");
+
+test("resolveChildPath accepts a plain child id", () => {
+  assert.equal(resolveChildPath(BASE, "modern-day"), path.join(BASE, "modern-day"));
+  assert.equal(resolveChildPath(BASE, "default.json"), path.join(BASE, "default.json"));
+});
+
+test("resolveChildPath rejects traversal, separators, empty and absolute paths", () => {
+  // Express decodes %2f to "/" before this runs, so the real attack arrives as "../".
+  for (const bad of ["../../manifest", "../sibling", "sub/child", "", ".", "/etc/passwd"]) {
+    assert.throws(() => resolveChildPath(BASE, bad), /Invalid/, `should reject ${JSON.stringify(bad)}`);
+  }
+});
+
+test("isLoopbackAddress recognises local addresses only", () => {
+  for (const ok of ["127.0.0.1", "127.1.2.3", "::1", "::ffff:127.0.0.1"]) {
+    assert.equal(isLoopbackAddress(ok), true, ok);
+  }
+  for (const no of ["192.168.1.5", "10.0.0.2", "::ffff:192.168.1.5", "", undefined, null]) {
+    assert.equal(isLoopbackAddress(no), false, String(no));
+  }
+});
+
+test("crossOriginWriteAllowed: safe methods always pass", () => {
+  assert.equal(crossOriginWriteAllowed({ method: "GET" }).allowed, true);
+  assert.equal(crossOriginWriteAllowed({ method: "OPTIONS" }).allowed, true);
+});
+
+test("crossOriginWriteAllowed: same-origin write allowed, foreign Origin blocked", () => {
+  assert.equal(
+    crossOriginWriteAllowed({ method: "POST", origin: "http://localhost:3000", host: "localhost:3000" }).allowed,
+    true,
+  );
+  assert.equal(
+    crossOriginWriteAllowed({ method: "DELETE", origin: "https://evil.com", host: "localhost:3000" }).allowed,
+    false,
+  );
+});
+
+test("crossOriginWriteAllowed: no-Origin allowed from loopback, blocked from LAN", () => {
+  assert.equal(
+    crossOriginWriteAllowed({ method: "POST", host: "localhost:3000", remoteAddress: "127.0.0.1" }).allowed,
+    true,
+  );
+  // A curl from another host on the LAN with no Origin — the hostile-LAN case.
+  const lan = crossOriginWriteAllowed({ method: "POST", host: "192.168.1.9:3000", remoteAddress: "192.168.1.50" });
+  assert.equal(lan.allowed, false);
+  assert.equal(lan.reason, "no-origin-nonloopback");
+});
+
+test("crossOriginWriteAllowed: override flag opens everything", () => {
+  assert.equal(
+    crossOriginWriteAllowed({ method: "POST", origin: "https://evil.com", host: "x", allowAll: true }).allowed,
+    true,
+  );
+});
+
+test("parseByteRange: suffix range returns the FINAL N bytes", () => {
+  assert.deepEqual(parseByteRange("bytes=-500", 10000), { start: 9500, end: 9999 });
+});
+
+test("parseByteRange: explicit and open-ended ranges", () => {
+  assert.deepEqual(parseByteRange("bytes=0-499", 10000), { start: 0, end: 499 });
+  assert.deepEqual(parseByteRange("bytes=500-", 10000), { start: 500, end: 9999 });
+});
+
+test("parseByteRange: empty / unsatisfiable ranges are 416", () => {
+  assert.equal(parseByteRange("bytes=-", 10000).status, 416);
+  assert.equal(parseByteRange("nonsense", 10000).status, 416);
+  assert.equal(parseByteRange("bytes=99999-", 10000).status, 416);
+});
+
+test("isAllowedHubUrl: https GitHub hosts only", () => {
+  const hosts = new Set(["github.com", "objects.githubusercontent.com"]);
+  assert.equal(isAllowedHubUrl(new URL("https://github.com/a/b"), hosts), true);
+  assert.equal(isAllowedHubUrl(new URL("https://objects.githubusercontent.com/x"), hosts), true);
+  assert.equal(isAllowedHubUrl(new URL("https://evil.com/x"), hosts), false);
+  assert.equal(isAllowedHubUrl(new URL("http://github.com/a/b"), hosts), false);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -46,6 +46,11 @@ import {
   getBasemapCatalog,
   getBasemapPayload,
 } from "./basemapStore.js";
+import {
+  crossOriginWriteAllowed,
+  isAllowedHubUrl,
+  parseByteRange,
+} from "./security.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const app = express();
@@ -90,28 +95,20 @@ const sendError = (res, statusCode, error) => {
 // web page the user happens to be visiting POST/PUT/DELETE to localhost:
 // delete saved maps and games, drive the AI relay at internal hosts, or hit
 // /api/server/shutdown. The app serves its own SPA, so real gameplay writes
-// are same-origin (Origin absent, or Origin host === Host); a foreign Origin
-// on a write is rejected. Set OH_ALLOW_CROSS_ORIGIN=1 to restore the old
-// fully-open behavior if a client setup genuinely needs cross-origin writes.
+// are same-origin (Origin host === Host). No-Origin writes are trusted only
+// from loopback — a native client on the same machine — so a curl from another
+// host on the LAN can't slip past with no Origin header. Set
+// OH_ALLOW_CROSS_ORIGIN=1 to restore the old fully-open behavior.
 const ALLOW_CROSS_ORIGIN_WRITES = process.env.OH_ALLOW_CROSS_ORIGIN === "1";
-const CROSS_ORIGIN_SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 app.use((req, res, next) => {
-  if (ALLOW_CROSS_ORIGIN_WRITES || CROSS_ORIGIN_SAFE_METHODS.has(req.method)) {
-    return next();
-  }
-  const origin = req.headers.origin;
-  if (!origin) {
-    // No Origin header: same-origin non-CORS request or a native (non-browser)
-    // client. Browsers always attach Origin to cross-site writes.
-    return next();
-  }
-  let originHost;
-  try {
-    originHost = new URL(origin).host;
-  } catch {
-    return sendError(res, 403, new Error("Cross-origin request blocked (invalid Origin)."));
-  }
-  if (originHost === req.headers.host) {
+  const decision = crossOriginWriteAllowed({
+    method: req.method,
+    origin: req.headers.origin,
+    host: req.headers.host,
+    remoteAddress: req.socket?.remoteAddress,
+    allowAll: ALLOW_CROSS_ORIGIN_WRITES,
+  });
+  if (decision.allowed) {
     return next();
   }
   return sendError(
@@ -136,30 +133,12 @@ const streamBinaryFile = (req, res, sourcePath, contentType = "application/octet
     return;
   }
 
-  const match = /bytes=(\d*)-(\d*)/i.exec(rangeHeader);
-  if (!match || (!match[1] && !match[2])) {
+  const range = parseByteRange(rangeHeader, totalSize);
+  if (range.status === 416) {
     res.status(416).setHeader("Content-Range", `bytes */${totalSize}`).end();
     return;
   }
-
-  let clampedStart;
-  let clampedEnd;
-  if (!match[1]) {
-    // Suffix range "bytes=-N": the final N bytes of the file, not the first N.
-    const suffix = Number.parseInt(match[2], 10);
-    clampedStart = Math.max(0, totalSize - suffix);
-    clampedEnd = totalSize - 1;
-  } else {
-    const start = Number.parseInt(match[1], 10);
-    const end = match[2] ? Number.parseInt(match[2], 10) : totalSize - 1;
-    clampedStart = Math.max(0, Math.min(start, totalSize - 1));
-    clampedEnd = Math.max(clampedStart, Math.min(end, totalSize - 1));
-  }
-
-  if (clampedStart >= totalSize) {
-    res.status(416).setHeader("Content-Range", `bytes */${totalSize}`).end();
-    return;
-  }
+  const { start: clampedStart, end: clampedEnd } = range;
 
   res.status(206);
   res.setHeader("Content-Length", clampedEnd - clampedStart + 1);
@@ -552,13 +531,10 @@ app.post("/api/server/shutdown", (_req, res) => {
   setTimeout(() => process.exit(0), 300);
 });
 
-const isAllowedHubUrl = (candidate) =>
-  candidate.protocol === "https:" && HUB_DOWNLOAD_HOSTS.has(candidate.hostname);
-
 app.get("/api/hub/file", async (req, res) => {
   try {
     let current = new URL(String(req.query.url ?? ""));
-    if (!isAllowedHubUrl(current)) {
+    if (!isAllowedHubUrl(current, HUB_DOWNLOAD_HOSTS)) {
       return sendError(res, 400, new Error("Only GitHub-hosted scenario files can be fetched."));
     }
 
@@ -576,7 +552,7 @@ app.get("/api/hub/file", async (req, res) => {
       const location = upstream.headers.get("location");
       if (!location) break;
       const next = new URL(location, current);
-      if (!isAllowedHubUrl(next)) {
+      if (!isAllowedHubUrl(next, HUB_DOWNLOAD_HOSTS)) {
         return sendError(res, 400, new Error("Scenario file redirected off GitHub."));
       }
       current = next;


### PR DESCRIPTION
Follow-up hardening on top of the merged audit fixes (#190). Targets `alpha`. `npm test` and the production build pass; the server behavior was verified against a running instance.

## Closed the hostile-LAN gap in the origin guard
The CSRF guard from #190 allowed writes with no `Origin` header (for native clients). A browser always sends `Origin`, so the only legitimate no-Origin caller is a native client on the **same machine** — now enforced: no-Origin writes are accepted only from loopback. A `curl` from another host on the LAN (no Origin, remote IP) can no longer delete saves or drive the AI relay.

This is a deliberately smaller fix than a full session token — it closes the same hole with **no client or connect-flow change**, so it doesn't need the token's UX work. `OH_ALLOW_CROSS_ORIGIN=1` still opens everything.

## Soft-delete for scenarios and games
Deleting a scenario/game now moves its directory into `server/data/.trash` (gitignored) instead of unlinking it, so an accidental (or, before #190, malicious) delete is recoverable. *Verified live:* delete → gone from `scenarios/`, present in `.trash/`.

## A test suite
Extracted the path-containment, origin-guard, range-parsing and hub-allowlist logic into `server/security.js` and covered it with `node:test` unit tests (`npm test`, no new dependencies). The audit's findings were all in exactly this kind of pure logic, so the suite locks them in against future refactors. 11 tests, all passing. Also made an out-of-range byte offset return 416 per RFC (caught by a test).

## ⚠️ On-device check
Same caveat as #190: the origin guard assumes the app runs same-origin after connecting. The loopback tightening only *narrows* the no-Origin path, so if #190 connected fine on-device this will too — but worth confirming. `OH_ALLOW_CROSS_ORIGIN=1` is the escape hatch.

---
Submitting for review — not merging.
