### PR TITLE
README: fix outdated and incorrect claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,22 @@
 
 ---
 
-## 🚀 Installation
+## 🚀 Play
 
-### Easiest
+### In your browser
+
+**[openhistoria.com](https://openhistoria.com)** — nothing to install. Games are saved in
+your browser, and you bring your own AI key (it goes straight to your provider, never to
+us). The world map is served by the community [content-node network](https://github.com/Open-Historia/open-historia-node).
+
+Local AI (Ollama, LM Studio) needs one extra step in the browser: the server has to allow
+the site's origin, e.g. start Ollama with `OLLAMA_ORIGINS=https://openhistoria.com`. The
+desktop app below needs no such setup.
+
+### Desktop (offline, single-player)
+
+Download **[`Open-Historia.zip`](https://github.com/Open-Historia/open-historia/releases/tag/app-stable)**
+(~186 MB — code *and* all map data), unzip it anywhere, then:
 
 - **Windows:** double-click **`Launch Open Historia.bat`**
 - **macOS:** double-click **`Launch Open Historia.command`** (first run: right-click → *Open*)
@@ -67,11 +80,13 @@ while preserving your saves, scenarios, and map data.
 Easiest: download **`pax-historia.apk`** from the
 [**Android release**](https://github.com/Open-Historia/open-historia/releases/tag/android)
 and open it to install (allow installs from your browser when Android asks).
-On first launch the app finds the Termux server on the same phone by itself;
-to play against another machine, type its address once — it's remembered.
-It's a thin client: the game itself runs on the server it connects to.
+It's a thin client: the game itself runs on whatever server it connects to, so you need
+one of the two:
 
-for it to work, you should have termux on your device setup
+- **A desktop on the same network** running the launcher — type its address
+  (e.g. `http://192.168.1.20:3000`) into the app once; it's remembered.
+- **[Termux](https://termux.dev/) on the phone itself** running the server — the app
+  finds it on first launch by itself, no address needed.
 
 <details>
 <summary>Build the APK yourself (needs the Android SDK)</summary>
@@ -115,8 +130,9 @@ Then open **http://localhost:3000** in your browser.
 
 ## 🌍 Scenarios
 
-**Modern Day** is the only built-in scenario. All other official presets — *WWII 1939*,
-*Medieval 1200*, *Rome 117 AD*, *Mongol World 1300*, *New World 1650* — live on the
+**Modern Day** is the only built-in scenario. All other official presets — *World War II — 1939*,
+*Medieval — 1200 AD*, *Rome — 117 AD*, *Mongol World — 1300 AD*, *New World — 1650*, and
+*Bronze Age — 1200 BC* — live on the
 [**Scenario Hub**](https://github.com/Open-Historia/Open-historia-scenarios), pinned at the top of
 the in-game **Community** tab. Import any of them with one click, or publish your own.
 


### PR DESCRIPTION
The README is the first thing a new player or contributor reads, and it was describing a download-only game with a few claims that are simply untrue. Each fix below was checked against the running system rather than assumed.

## Wrong information

| Claim | Reality |
|---|---|
| No mention of playing in a browser | **openhistoria.com is live** — `/` and `/play/` both return 200 |
| Presets: *WWII 1939, Medieval 1200, Rome 117 AD, Mongol World 1300, New World 1650* | The hub ships **six** bundles — ***Bronze Age — 1200 BC*** was missing |
| "for it to work, you should have termux on your device setup" | Contradicts the two lines above it; the APK is a thin client that needs **a** server — a desktop **or** Termux |

## What changed

- **Leads with browser play.** The game has been playable at openhistoria.com for a while and the README pointed everyone at a 186 MB download instead. Includes the local-AI caveat: Ollama on a hosted origin needs `OLLAMA_ORIGINS=https://openhistoria.com`, or it fails with an unexplained `Failed to fetch` (the browser drops the reply for want of a CORS header — verified against a real HTTPS origin).
- **Fixed the preset list** and matched the hub's real display names.
- **Fixed the Android section** to state both server options instead of contradicting itself.
- **Says where to get the download.** "Easiest" previously began mid-story — double-click a launcher, from a zip it never told you to download. Size corrected to ~186 MB (the asset is 186,368,698 bytes; it said ~182 MB).

## Notes

Targets `main` because that is the default branch, so this is the README GitHub actually shows. `alpha`'s README has diverged and needs its own pass; `main` and `beta` are identical here, so beta can take the same change unchanged.

No code, no behavior. Docs only.