### PR TITLE
Stop the server writing to disk every 5 seconds while the game sits idle

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -316,6 +316,28 @@ const readJsonFile = (targetPath, fallback = null) => {
 const writeJsonFile = (targetPath, value) => {
   ensureDirectory(path.dirname(targetPath));
   fs.writeFileSync(targetPath, JSON.stringify(value, null, 2), "utf-8");
+  // Any write can change what the catalogs describe, so drop them. This is the
+  // one choke point every meta and manifest write goes through — including
+  // create and delete, which rewrite the manifest — so hooking it here is what
+  // makes the cache safe without touching 43 call sites individually.
+  invalidateCatalogs();
+};
+
+// ---- Catalog cache ---------------------------------------------------------
+// getGameCatalog/getScenarioCatalog walk EVERY game and scenario directory and
+// parse each meta file. Nothing needs that per request, but everything paid for
+// it: resolving one runtime asset (the 5s poll for world.json) cost 139 sync
+// file ops and ~43ms of blocked event loop, just to learn which game is active.
+//
+// Cache both, and drop BOTH on any write. Coarse on purpose: writes are rare and
+// a rebuild is cheap, while a stale catalog is a bug that surfaces as "my save
+// vanished". Correctness first — the win is in the reads.
+let gameCatalogCache = null;
+let scenarioCatalogCache = null;
+
+const invalidateCatalogs = () => {
+  gameCatalogCache = null;
+  scenarioCatalogCache = null;
 };
 
 const normalizeId = (rawValue, prefix) => {
@@ -695,6 +717,19 @@ const syncBuiltInScenarioSeedDate = () => {
     return;
   }
 
+  // Already at the target: the backfill has nothing to do. Without this the
+  // write below re-arms its own guard forever — it sets gameDate and startDate
+  // to the SAME value, and shouldBackfillSeedDatePair treats
+  // `currentGameDate === currentStartDate` as "needs backfilling". So every
+  // caller rewrote an identical game.json, and since ensure* runs on the read
+  // path, each 5s poll wrote this file 4 times. Idle, forever, onto the disk.
+  if (
+    currentGameDate === BUILT_IN_SCENARIO_DEFAULT_DATE &&
+    currentStartDate === BUILT_IN_SCENARIO_DEFAULT_DATE
+  ) {
+    return;
+  }
+
   writeJsonFile(targetPath, {
     ...cloneJson(currentGame),
                 gameDate: BUILT_IN_SCENARIO_DEFAULT_DATE,
@@ -866,13 +901,25 @@ const ensureDefaultScenario = () => {
   syncBuiltInScenarioSeedDate();
 
   const manifest = getScenarioManifest();
+  let changed = false;
   if (!manifest.order.includes(DEFAULT_SCENARIO_ID)) {
     manifest.order.unshift(DEFAULT_SCENARIO_ID);
+    changed = true;
   }
   if (!manifest.selectedScenarioId) {
     manifest.selectedScenarioId = DEFAULT_SCENARIO_ID;
+    changed = true;
   }
-  saveScenarioManifest(manifest);
+  // Save when a guard above changed something, OR on a true first run when no
+  // manifest file exists yet. That second case is not optional: getScenarioManifest
+  // synthesizes a default that ALREADY lists the built-in scenario, so both guards
+  // are no-ops on first run and `changed` stays false — the old unconditional save
+  // was what committed that default to disk. Dropping it silently shipped an empty
+  // library on a fresh install (caught only by testing a fresh install).
+  //
+  // Otherwise skip: ensure* runs on the read path, so an unconditional save had
+  // every 5s poll rewriting an unchanged manifest 4 times, forever.
+  if (changed || !fs.existsSync(SCENARIO_MANIFEST_PATH)) saveScenarioManifest(manifest);
 };
 
 const ensureScenarioStore = () => {
@@ -969,6 +1016,11 @@ const getScenarioUsageCountMap = () => {
 };
 
 const getScenarioCatalog = () => {
+  if (!scenarioCatalogCache) scenarioCatalogCache = buildScenarioCatalog();
+  return scenarioCatalogCache;
+};
+
+const buildScenarioCatalog = () => {
   ensureScenarioStore();
   const usageCounts = getScenarioUsageCountMap();
   const manifest = getScenarioManifest();
@@ -1022,6 +1074,11 @@ const getScenarioCatalog = () => {
 };
 
 const getGameCatalog = () => {
+  if (!gameCatalogCache) gameCatalogCache = buildGameCatalog();
+  return gameCatalogCache;
+};
+
+const buildGameCatalog = () => {
   ensureGameStore();
   const scenarioCatalog = getScenarioCatalog();
   const scenarioLookup = new Map(scenarioCatalog.scenarios.map((scenario) => [scenario.id, scenario]));


### PR DESCRIPTION
An idle game wrote **~56 files every 5 seconds, forever** — rewriting identical bytes onto the disk for as long as the app stayed open. That's continuous SSD wear for a game doing nothing.

Found while investigating a code review that flagged the polling and the uncached catalog rebuilds. Both real, but the disk writes underneath them were worse and weren't in the report.

### Two bugs, both on the *read* path

`readRuntimeJsonAsset` calls `ensureGameStore` → `ensureScenarioStore` → `ensureDefaultScenario` **before** it reads, so a read mutated the store.

**1. `syncBuiltInScenarioSeedDate` re-armed its own guard.** It writes `gameDate` and `startDate` as the *same* value, and `shouldBackfillSeedDatePair` treats `currentGameDate === currentStartDate` as "needs backfilling". Completing the backfill *guaranteed* the next call would redo it — a self-perpetuating loop by construction.

**2. `ensureDefaultScenario` saved the manifest unconditionally**, even when its own guards changed nothing.

### The trap in fixing #2

Making the save purely conditional **shipped an empty library on fresh installs**. `getScenarioManifest` synthesizes a default that already lists the built-in scenario, so both guards are no-ops on a first run and `changed` stays `false` — the unconditional save was what committed it to disk. Only testing an actual fresh install caught it. Hence `changed || !fs.existsSync(SCENARIO_MANIFEST_PATH)`.

### Then the catalogs could finally be cached

Every call rebuilt both catalogs by walking every game and scenario directory. They *could never have been cached before* — the read path wrote, and writes must invalidate. Invalidation hangs off `writeJsonFile`, the single choke point all metas and manifests pass through, so no caller has to remember it.

### Measured, per `world.json` read

| | before | after |
|---|---|---|
| disk writes | 8 | **0** |
| file ops | 139 | **13** |
| time | 42.8 ms | **6.9 ms** |
| idle CPU (6 pollers) | ~6% | **~1%** |

Every other API call used to queue behind those 43ms stalls — Node is single-threaded.

### Verified

- Fresh install still seeds (1 scenario, manifest written).
- Existing library loads all 3 scenarios over HTTP (200).
- **12 polls against the running server leave both files' mtimes untouched.**

Not doing the wholesale `fs.promises` conversion the review suggested: 83 call sites, and on a single-user localhost server there's no concurrency for sync I/O to block. After this the op count is trivial anyway.