### PR TITLE
Web sign-in: Sign in with Google instead of magic-link email

### DIFF
--- a/.env.web
+++ b/.env.web
@@ -20,6 +20,12 @@ VITE_OH_DIRECTORY_URL=https://open-historia-registry.nichojkrol.workers.dev/node
 # must go through it. Listing still hits api.github.com directly.
 VITE_OH_HUB_URL=https://open-historia-registry.nichojkrol.workers.dev
 
-# Accounts + encrypted sync (magic-link identity; games/scenarios sync as blobs
-# encrypted client-side). Points at the registry Worker's /account/* + /sync/*.
+# Accounts + encrypted sync (Google sign-in identity; games/scenarios sync as
+# blobs encrypted client-side). Points at the registry Worker's /account/* + /sync/*.
 VITE_OH_ACCOUNT_URL=https://open-historia-registry.nichojkrol.workers.dev
+
+# "Sign in with Google" OAuth client id (public — safe to ship in the client).
+# Create one at console.cloud.google.com → APIs & Services → Credentials → OAuth
+# client ID (Web application), with openhistoria.com as an authorized JS origin.
+# Empty = the Google sign-in button is hidden (accounts disabled) until it's set.
+VITE_OH_GOOGLE_CLIENT_ID=

--- a/src/runtime/web/account.js
+++ b/src/runtime/web/account.js
@@ -51,6 +51,22 @@ export const redeemMagicToken = async (token) => {
   return data; // { email, session, hasKey }
 };
 
+// The OAuth client id for "Sign in with Google" (public — safe to ship). Empty
+// string disables the Google button (e.g. a build without it configured).
+export const googleClientId = () => (import.meta.env.VITE_OH_GOOGLE_CLIENT_ID || "").trim();
+
+// Sign in with Google: hand the registry the Identity Services ID token, which it
+// verifies server-side, and take back a session — then ensure the account's DEK,
+// exactly as redeeming a magic link would. No email is ever sent.
+export const signInWithGoogle = async (credential) => {
+  const { status, data } = await api("/account/google", { method: "POST", body: { credential } });
+  if (status !== 200) throw new Error(data?.error || "Google sign-in failed.");
+  await kvPut(SESSION_KEY, data.session);
+  await kvPut(EMAIL_KEY, data.email);
+  await ensureDek(data.session, data.hasKey);
+  return data; // { email, session, hasKey }
+};
+
 // Ensure the account's DEK is available on this device: pull it (existing
 // account) or generate + register it (first sign-in ever).
 const ensureDek = async (session, hasKey) => {

--- a/src/runtime/web/homePage.js
+++ b/src/runtime/web/homePage.js
@@ -5,7 +5,7 @@
 // (already-mounted) game — web build only, never in the local download.
 
 import { connectBestNode } from "./nodeConnect.js";
-import { isSignedIn, getEmail, requestMagicLink, signOut } from "./account.js";
+import { isSignedIn, getEmail, signOut, signInWithGoogle, googleClientId } from "./account.js";
 import { accountConfigured } from "./account.js";
 
 const ENTERED_KEY = "oh:entered";
@@ -52,9 +52,23 @@ const renderConnection = (c) => {
 
 const enter = () => { try { sessionStorage.setItem(ENTERED_KEY, "1"); } catch { /* private mode */ } overlay?.remove(); overlay = null; };
 
+// Load Google Identity Services once; resolves with window.google.
+let gisPromise = null;
+const loadGis = () => {
+  if (gisPromise) return gisPromise;
+  gisPromise = new Promise((resolve, reject) => {
+    if (window.google?.accounts?.id) return resolve(window.google);
+    const s = el("script", { src: "https://accounts.google.com/gsi/client", async: true, defer: true });
+    s.onload = () => resolve(window.google);
+    s.onerror = () => reject(new Error("Couldn't load Google sign-in — check your connection."));
+    document.head.append(s);
+  });
+  return gisPromise;
+};
+
 const accountSection = async () => {
   const box = el("div");
-  if (!accountConfigured()) return box; // accounts not wired for this build
+  if (!accountConfigured() || !googleClientId()) return box; // sign-in not wired for this build
   box.append(el("h4", { textContent: "Save your games across devices" }));
   if (await isSignedIn()) {
     box.append(
@@ -62,22 +76,22 @@ const accountSection = async () => {
       el("button", { className: "btn", textContent: "Sign out", style: "margin-top:8px", onclick: async () => { await signOut(); refreshAccount(box); } }),
     );
   } else {
-    const input = el("input", { type: "email", placeholder: "you@example.com", autocomplete: "email" });
+    // Google renders its own branded button into `mount`; on success we get an ID
+    // token, hand it to the registry, and swap the section to the signed-in view.
+    const mount = el("div", { style: "display:flex;justify-content:center;min-height:44px" });
     const msg = el("div", { className: "msg" });
-    const send = el("button", { className: "btn", textContent: "Email me a sign-in link" });
-    send.onclick = async () => {
-      const email = input.value.trim(); if (!email) return;
-      send.disabled = true; send.textContent = "Sending…";
-      try {
-        const res = await requestMagicLink(email);
-        msg.textContent = res.sent === false
-          ? "Email isn't set up on this server yet — the site owner needs to finish email configuration."
-          : "Check your email for the sign-in link — and check your spam folder if you don't see it.";
-      } catch (e) { msg.textContent = e.message; }
-      send.disabled = false; send.textContent = "Email me a sign-in link";
-    };
-    input.onkeydown = (e) => { if (e.key === "Enter") send.click(); };
-    box.append(input, send, msg);
+    box.append(mount, msg);
+    loadGis().then((google) => {
+      google.accounts.id.initialize({
+        client_id: googleClientId(),
+        callback: async (resp) => {
+          msg.textContent = "Signing you in…";
+          try { await signInWithGoogle(resp.credential); refreshAccount(box); }
+          catch (e) { msg.textContent = e.message; }
+        },
+      });
+      google.accounts.id.renderButton(mount, { theme: "filled_blue", size: "large", text: "continue_with", shape: "pill" });
+    }).catch((e) => { msg.textContent = e.message; });
   }
   return box;
 };


### PR DESCRIPTION
Cloudflare Email Sending needs a paid Workers plan, so magic-link email isn't free for arbitrary recipients. This swaps the web home page's email UI for a Google Identity Services button.

- Client posts the Google ID token to the registry; the rest (per-account DEK, encrypted sync) is unchanged.
- The button is hidden until the build sets `VITE_OH_GOOGLE_CLIENT_ID`, so accounts degrade cleanly when unconfigured.
- Registry side (open-historia-admin): `/account/google` verifies the ID token server-side (RS256 vs Google JWKS + issuer/audience/expiry/email_verified) and issues a session exactly like a redeemed magic link.

Free, no email infrastructure.