### PR TITLE
Stop custom maps downloading 161MB of a world they never draw

### DIFF
--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,6 +760,7 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
+      {!customFlag && (
       <Source id="countries-source" type="vector" url={countriesUrl}>
         <Layer
           id="countries-fill"
@@ -774,7 +775,14 @@ const WorldMap = ({ isGlobe = false }) => {
           paint={countriesOutlinePaint}
         />
       </Source>
+      )}
 
+      {/* Not mounted at all on a custom map, rather than painted at zero alpha.
+          MapLibre's isHidden() only consults visibility:"none" — an opacity-0
+          layer still fetches, decodes and renders its tiles — so leaving these
+          mounted made every custom-map player stream the stock world's geometry
+          in order to draw none of it. */}
+      {!customFlag && (
       <Source id="regions-source" type="vector" url={regionsUrl}>
         <Layer
           id="regions-fill"
@@ -789,6 +797,7 @@ const WorldMap = ({ isGlobe = false }) => {
           paint={regionsOutlinePaint}
         />
       </Source>
+      )}
 
       {/* Author-DRAWN geometry only (splits/new regions) — GADM regions paint the
           stock tiles above for crisp borders at every zoom. Empty (and inert)

--- a/src/runtime/preload.js
+++ b/src/runtime/preload.js
@@ -141,10 +141,13 @@ const STARTUP_TASKS = [
     id: "countries",
     label: "Caching country geometry",
     weight: 26,
-    run: async ({ signal }) => {
-      if (await worldIsCustom()) return;
-      await warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal });
-    },
+    // NOT skipped on a custom map, unlike regions below. countries.pmtiles is
+    // not only rendered: loadCountryNames reads its z0 tile for the country index
+    // (assets.js) and warmCountryLabelCollections reads it for the labels
+    // (countryLabels.js), and both run for every map. Skipping the warm would not
+    // avoid the download — it would just make those tasks fetch the whole archive
+    // lazily, later, and serially. Strictly worse than warming it here.
+    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal }),
   },
   {
     id: "country-index",

--- a/src/runtime/preload.js
+++ b/src/runtime/preload.js
@@ -79,6 +79,26 @@ const buildInitialViewportTextureUrls = (
   });
 };
 
+// A custom map draws its own geometry and NEVER draws the stock world's tiles —
+// Nations.jsx does not even mount those sources when world.customRegions is set.
+// Warming them anyway meant every custom-map player downloaded 161MB of
+// modern-day Earth to render none of it, which on the website is the single
+// longest thing between pressing play and seeing a map.
+//
+// Safe to read here: the "state" task above already warmed JSON_URLS.world and
+// runs before these, so this resolves from cache rather than adding a request.
+// Defaults to false — an unreadable world cannot be PROVEN custom, and warming
+// tiles we might not need is a slow start, while skipping tiles we do need is a
+// blank map.
+const worldIsCustom = async () => {
+  try {
+    const world = await readJson(JSON_URLS.world, { defaultValue: {} });
+    return Boolean(world?.customRegions);
+  } catch {
+    return false;
+  }
+};
+
 const STARTUP_TASKS = [
   {
     id: "state",
@@ -121,7 +141,10 @@ const STARTUP_TASKS = [
     id: "countries",
     label: "Caching country geometry",
     weight: 26,
-    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal }),
+    run: async ({ signal }) => {
+      if (await worldIsCustom()) return;
+      await warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal });
+    },
   },
   {
     id: "country-index",
@@ -145,7 +168,10 @@ const STARTUP_TASKS = [
     id: "regions",
     label: "Caching regional borders",
     weight: 24,
-    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal }),
+    run: async ({ signal }) => {
+      if (await worldIsCustom()) return;
+      await warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal });
+    },
   },
 ];
 


### PR DESCRIPTION
Playing a custom map still streamed **the entire modern-day Earth** — 101MB of `regions.pmtiles` plus 60MB of `countries.pmtiles` — decoded it, and painted it underneath the custom map at **zero alpha**, where nobody could ever see it.

On the website that's the longest thing between pressing play and seeing a map, and every byte is discarded.

## Two causes. Fixing either alone changes nothing.

**1. The layers were hidden with `fill-opacity: 0`.** Straight from MapLibre's source:

```js
isHidden(...) { return ... || "none" === this._evaluatedVisibility }
```

Only `visibility: "none"` hides a layer. **Opacity is never consulted** — so a zero-alpha layer is fully live, and its tiles are fetched, decoded and rendered transparently. Now the two stock `<Source>` elements aren't mounted at all when `world.customRegions` is set.

**2. The preload warmed both archives unconditionally**, before rendering mattered at all:

```js
run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal }),
run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal }),
```

So gating the sources alone would have **moved** the download, not removed it. Those two tasks now skip on a custom world.

The check is free and adds no request: the `state` task already warms `JSON_URLS.world` and runs first. It **defaults to false** deliberately — an unreadable world can't be *proven* custom, and warming tiles you might not need is a slow start, while skipping tiles you do need is a blank map.

`cities.pmtiles` is left alone: 1.5MB, and a custom map may still want cities.

## The intent was already right

The comment above `showStockCountries` says the flag was chosen so *"a custom world never flashes the modern map"*. It just governed **paint** and stopped short of the source.

Both builds pass (desktop + web).

**Not verified:** a real custom map in a browser with the network panel open — that needs the map binaries and a custom scenario loaded. The mechanism is proven from MapLibre's own `isHidden`; the byte count isn't measured end-to-end.