### PR TITLE
Fix editing a scenario's map deleting its flags, and reputation never moving

### DIFF
--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -266,6 +266,12 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     // (buildGameSeed reads doc.metadata.customBackground) re-persists it instead of
     // clearing the scenario's background when the user re-opens and re-applies.
     if (initialMap.background) base.metadata.customBackground = initialMap.background;
+    // Same reasoning as the background above, and it is data loss if missed:
+    // buildGameSeed emits flags: null when the document has none, and
+    // applyMapToScenario reads that null as "clear the scenario's flags.json".
+    // So opening a scenario's map without its flags and pressing Apply & Play
+    // deleted every author-set flag. Restore them so a round-trip is a no-op.
+    if (initialMap.flags) base.flags = { ...initialMap.flags };
     base.features = (initialMap.cities?.features || [])
       .map((f) => ({
         id: newId("feat"),

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -103,6 +103,15 @@ const polityChangeSchema = {
     name: textSchema("New polity name, only when it changes."),
     color: textSchema("New six-digit hexadecimal color, only when it changes."),
     aliases: stringArraySchema("Alternative polity names."),
+    // The prompt asks for this and gameState normalizes/clamps/writes it, but it
+    // was missing here — and additionalProperties:false means a json_schema
+    // provider could never emit it, so international reputation silently never
+    // moved. Declaring it is what actually connects that feature.
+    reputation: {
+      type: "number",
+      description:
+        "International reputation 0-100, only when it changes. 0 is a pariah state, 100 is universally trusted.",
+    },
     note: textSchema("Brief reason for the change."),
   },
   required: ["code"],

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -1905,9 +1905,14 @@ const LibraryTopBar = () => {
               downloadScenarioJsonAsset(scenario.id, "regionsGeojson"),
               downloadScenarioJsonAsset(scenario.id, "citiesGeojson"),
               downloadScenarioJsonAsset(scenario.id, "colors"),
+              // The author-set flags, for the same reason as the background below:
+              // without them the editor opens with none, and Apply & Play cannot
+              // tell "this map has no flags" from "this map never loaded them" —
+              // so it clears the scenario's flags.json and the author's work is gone.
+              downloadScenarioJsonAsset(scenario.id, "flags"),
               // The custom map background so re-opening the editor restores it.
               world.background?.kind ? downloadScenarioJsonAsset(scenario.id, "backgroundData") : Promise.resolve(null),
-            ]).then(([regions, cities, colors, bgData]) => {
+            ]).then(([regions, cities, colors, flags, bgData]) => {
               const bgDesc = world.background;
               const background =
                 bgDesc?.kind === "image" && bgData?.dataUrl
@@ -1922,6 +1927,7 @@ const LibraryTopBar = () => {
                 regions: regions && Array.isArray(regions.features) && regions.features.length ? regions : null,
                 cities: cities && Array.isArray(cities.features) ? cities : null,
                 colors: colors && typeof colors === "object" && !Array.isArray(colors) ? colors : null,
+                flags: flags && typeof flags === "object" && !Array.isArray(flags) ? flags : null,
                 background,
                 basemap: world.basemap || null,
               });


### PR DESCRIPTION
Two bugs found while designing country tags — both are features wired everywhere except one link. Neither is hypothetical; both are reproduced below.

## 1. Editing a scenario's map deletes its flags 🔴 data loss

`onOpenMapEditor` downloads `regionsGeojson`, `citiesGeojson`, `colors`, `backgroundData` — **not `flags`**. So the editor opens with none. `buildGameSeed` emits `flags: null` for a document with no flags (`exportPreset.js:239`), and `applyMapToScenario` reads that null as *clear the scenario's flags.json*.

Nothing could distinguish **"this map has no flags"** from **"this map never loaded them"**. So **Open map → Apply & Play silently destroyed every author-set flag.**

The background already carries this exact fix, and says so at `MapEditor.jsx:265`:
> *"so Apply & Play re-persists it instead of clearing the scenario's background when the user re-opens and re-applies"*

Flags never got it. Colours survive by luck — they ride the palette via `mergeColors`, so the export rebuilds them regardless.

**Reproduced** by replaying the round-trip:

| | seed.flags | applyMapToScenario |
|---|---|---|
| before | `null` | **CLEAR — flags deleted** |
| after | `USA,SOV` | **UPLOAD — preserved** |

## 2. International reputation could never change

The prompt asks for it (`gameplay.js`), and `gameState.js:409-412` normalizes, clamps 0–100 and writes it. But `reputation` was **absent from `polityChangeSchema`** (`gameplaySchemas.js:98`), which is `additionalProperties: false` and is sent to the provider as a `json_schema` response format (`main.jsx:541`).

So a schema-constrained model was **structurally unable to emit** the field the rest of the feature waits for. `world.internationalReputation` never moved. Declaring the property is what actually connects it.

Worth noting this is the cautionary case for any future AI-writable field: prompt + normalizer + writer all present, schema missing, fails silently.