### PR TITLE
Drawing a region takes its land out of the regions underneath

### DIFF
--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -40,7 +40,7 @@ import { defaults as defaultControls } from "ol/control/defaults";
 import { makeRegionStyle } from "./olStyle.js";
 import { loadSeedFeatures } from "./regionImport.js";
 import { newId } from "./useMapDocument.js";
-import { unionGeoms, translatedClone } from "./geometry.js";
+import { unionGeoms, translatedClone, subtractFrom, overlaps } from "./geometry.js";
 
 const BASEMAP_BG = {
   dark: "#0b1020",
@@ -757,9 +757,58 @@ const OlMap = ({
         if (!f.get("name")) f.set("name", "New Region");
         if (f.get("gid0") == null) f.set("gid0", "");
         if (f.get("country") == null) f.set("country", "");
+
+        // Take the new region's land OUT of whatever it was drawn over. Two
+        // regions covering the same ground is not a cosmetic problem: the place
+        // is then owned twice, only the last-rendered owner is visible, and the
+        // exported ownership map disagrees with the map the author was looking
+        // at. Drawing inside a region leaves a hole in it; drawing across an
+        // edge takes a bite; drawing over one entirely deletes it.
+        const cutter = f.getGeometry();
+        const carved = [];
+        for (const other of source.getFeatures()) {
+          if (other === f) continue;
+          const geom = other.getGeometry();
+          if (!geom || !overlaps(geom, cutter)) continue;
+          const before = geom.clone();
+          const after = subtractFrom(geom, cutter);
+          if (!after) {
+            // Fully covered: nothing of it is left to own.
+            source.removeFeature(other);
+            carved.push({ feature: other, before, after: null });
+          } else {
+            other.setGeometry(after);
+            // Mark it edited so the exporter ships this geometry rather than
+            // assuming the stock GADM shape still describes it.
+            other.set("edited", true);
+            carved.push({ feature: other, before, after: after.clone() });
+          }
+        }
+        if (carved.length) {
+          layer.changed();
+          labelLayerRef.current?.changed();
+        }
+
         // defer so drawend finishes adding to the source before we count
         setTimeout(notifyRegions, 0);
-        pushCmd({ undo: () => source.removeFeature(f), redo: () => source.addFeature(f) });
+        pushCmd({
+          undo: () => {
+            source.removeFeature(f);
+            for (const c of carved) {
+              c.feature.setGeometry(c.before.clone());
+              if (!c.after) source.addFeature(c.feature);
+            }
+            layer.changed();
+          },
+          redo: () => {
+            source.addFeature(f);
+            for (const c of carved) {
+              if (!c.after) source.removeFeature(c.feature);
+              else c.feature.setGeometry(c.after.clone());
+            }
+            layer.changed();
+          },
+        });
       });
       added.push(draw, new Snap({ source })); // Snap last so it sees events first
     } else if (activeTool === "modify") {

--- a/src/Editor/geometry.js
+++ b/src/Editor/geometry.js
@@ -32,6 +32,30 @@ export const unionGeoms = (geoms) => {
   return coordsToOl(res);
 };
 
+// `target` minus `cutter`. Returns:
+//   - an OL geometry for what survives,
+//   - null when the cutter swallows the target whole (caller deletes it),
+//   - the target unchanged when they don't actually overlap.
+//
+// A region drawn inside another must take that land OUT of the one beneath it,
+// or the two overlap: the map then has one place owned twice, whichever renders
+// last wins, and the exported ownership map disagrees with what the author sees.
+// difference() also handles the interesting case for free — a region drawn in the
+// middle of another leaves a hole (an interior ring) rather than a bitten edge.
+export const subtractFrom = (target, cutter) => {
+  const res = polygonClipping.difference(olToCoords(target), olToCoords(cutter));
+  if (!res || res.length === 0) return null;
+  return coordsToOl(res);
+};
+
+// Do these two geometries share any area at all? Cheap-ish guard so drawing a
+// region only rewrites the neighbours it genuinely overlaps, instead of running a
+// difference against every region on the map and marking them all edited.
+export const overlaps = (a, b) => {
+  const res = polygonClipping.intersection(olToCoords(a), olToCoords(b));
+  return Boolean(res && res.length > 0);
+};
+
 // Build a thin ribbon polygon (MultiPolygon coords) around a polyline — used as
 // a cutter: subtracting it from a region bisects the region along the line.
 const bufferLine = (line, hw) => {


### PR DESCRIPTION
Drawing a region inside an existing one left **both claiming the same ground**.

That isn't cosmetic. The place is owned twice, only whichever renders last is visible, and the ownership map the scenario exports disagrees with the map the author was looking at. The overlap is invisible in the editor — it surfaces later as a region that won't recolour once the map is in a game.

`drawend` now subtracts the new region from every region it genuinely overlaps:

| you draw | what happens to the region beneath |
|---|---|
| **inside** it | gets a **hole** (interior ring) |
| **across an edge** | takes a bite |
| **over it entirely** | deleted — nothing left to own |
| **not touching** | skipped, not rewritten |

### The load-bearing detail

Carved regions are marked `edited`. That's not tidiness: `detectCustomGeometry` (`exportPreset.js:73`) keys **tier-2 export** off that flag. Without it the game keeps rendering the original GADM outline from the stock pmtiles, and **the hole vanishes the moment the map is played**.

### Undo

Restores the carved neighbours *and* the new region, including any the cut deleted outright — the whole draw is one reversible step.

### No new dependency

`polygon-clipping` already ships for the dissolve tool; this uses its `difference`/`intersection`.

### Verified against the library directly

```
inside:  parent rings = 2  -> outer + hole
overlap: parent polys = 1, rings = 1 -> bite taken
covered: result = [] -> region deleted
apart:   intersection = 0 -> guard skips it
```

Both builds pass. Mirrored to the standalone editor.

**Not verified:** drawing with a mouse on a real map — the canvas doesn't render headless, so the geometry is proven and the interaction isn't.