### PR TITLE
Fix every language silently failing on the website

### DIFF
--- a/src/runtime/web/settingsStore.js
+++ b/src/runtime/web/settingsStore.js
@@ -12,14 +12,21 @@ const isLangCode = (code) => /^[a-z]{2,3}$/.test(code);
 const langKey = (code) => `lang:${code}`;
 const shippedPackCache = new Map();
 
-// Fetch the shipped pack Vite copied to /lang/<code>.json (static, same-origin).
+// Fetch the shipped pack Vite copied to <base>lang/<code>.json (static, same-origin).
 // This is a non-/api path, so the wrapped fetch passes it straight to the network
 // (no recursion into the router). Missing packs (most languages ship none) → {}.
+//
+// Resolve against import.meta.env.BASE_URL, NOT location.origin. openhistoria.com
+// builds with --base /play/, so the packs deploy to /play/lang/*.json while an
+// origin-rooted /lang/*.json is a 404 — and the catch below turns that into an
+// empty pack, so every language silently fell back to untranslated English with
+// no error. BASE_URL is "/" for the local server, so one path serves both builds.
 const loadShippedPack = async (code) => {
   if (shippedPackCache.has(code)) return shippedPackCache.get(code);
   let pack = {};
   try {
-    const response = await fetch(new URL(`/lang/${code}.json`, location.origin), { cache: "force-cache" });
+    const base = new URL(import.meta.env.BASE_URL || "/", location.origin);
+    const response = await fetch(new URL(`lang/${code}.json`, base), { cache: "force-cache" });
     if (response.ok) {
       const data = await response.json();
       if (data && typeof data === "object" && !Array.isArray(data)) pack = data;


### PR DESCRIPTION
On openhistoria.com every language rendered as untranslated English.

The site builds with `--base /play/`, so Vite copies the shipped packs to `/play/lang/<code>.json`. But `loadShippedPack` fetched `new URL('/lang/<code>.json', location.origin)` — `openhistoria.com/lang/<code>.json`, one directory up from where they live. That 404s.

The `catch` then turned the 404 into an empty pack, so nothing errored and nothing logged. It just looked like translation didn't work.

Now resolves against `import.meta.env.BASE_URL` — `/play/` on the site, `/` for the local server, so one path serves both builds.

**Verified against production** (already deployed): `/play/lang/{ar,es,fr,ru,zh}.json` all return 200; the old origin-rooted `/lang/ar.json` still 404s, as it always did.

One file, one line of behaviour.