### PR TITLE
Build: exclude the web runtime from the desktop build so a fresh download builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,20 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
+// `--mode web` (npm run build:web / build:site / dev:web) builds the website; any
+// other mode builds the local/desktop app that ships in "Download for Windows".
+export default defineConfig(({ mode }) => ({
+  define: {
+    // Make the web flag a COMPILE-TIME literal so Rollup dead-code-eliminates
+    // every `if (import.meta.env.VITE_OH_WEB)` branch — and the web backend they
+    // dynamically import (src/runtime/web/*) — from the desktop build. Without
+    // this the flag is only a runtime value, so `npm run build` still pulls the
+    // web runtime into the graph and fails to resolve its web-only, git-ignored
+    // generated seed files on any machine that hasn't run a web build first (e.g.
+    // a fresh "Download for Windows" extract). Boolean is safe: every use site is
+    // a plain truthiness check.
+    'import.meta.env.VITE_OH_WEB': JSON.stringify(mode === 'web'),
+  },
   plugins: [
     react({
       babel: {
@@ -30,4 +43,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
## The bug

A fresh clone or source download fails to build:

```
error during build:
Could not resolve "./generated/fallbackColors.js" from "src/runtime/web/libraryStore.js"
```

Reported by a user who downloaded the source from GitHub.

## Why

`src/runtime/web/generated/` is produced by `scripts/seed-web-defaults.mjs`, which only runs in the web targets (`dev:web`, `build:web`, `build:site`). It is committed on no branch, so a fresh checkout has no `generated/` folder at all — yet `libraryStore.js` imports `./generated/fallbackColors.js` **statically**, so rollup has to resolve it even in the desktop build, which never needs the web runtime.

## The fix

Make `import.meta.env.VITE_OH_WEB` a compile-time literal via vite's `define`, so the web-only branches are dead-code-eliminated in the desktop build and `libraryStore.js` drops out of the module graph entirely.

## Verified

Built from a worktree with no `generated/` folder — exactly what a fresh download looks like:

| | result |
|---|---|
| `alpha` as-is | `Could not resolve "./generated/fallbackColors.js"` (reproduces the report) |
| `alpha` + this commit | `✓ built in 16.99s` |

## Follow-up worth considering

This makes the desktop build work by relying on dead-code elimination removing the module. That is one unconditional import of `libraryStore.js` away from breaking again. Running `scripts/seed-web-defaults.mjs` from a `prebuild`/`postinstall` hook would make the failure structurally impossible rather than contingent.