### PR TITLE
Stop losing map edits: fix the autosave, and guard the close button

### DIFF
--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -207,6 +207,15 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
     }
   };
 
+  // The unload/visibility listeners below are registered once, so a closure would
+  // freeze whatever the document was at that moment and flush THAT on the way out
+  // — the same stale-closure bug the autosave effect above documents, except its
+  // victim is the user's last edits. Refs re-point every render instead.
+  const dRef = useRef(d);
+  dRef.current = d;
+  const saveNowRef = useRef(saveNow);
+  saveNowRef.current = saveNow;
+
   const newDoc = (kind) => {
     d.setDoc(createDocument({ name: kind === "blank" ? "Untitled Map" : "World Map", kind }));
     setDocId(null);
@@ -245,12 +254,60 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
   };
 
   // Debounced autosave whenever the document is dirty.
+  //
+  // Depends on d.doc, not on a hand-listed set of its fields. That list had gone
+  // stale — it named name/types/features/metadata but not colorOverrides, flags
+  // or tags — and the failure was silent data loss, not a missed save: with the
+  // document ALREADY dirty, changing a colour re-rendered but changed no listed
+  // dep, so this effect did not re-run. The timer already pending then fired with
+  // the saveNow closure from BEFORE the change, wrote the older payload, and set
+  // the status to "saved" — leaving the new colour unsaved and the UI claiming
+  // otherwise. d.doc is a new object on every document change, so it cannot fall
+  // behind the way a field list does.
   useEffect(() => {
     if (!api || d.saveStatus !== "dirty") return;
     const t = setTimeout(() => saveNow(), 2000);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, d.saveStatus, docId, d.name, d.types, d.features, d.metadata]);
+  }, [api, d.saveStatus, docId, d.doc]);
+
+  // Don't let the tab close on unsaved work. The autosave debounce means up to
+  // two seconds of edits exist only in memory at any moment, and on the website
+  // a closed tab takes them with it — there is no server-side copy to recover.
+  //
+  // The browser shows its own generic wording and ignores ours; assigning
+  // returnValue is what actually triggers the prompt (Chrome needs it even with
+  // preventDefault). "saving" counts as unsaved: the write is in flight and has
+  // not landed in IndexedDB yet.
+  useEffect(() => {
+    const unsaved = d.saveStatus === "dirty" || d.saveStatus === "saving";
+    if (!unsaved) return;
+    const onBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [d.saveStatus]);
+
+  // Flush the moment the tab is hidden rather than waiting out the debounce.
+  // Switching tabs or apps is the last event we reliably get before a phone or a
+  // laptop suspends the page, and on mobile pagehide is often the ONLY one — so
+  // this is what shrinks the loss window from "the last two seconds of work" to
+  // "nothing", in the cases the beforeunload prompt above never gets to appear.
+  useEffect(() => {
+    if (!api) return;
+    const flush = () => {
+      if (dRef.current.saveStatus === "dirty") saveNowRef.current();
+    };
+    const onVisibility = () => { if (document.hidden) flush(); };
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pagehide", flush);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pagehide", flush);
+    };
+  }, [api]);
 
   // Hydrate the editor with the scenario's CURRENT map: its regions + owners
   // (custom geometry when it has one, else the stock world with the scenario's
@@ -419,7 +476,21 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
           )}
           {onClose && (
             <button
-              onClick={onClose}
+              onClick={async () => {
+                // Closing with edits still in the debounce window would drop them
+                // silently — the button looks like "go back", not "discard". Try
+                // to save first, and only ask if that fails or is still pending,
+                // so the common case closes with no prompt and no loss.
+                if (d.saveStatus === "dirty") {
+                  await saveNow();
+                  if (dRef.current.saveStatus === "saved") { onClose(); return; }
+                }
+                if (d.saveStatus === "saved") { onClose(); return; }
+                const ok = window.confirm(
+                  "This map has changes that could not be saved. Close it and lose them?",
+                );
+                if (ok) onClose();
+              }}
               title="Close map editor"
               style={{
                 ...panelSurface,


### PR DESCRIPTION
Two ways the map editor lost work, and one of them has been live since colours shipped.

## The autosave was silently discarding edits 🔴

It watched a hand-listed set of document fields:

```js
}, [api, d.saveStatus, docId, d.name, d.types, d.features, d.metadata]);
```

That list never named `colorOverrides`, `flags` or `tags`. And the failure isn't a *missed* save — it's a **wrong** one:

1. Document is already `dirty` (say you moved a region).
2. You change a country's colour. React re-renders, but **no listed dep changed**, so the effect doesn't re-run and the pending timer isn't reset.
3. That timer fires holding the `saveNow` closure from **before** your colour change, writes the older payload, and sets the status to **"saved"**.
4. Your colour is gone, and the UI says everything is fine.

So any colour edit made on top of another unsaved edit has been lost this way since colours shipped. Flags and tags inherited it.

**Fix:** depend on `d.doc`. It's a new object on any document change, so it can't fall behind the way a field list does — and the next person to add a field doesn't have to know this exists.

## Closing dropped work

- `beforeunload` prompts while edits are unsaved (`saving` counts — the write hasn't landed yet).
- The editor **flushes when the tab is hidden**, beating the 2s debounce. This matters most on mobile, where `pagehide` is often the only event we get.
- The close button **saves first**, and only asks if that fails — so the normal case closes with no prompt and no loss.

The unload/visibility listeners register once, so they read the document through refs. A closure there would freeze the document at mount and flush *that* on the way out — the same bug class, with the user's last edits as the victim.

## One correction worth stating

**On the website, a node going offline cannot lose editor work.** Documents save to IndexedDB in the browser (`web/editorStore.js`), not to the node — nodes only serve map tiles.

## Verified in a browser

| | |
|---|---|
| edit made | "Unsaved changes" |
| `beforeunload` while dirty | **blocks → prompt** |
| after 2s | **autosaved → "saved"** |
| `beforeunload` after save | no prompt |
| tab hidden mid-debounce | **flushed in 700ms** |
| clean document | never prompts |

Identical commit on all three branches; `MapEditor.jsx` is currently the same across main/beta/alpha. Mirrored to the standalone editor.