### PR TITLE
Site: return a real 404 instead of the landing page

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,117 @@
+<!-- Open Historia — 404 page © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page not found — Open Historia</title>
+    <!-- Same inline favicon as the landing page: a 404 must not depend on a file
+         that might itself be missing. -->
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%8F%9B%EF%B8%8F%3C/text%3E%3C/svg%3E" />
+    <meta name="theme-color" content="#e9dcc0" />
+
+    <!-- This file is why unknown URLs return a real 404. Cloudflare Pages serves
+         /404.html with a 404 status when a path matches no asset; with no such file
+         it falls back to /index.html with a 200, so every typo, dead link and stale
+         search result answered as the landing page. Search engines read that as a
+         "soft 404" and it made a broken sitemap URL indistinguishable from a working
+         one. Deleting this file silently restores that behaviour. -->
+    <meta name="robots" content="noindex" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=EB+Garamond:ital,wght@0,400;0,500;1,400&display=swap"
+    />
+
+    <style>
+      :root {
+        --parch: #e9dcc0;
+        --ink: #2c2216;
+        --sepia: #6c5a3c;
+        --line: rgba(74, 54, 24, 0.18);
+        --line2: rgba(74, 54, 24, 0.3);
+        --bronze: #9a6b2f;
+        --gold: #b8860b;
+        --serif: "EB Garamond", Georgia, "Times New Roman", serif;
+        --display: "Cinzel", Georgia, "Times New Roman", serif;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        color: var(--ink);
+        font-family: var(--serif);
+        font-size: 18px;
+        line-height: 1.62;
+        text-align: center;
+        background:
+          radial-gradient(1200px 540px at 50% -12%, rgba(184, 134, 11, 0.12), transparent 60%),
+          repeating-linear-gradient(112deg, rgba(120, 90, 40, 0.028) 0 2px, transparent 2px 7px),
+          var(--parch);
+      }
+      .wrap { max-width: 560px; }
+      .mark { font-size: 3rem; line-height: 1; margin-bottom: 12px; }
+      h1 {
+        font-family: var(--display);
+        font-size: clamp(2.2rem, 8vw, 3.4rem);
+        margin: 0 0 6px;
+        letter-spacing: 0.02em;
+      }
+      .eyebrow {
+        font-family: var(--display);
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-size: 0.78rem;
+        color: var(--sepia);
+        margin-bottom: 18px;
+      }
+      p { color: var(--sepia); margin: 0 auto 26px; }
+      .rule {
+        width: 90px;
+        height: 1px;
+        margin: 22px auto;
+        background: linear-gradient(90deg, transparent, var(--line2), transparent);
+      }
+      .btns { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+      .btn {
+        font-family: var(--display);
+        font-size: 0.95rem;
+        text-decoration: none;
+        padding: 0.7rem 1.2rem;
+        border-radius: 12px;
+        border: 1px solid var(--line2);
+        color: var(--ink);
+        transition: transform 0.12s ease, box-shadow 0.12s ease;
+      }
+      .btn:hover { transform: translateY(-1px); box-shadow: 0 10px 22px -14px rgba(60, 40, 14, 0.7); }
+      .btn-primary {
+        background: linear-gradient(100deg, #7c4f18 0%, var(--gold) 52%, #8f6a22 100%);
+        color: #fff8e6;
+        border-color: var(--bronze);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <div class="mark">🏛️</div>
+      <div class="eyebrow">Error 404</div>
+      <h1>Lost to history</h1>
+      <div class="rule"></div>
+      <p>
+        This page doesn't exist — or it did once, and the borders have moved since.
+        Check the address, or start again from somewhere solid.
+      </p>
+      <div class="btns">
+        <a class="btn btn-primary" href="/">Return home</a>
+        <a class="btn" href="/play/">Play</a>
+        <a class="btn" href="/guides/">Guides</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,1 +1,14 @@
-/play/*  /play/index.html  200
+# No rules on purpose.
+#
+# This file used to hold:
+#     /play/*  /play/index.html  200
+# Cloudflare rejected it outright — `/play/index.html` itself matches `/play/*`, so it
+# is an infinite loop. Wrangler reported "Parsed 0 valid redirect rules" and ignored
+# the file, so the rule never ran in production a single time.
+#
+# It is also unnecessary: the web game does no path-based routing (it only uses
+# history.replaceState to strip ?magic= from the query string), so there are no
+# /play/<route> URLs to rewrite, and /play/ resolves as an ordinary directory index.
+#
+# If the game ever does adopt client-side routing, the replacement rule must not match
+# its own target — do not paste the line above back in.


### PR DESCRIPTION
Follow-up to #236, which correctly flagged this but assumed it needed a dashboard change. **It doesn't — it's fixable from the repo, and this is the fix.**

## The bug

Every unknown URL returns **200 with the landing page**:

```
/nope-xyz/                 200  28780B  (the landing page)
/robots.txt                200  28780B  (the landing page!)
/sitemap.xml               200  28780B  (the landing page!)
```

Cloudflare Pages falls back to `/index.html` when a path matches no asset and there's no `/404.html`. Search engines call this a **soft 404** and treat it as a quality problem.

**It's also why the broken sitemap in #234 was invisible.** A URL pointing at nothing answered 200 with real-looking HTML, so Search Console would have reported that sitemap as *valid* while indexing eight duplicates of the homepage. Nothing would have alerted anyone.

## The fix

`site/404.html` — that's it. Pages serves it with a 404 the moment it exists. Styled to match the landing page (same palette, same fonts, same inline emoji favicon so the 404 can't depend on a file that's itself missing), `noindex`, and it links back to `/`, `/play/` and `/guides/` — all paths verified to actually 200.

## Also: `_redirects` has never worked

Wrangler's own parser:

```
✨ Parsed 0 valid redirect rules.
▲ WARNING Found 1 invalid redirect rule:
  ▶︎ Infinite loop detected in this rule and has been ignored.
      at _redirects:1 | /play/*  /play/index.html  200
```

`/play/index.html` itself matches `/play/*`, so Cloudflare rejects the rule outright. It has never run in production — which is why `/play/anything` fell through to the landing page rather than the game.

It was never needed, either: the web game does no path-based routing (only `history.replaceState` to strip `?magic=`), and `/play/` resolves as an ordinary directory index. Removed, with the reasoning kept in the file so the broken line doesn't get pasted back.

## Verified

`wrangler pages dev dist-site` on the merged base:

| Path | Before | After |
|---|---|---|
| `/`, `/guides/`, `/get-started/`, `/how-to-play/` | 200 | 200 ✅ |
| `/robots.txt`, `/sitemap.xml` | 200 *(landing page!)* | 200 ✅ *(real files)* |
| `/play/` | 200 | 200 ✅ |
| `/nope-xyz/`, `/guides/typo` | **200 landing page** | **404** ✅ |

Invalid-rule warnings: **1 → 0**.