### PR TITLE
Timeline: short/custom skips + cancel + event-per-action; auto-rebuild on update

### DIFF
--- a/Launch Open Historia.bat
+++ b/Launch Open Historia.bat
@@ -84,13 +84,21 @@ REM ---- 4. Build the client ---------------------------------
 REM Give Node extra heap so the production build doesn't run out of memory
 REM on machines that are low on free RAM.
 set "NODE_OPTIONS=--max-old-space-size=4096"
-if not exist "dist\index.html" (
+REM Rebuild when the build is missing OR stale (an update made any source file
+REM newer than the last build). Previously this only built when dist was missing,
+REM so after every update players had to delete the dist folder by hand.
+set "OH_NEEDS_BUILD="
+if not exist "dist\index.html" set "OH_NEEDS_BUILD=1"
+if not defined OH_NEEDS_BUILD (
+    powershell -NoProfile -Command "$b=(Get-Item 'dist/index.html').LastWriteTimeUtc; if (Get-ChildItem -Recurse -File -Path src,public,server,index.html,vite.config.ts,package.json -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTimeUtc -gt $b } | Select-Object -First 1) { exit 1 }; exit 0"
+    if errorlevel 1 set "OH_NEEDS_BUILD=1"
+)
+if defined OH_NEEDS_BUILD (
     echo Building the app...
     call npm run build
     if errorlevel 1 goto :fail
 ) else (
-    echo [OK] Build already present.
-    echo      ^(Delete the "dist" folder to force a rebuild.^)
+    echo [OK] Build already up to date.
 )
 echo.
 

--- a/Launch Open Historia.sh
+++ b/Launch Open Historia.sh
@@ -129,12 +129,17 @@ echo ""
 # Give Node extra heap so the production build doesn't run out of memory
 # on machines that are low on free RAM.
 export NODE_OPTIONS="--max-old-space-size=4096"
+# Rebuild when the build is missing OR stale — i.e. an update changed any source
+# file since the last build. Previously this only built when dist was missing, so
+# after every update players had to delete dist by hand for changes to apply.
 if [ ! -f "dist/index.html" ]; then
     echo "Building the app..."
     npm run build || { echo ""; echo "[ERROR] Setup failed - see the messages above for details."; exit 1; }
+elif [ -n "$(find src public server index.html vite.config.ts package.json -newer "dist/index.html" 2>/dev/null | head -n 1)" ]; then
+    echo "An update changed the app - rebuilding to apply it..."
+    npm run build || { echo ""; echo "[ERROR] Setup failed - see the messages above for details."; exit 1; }
 else
-    echo "[OK] Build already present."
-    echo "     (Delete the \"dist\" folder to force a rebuild.)"
+    echo "[OK] Build already up to date."
 fi
 echo ""
 

--- a/Update Open Historia.bat
+++ b/Update Open Historia.bat
@@ -187,6 +187,10 @@ if not errorlevel 1 (
         node "scripts\fetch-fmg.mjs"
     )
 )
+REM The update changed the app's source, so the previous build in dist\ is
+REM stale. Remove it so the next launch rebuilds cleanly - players no longer
+REM have to delete dist by hand for an update to take effect.
+if exist "dist" rmdir /s /q "dist"
 echo.
 echo ===================================================
 echo   Update complete.

--- a/Update Open Historia.sh
+++ b/Update Open Historia.sh
@@ -182,6 +182,10 @@ finish() {
     # ZIP extraction can lose the executable bit - restore it.
     chmod +x "Launch Open Historia.sh" "Update Open Historia.sh" \
              "Launch Open Historia.command" "Update Open Historia.command" 2>/dev/null
+    # The update changed the app's source, so the previous build in dist/ is
+    # stale. Remove it so the next launch rebuilds cleanly - players no longer
+    # have to delete dist by hand for an update to take effect.
+    rm -rf dist 2>/dev/null || true
     # Refresh the vendored Fantasy Map Generator from its repo (the map editor's
     # world generator). Best-effort - needs Node + deps, which the launcher keeps
     # installed; a failure here never blocks the update.

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -244,6 +244,7 @@ const buildTemplateVariables = async (bundle, options = {}) => {
 // with nothing to show. The UI has spinners; waiting beats silently wrong.
 const runJsonTask = async (taskKey, {
   fallback,
+  signal,
   timeoutMs = 120000,
   userMessage,
   validatePayload,
@@ -265,6 +266,12 @@ const runJsonTask = async (taskKey, {
   }
 
   const controller = new AbortController();
+  // Let an external signal (the player pressing Cancel) abort the in-flight AI
+  // call too — the abort propagates through callAI to the server relay.
+  if (signal) {
+    if (signal.aborted) controller.abort(signal.reason);
+    else signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true });
+  }
   const deadline = Number.isFinite(timeoutMs) && timeoutMs > 0 ? Date.now() + timeoutMs : null;
   const timeoutError = new Error(`AI task "${taskKey}" timed out.`);
   const timeoutId = deadline ? setTimeout(() => controller.abort(timeoutError), timeoutMs) : null;
@@ -312,6 +319,15 @@ const runJsonTask = async (taskKey, {
     failureReason = normalizeString(actualError?.message || actualError) || failureReason;
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
+  }
+
+  // A deliberate user cancel must NOT silently fall back to canned events —
+  // propagate the abort so the caller can quietly cancel the jump with no state
+  // change. (A timeout still uses the fallback, as before.)
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new DOMException("Timeline jump cancelled.", "AbortError");
   }
 
   if (typeof fallback !== "function") {
@@ -1281,6 +1297,7 @@ export const advanceActiveCatalyst = async (choiceText) => {
 // Event density per skip length (player-tuned): longer skips must return
 // proportionally more events, and short ones must stay brief.
 const eventCountRangeForDays = (days) => {
+  if (days < 1) return [1, 1];   // sub-day skip (e.g. 6 hours)
   if (days <= 7) return [1, 2];
   if (days <= 31) return [5, 7];
   if (days <= 92) return [10, 13];
@@ -1288,19 +1305,49 @@ const eventCountRangeForDays = (days) => {
   return [29, 37];
 };
 
-export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
+// Human-readable label for the skipped span, used in the AI prompt. Collapses
+// whole-day counts into weeks/months/years where they divide evenly.
+const formatDurationLabel = (days) => {
+  if (days < 1) {
+    const hours = Math.max(1, Math.round(days * 24));
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const whole = Math.round(days);
+  const pluralize = (n, unit) => `${n} ${unit}${n === 1 ? "" : "s"}`;
+  if (whole % 365 === 0) return pluralize(whole / 365, "year");
+  if (whole % 30 === 0) return pluralize(whole / 30, "month");
+  if (whole % 7 === 0) return pluralize(whole / 7, "week");
+  return pluralize(whole, "day");
+};
+
+export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {}) => {
   const bundle = await readGameStateBundle({ force: true });
   const baseColors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
-  const safeDays = Math.max(1, Math.trunc(Number(days) || 0));
+  // Fractional days are allowed so sub-day skips (e.g. 6h = 0.25) work; the game
+  // date only advances in whole days, so a sub-day skip keeps the same date.
+  const safeDays = Math.max(0, Number(days) || 0);
+  if (safeDays <= 0) {
+    throw new Error("Choose a time-skip amount greater than zero.");
+  }
+  const dateStep = Math.max(0, Math.round(safeDays));
   const originDate = normalizeString(bundle.game.gameDate);
-  const targetDate = addIsoDays(originDate, safeDays) || originDate;
-  if (parseIsoDate(originDate) && targetDate === originDate) {
+  const targetDate = dateStep >= 1 ? (addIsoDays(originDate, dateStep) || originDate) : originDate;
+  if (dateStep >= 1 && parseIsoDate(originDate) && targetDate === originDate) {
     throw new Error("The requested jump exceeds the supported date range.");
   }
   const variables = await buildTemplateVariables(bundle, { targetDate });
-  const [minEvents, maxEvents] = eventCountRangeForDays(safeDays);
+  const durationLabel = formatDurationLabel(safeDays);
+  let [minEvents, maxEvents] = eventCountRangeForDays(safeDays);
+  // Guarantee at least one event per queued action, so each planned action has a
+  // slot to resolve into (bounded so a huge queue can't demand absurd counts).
+  const plannedActionCount = normalizeActions(bundle.actions).filter((action) => action.status === "planned").length;
+  if (plannedActionCount > minEvents) {
+    minEvents = Math.min(plannedActionCount, 37);
+    maxEvents = Math.max(maxEvents, minEvents + 3);
+  }
   const { generation, payload } = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {
-    fallback: () => fallbackJumpSimulation({ bundle, days: safeDays, mode, targetDate }),
+    fallback: () => fallbackJumpSimulation({ bundle, days: dateStep || 1, mode, targetDate }),
+    signal,
     // The jump IS the game — let slow (local/reasoning) models finish instead
     // of silently swapping in the canned fallback after a few seconds.
     timeoutMs: 180000,
@@ -1310,7 +1357,7 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
           "Scale the events array to the time actually covered before your stop point: roughly 1-2 events per week, " +
           "5-7 per month, 10-13 per quarter, up to 29-37 for a full year — spread their dates across the covered period."
         : `Simulate a standard jump forward to the requested target date. Return JSON only. The "events" array must ` +
-          `contain between ${minEvents} and ${maxEvents} events (this jump covers ${safeDays} days), with their dates ` +
+          `contain between ${minEvents} and ${maxEvents} events (this jump covers ${durationLabel}), with their dates ` +
            `spread across the skipped period.`,
     validatePayload: async (candidate) => {
       const eventCount = normalizeArray(candidate?.events).length;
@@ -1344,8 +1391,8 @@ export const simulateTimelineJump = async ({ days, mode = "jump" } = {}) => {
   });
 };
 
-export const simulateAutoJump = async ({ days = 365 } = {}) =>
-  simulateTimelineJump({ days, mode: "auto" });
+export const simulateAutoJump = async ({ days = 365, signal } = {}) =>
+  simulateTimelineJump({ days, mode: "auto", signal });
 
 export const applyGameMasterCommand = async (requestText) => {
   const bundle = await readGameStateBundle({ force: true });

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -857,13 +857,25 @@ const TimelineSkipPanel = ({
     isLoading,
     isOpen,
     onAutoJump,
+    onCancel,
     onClose,
     onJump,
     onUndo,
     topOffset,
     undoCount,
 }) => {
+    const [customValue, setCustomValue] = useState("");
+    const [customUnit, setCustomUnit] = useState("days");
+    const unitToDays = { hours: 1 / 24, days: 1, weeks: 7, months: 30, years: 365 };
+    const runCustomJump = () => {
+        const amount = Number(customValue);
+        if (!Number.isFinite(amount) || amount <= 0 || isLoading) return;
+        onJump(amount * (unitToDays[customUnit] ?? 1));
+    };
     const jumpOptions = [
+        { label: "6 hours", sublabel: dayjs(currentDate).format("M/D/YYYY"), days: 0.25 },
+        { label: "1 day", sublabel: dayjs(currentDate).add(1, "day").format("M/D/YYYY"), days: 1 },
+        { label: "3 days", sublabel: dayjs(currentDate).add(3, "day").format("M/D/YYYY"), days: 3 },
         { label: "1 week", sublabel: dayjs(currentDate).add(7, "day").format("M/D/YYYY"), days: 7 },
         { label: "1 month", sublabel: dayjs(currentDate).add(1, "month").format("M/D/YYYY"), days: 30 },
         { label: "3 months", sublabel: dayjs(currentDate).add(3, "month").format("M/D/YYYY"), days: 90 },
@@ -961,6 +973,84 @@ const TimelineSkipPanel = ({
         >
         <div style={{ fontSize: "0.85rem", fontWeight: 700 }}>Auto-jump</div>
         </button>
+
+        <div style={{ background: "rgba(139,92,246,0.4)", height: "1.25rem", width: "2px" }} />
+        <div
+        style={{
+            alignItems: "center",
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "12px",
+            display: "flex",
+            gap: "0.35rem",
+            padding: "0.45rem 0.5rem",
+            width: "12.5rem",
+        }}
+        >
+        <input
+        type="number"
+        min="1"
+        step="any"
+        value={customValue}
+        onChange={(event) => setCustomValue(event.target.value)}
+        onKeyDown={(event) => { if (event.key === "Enter") runCustomJump(); }}
+        placeholder="Custom"
+        disabled={isLoading}
+        style={{
+            background: "rgba(0,0,0,0.25)",
+            border: "1px solid rgba(255,255,255,0.16)",
+            borderRadius: "8px",
+            color: "#fff",
+            fontSize: "0.8rem",
+            minWidth: 0,
+            outline: "none",
+            padding: "0.3rem 0.4rem",
+            width: "3.4rem",
+        }}
+        />
+        <select
+        data-no-translate
+        value={customUnit}
+        onChange={(event) => setCustomUnit(event.target.value)}
+        disabled={isLoading}
+        style={{
+            background: "rgba(0,0,0,0.25)",
+            border: "1px solid rgba(255,255,255,0.16)",
+            borderRadius: "8px",
+            color: "#fff",
+            cursor: "pointer",
+            flex: 1,
+            fontSize: "0.8rem",
+            minWidth: 0,
+            outline: "none",
+            padding: "0.3rem 0.2rem",
+        }}
+        >
+        <option value="hours" style={{ color: "black" }}>hours</option>
+        <option value="days" style={{ color: "black" }}>days</option>
+        <option value="weeks" style={{ color: "black" }}>weeks</option>
+        <option value="months" style={{ color: "black" }}>months</option>
+        <option value="years" style={{ color: "black" }}>years</option>
+        </select>
+        <button
+        type="button"
+        onClick={runCustomJump}
+        disabled={isLoading || !customValue}
+        style={{
+            background: "rgba(109,40,217,0.4)",
+            border: "1px solid rgba(139,92,246,0.6)",
+            borderRadius: "8px",
+            color: "#fff",
+            cursor: isLoading || !customValue ? "default" : "pointer",
+            fontSize: "0.8rem",
+            fontWeight: 700,
+            opacity: isLoading || !customValue ? 0.5 : 1,
+            padding: "0.3rem 0.6rem",
+        }}
+        >
+        Go
+        </button>
+        </div>
         </div>
 
         {isLoading && (
@@ -979,6 +1069,26 @@ const TimelineSkipPanel = ({
             }}
             >
             <SpinnerRing size={15} />
+            <span>Simulating…</span>
+            {onCancel && (
+                <button
+                type="button"
+                onClick={onCancel}
+                style={{
+                    background: "rgba(220,38,38,0.18)",
+                    border: "1px solid rgba(248,113,113,0.5)",
+                    borderRadius: "8px",
+                    color: "#fecaca",
+                    cursor: "pointer",
+                    fontSize: "0.74rem",
+                    fontWeight: 600,
+                    marginLeft: "0.2rem",
+                    padding: "0.28rem 0.7rem",
+                }}
+                >
+                Cancel
+                </button>
+            )}
             </div>
         )}
 
@@ -1111,6 +1221,8 @@ const DateWidget = ({
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState("");
     const [fallbackWarning, setFallbackWarning] = useState("");
+    // Holds the in-flight jump's AbortController so the Cancel button can stop it.
+    const jumpAbortRef = React.useRef(null);
     const [visibleEventCount, setVisibleEventCount] = useState(1);
     const [undoCount, setUndoCount] = useState(0);
     const openPanel = typeof onSetPanel === "function" ? activePanel : localOpenPanel;
@@ -1221,10 +1333,12 @@ const DateWidget = ({
         setError("");
         setFallbackWarning("");
 
+        const controller = new AbortController();
+        jumpAbortRef.current = controller;
         try {
             const result = mode === "auto"
-            ? await simulateAutoJump({ days })
-            : await simulateTimelineJump({ days });
+            ? await simulateAutoJump({ days, signal: controller.signal })
+            : await simulateTimelineJump({ days, signal: controller.signal });
             setGameData(result.game);
             setEvents(result.events);
             setWorldState(result.world);
@@ -1234,11 +1348,21 @@ const DateWidget = ({
             }
             setPanel("history");
         } catch (jumpError) {
-            console.error("Failed to simulate jump:", jumpError);
-            setError(jumpError.message || "Failed to simulate timeline jump.");
+            if (controller.signal.aborted || jumpError?.name === "AbortError") {
+                // Player cancelled — nothing was written, so just close out quietly.
+                setError("");
+            } else {
+                console.error("Failed to simulate jump:", jumpError);
+                setError(jumpError.message || "Failed to simulate timeline jump.");
+            }
         } finally {
+            jumpAbortRef.current = null;
             setIsLoading(false);
         }
+    };
+
+    const cancelJump = () => {
+        jumpAbortRef.current?.abort(new DOMException("Timeline jump cancelled.", "AbortError"));
     };
 
     // How many turns can be undone (a restore point is captured at the start of
@@ -1366,6 +1490,7 @@ const DateWidget = ({
         isLoading={isLoading}
         isOpen={openPanel === "skip"}
         onAutoJump={() => runJump(365, "auto")}
+        onCancel={cancelJump}
         onClose={() => setPanel(null)}
         onJump={(days) => runJump(days, "jump")}
         onUndo={runUndo}


### PR DESCRIPTION
Five player-requested fixes/features. Targets `alpha` (builds on Mininaut's #204 AI-harness refactor). Build passes, `npm test` passes, and the new timeline math is unit-checked.

## Updates apply without deleting `dist/`
The launcher only rebuilt when `dist/` was missing, so after every update players had to delete it by hand. Now:
- **Launcher** (`.sh` + `.bat`) rebuilds when any source file is newer than the build — the "rebuild on start" fix.
- **Updater** (`.sh` + `.bat`) removes the stale `dist/` after a successful update, so the next launch rebuilds cleanly.
(macOS `.command` files just wrap the `.sh`, so they inherit it.)

## Shorter + custom time skips
Added **6h / 1d / 3d** presets and a **custom amount + unit** control (hours → years) to the skip panel. Sub-day skips (6h) keep the same date; whole-day math otherwise. The AI prompt now describes the span in human terms ("6 hours", "2 weeks") instead of raw day counts.

## Cancel a time skip
A **Cancel** button on the loading spinner aborts the in-flight AI call — it flows through `callAI` to Mininaut's relay `AbortController` and stops the upstream request. A deliberate cancel no longer falls back to canned events, so **the game is left exactly as it was** (no partial turn).

## At least one event per queued action
If the player has more queued actions than the base event count for the span (e.g. 5 actions on a 6-hour skip, base 1), the event count is raised so **each action gets a slot** (bounded at 37 so a huge queue can't demand absurd counts). Verified: 5 actions on a 6h skip → the model is asked for 5–8 events.

⚠️ The timeline UI is build-verified only (the game doesn't render in my sandbox) — the pure jump/event-count logic is unit-tested, but the new panel controls want a quick real-browser look.

---
Submitting for review — not merging.
