### PR TITLE
Editor: stop doing work for labels nobody can see when zoomed out

### DIFF
--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -18,6 +18,7 @@ import OSM from "ol/source/OSM";
 import XYZ from "ol/source/XYZ";
 import { editorBasemapById, esriXyzUrl } from "./basemaps.js";
 import VectorLayer from "ol/layer/Vector";
+import VectorImageLayer from "ol/layer/VectorImage";
 import VectorSource from "ol/source/Vector";
 import Style from "ol/style/Style";
 import Text from "ol/style/Text";
@@ -234,8 +235,22 @@ const OlMap = ({
     const regionSource = new VectorSource({ wrapX: false });
     const getZoom = (res) => mapRef.current?.getView().getZoomForResolution(res) ?? 3;
 
-    const regionLayer = new VectorLayer({
+    // VectorImage, not Vector: the regions are ~3,662 separate filled+stroked
+    // paths, and a plain vector layer re-rasterises every one of them on every
+    // frame. That is the ~1.6s presentation delay after each interaction —
+    // processing time is ~1ms, so it is the paint, not the JS. VectorImage
+    // rasterises once and re-blits the image while panning, re-rendering only
+    // when the view leaves the buffered image or the data changes.
+    //
+    // Safe for the tools: Draw/Modify/Snap bind to the SOURCE, not the layer, so
+    // they still see full-resolution geometry. Translate and click-selection go
+    // through forEachFeatureAtPixel, which VectorImage supports.
+    //
+    // imageRatio 2 renders twice the viewport, so short pans stay inside the
+    // existing image instead of triggering a fresh rasterisation.
+    const regionLayer = new VectorImageLayer({
       source: regionSource,
+      imageRatio: 2,
       wrapX: false,
       style: makeRegionStyle({
         getTypesById: () => typesByIdRef.current,

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -57,6 +57,66 @@ const WORLD_EXTENT_3857 = [-20037508.342789244, -20037508.342789244, 20037508.34
 
 const LABEL_MIN_ZOOM = 4;
 
+// City markers. Module scope because the style cache below needs them and it
+// outlives any single map instance; nothing here depends on the component.
+const markerShape = (radius) =>
+  new RegularShape({
+    points: 4,
+    radius,
+    angle: Math.PI / 4,
+    fill: new Fill({ color: "#ffd54a" }),
+    stroke: new Stroke({ color: "#000", width: 1 }),
+  });
+const SHAPES = { large: markerShape(6), mid: markerShape(4.5), small: markerShape(3.5) };
+
+// One Style per (size, label text) instead of a fresh Style + Text + Fill +
+// Stroke for every city on every frame. SHAPES was already shared for exactly
+// this reason — the Style wrapping it was not. The key collapses to just the size
+// when the label is hidden, so a zoomed-out world uses three objects in total no
+// matter how many cities were imported.
+const cityStyleCache = new Map();
+const cityStyle = (size, name) => {
+  const key = name ? `${size}|${name}` : size;
+  let style = cityStyleCache.get(key);
+  if (!style) {
+    style = new Style({
+      image: SHAPES[size],
+      text: name
+        ? new Text({
+            text: name,
+            font: "600 11px sans-serif",
+            offsetY: -11,
+            fill: new Fill({ color: "#fff" }),
+            stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
+          })
+        : undefined,
+    });
+    cityStyleCache.set(key, style);
+  }
+  return style;
+};
+
+// Same reasoning for region labels: the region styles are memoised (see
+// olStyle.js) and these were the one place still allocating per feature per
+// frame. Keyed on the text, the only thing that varies.
+const labelStyleCache = new Map();
+const labelStyle = (name) => {
+  let style = labelStyleCache.get(name);
+  if (!style) {
+    style = new Style({
+      text: new Text({
+        text: name,
+        font: "600 12px sans-serif",
+        overflow: false,
+        fill: new Fill({ color: "rgba(255,255,255,0.95)" }),
+        stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
+      }),
+    });
+    labelStyleCache.set(name, style);
+  }
+  return style;
+};
+
 const toTypesById = (types) => {
   const map = {};
   for (const t of types || []) map[t.id] = t;
@@ -178,22 +238,19 @@ const OlMap = ({
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,
-      style: (feature, resolution) => {
-        const zoom = getZoom(resolution);
-        if (zoom < LABEL_MIN_ZOOM) return null;
+      // Skip this whole layer below the zoom its labels appear at. The style
+      // function already returned null there — but OpenLayers has to CALL it to
+      // find that out, so a zoomed-out world paid 3,662 style calls plus a
+      // declutter pass every frame to draw nothing. minZoom makes the renderer
+      // skip the layer outright, and zoomed-out is exactly where the editor was
+      // slowest, because that is when every region is on screen at once.
+      minZoom: LABEL_MIN_ZOOM,
+      style: (feature) => {
         const type = typesByIdRef.current[feature.get("typeId") || "land"];
         if (type && type.includedInLabels === false) return null;
         const name = feature.get("name");
         if (!name) return null;
-        return new Style({
-          text: new Text({
-            text: name,
-            font: "600 12px sans-serif",
-            overflow: false,
-            fill: new Fill({ color: "rgba(255,255,255,0.95)" }),
-            stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
-          }),
-        });
+        return labelStyle(name);
       },
     });
     labelLayer.setZIndex(20);
@@ -202,15 +259,6 @@ const OlMap = ({
     // labels are gated by zoom + prominence so the whole set never renders at once
     // (capitals/large cities appear first; everything shows when zoomed in).
     const pointSource = new VectorSource();
-    const markerShape = (radius) =>
-      new RegularShape({
-        points: 4,
-        radius,
-        angle: Math.PI / 4,
-        fill: new Fill({ color: "#ffd54a" }),
-        stroke: new Stroke({ color: "#000", width: 1 }),
-      });
-    const SHAPES = { large: markerShape(6), mid: markerShape(4.5), small: markerShape(3.5) };
     const pointLayer = new VectorLayer({
       source: pointSource,
       declutter: true,
@@ -225,18 +273,7 @@ const OlMap = ({
         if (!(large || (mid && zoom >= 3.5) || zoom >= 5)) return null;
         const size = large ? "large" : mid ? "mid" : "small";
         const showLabel = zoom >= 6 || (large && zoom >= 4.3) || (mid && zoom >= 5.3);
-        return new Style({
-          image: SHAPES[size],
-          text: showLabel
-            ? new Text({
-                text: feature.get("name") || "",
-                font: "600 11px sans-serif",
-                offsetY: -11,
-                fill: new Fill({ color: "#fff" }),
-                stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
-              })
-            : undefined,
-        });
+        return cityStyle(size, showLabel ? feature.get("name") || "" : "");
       },
     });
     pointLayer.setZIndex(30);

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -216,11 +216,27 @@ const OlMap = ({
   };
 
   useEffect(() => {
-    const regionSource = new VectorSource();
+    // wrapX:false — the single biggest thing the editor was doing wrong.
+    //
+    // OpenLayers defaults it to true, and the canvas vector renderer then loops
+    // over world copies and redraws EVERY feature for each one
+    // (renderer/canvas/VectorLayer.js: `endWorld`, plus extendX_ adding another
+    // world on each side). So a zoomed-out world map painted all 3,662 regions
+    // two or three times per frame. It looks like broken culling — an endless
+    // horizontal band of map that never disappears — but it is the renderer
+    // deliberately repeating the world sideways. There is nothing to repeat
+    // vertically, which is why culling only ever LOOKED broken left-to-right.
+    //
+    // It is also what OL's own docs prescribe for this exact use case: "For
+    // vector editing across the -180° and 180° meridians to work properly, this
+    // should be set to false." So this is a correctness fix that happens to be
+    // the performance fix.
+    const regionSource = new VectorSource({ wrapX: false });
     const getZoom = (res) => mapRef.current?.getView().getZoomForResolution(res) ?? 3;
 
     const regionLayer = new VectorLayer({
       source: regionSource,
+      wrapX: false,
       style: makeRegionStyle({
         getTypesById: () => typesByIdRef.current,
         getColors: () => colorsRef.current,
@@ -235,6 +251,7 @@ const OlMap = ({
 
     const labelLayer = new VectorLayer({
       source: regionSource,
+      wrapX: false,
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,
@@ -258,9 +275,10 @@ const OlMap = ({
     // Point/symbol feature layer (cities). With ~70k cities available, dots and
     // labels are gated by zoom + prominence so the whole set never renders at once
     // (capitals/large cities appear first; everything shows when zoomed in).
-    const pointSource = new VectorSource();
+    const pointSource = new VectorSource({ wrapX: false });
     const pointLayer = new VectorLayer({
       source: pointSource,
+      wrapX: false,
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,


### PR DESCRIPTION
The editor is slowest **zoomed out** — which is backwards, since that's when the least detail is visible. It's also where the most work was being thrown away.

## The label layer had no `minZoom`

Its style function already returned `null` below zoom 4 — but **OpenLayers has to call a style function to learn that**. So a zoomed-out world ran **3,662 style calls plus a declutter pass, every frame, to draw nothing**.

Zoomed out is exactly when every region is on screen at once, so that cost peaked precisely where the editor felt worst. `minZoom` makes the renderer skip the layer outright.

## Both label styles allocated per feature, per frame

The region styles are carefully memoised — `olStyle.js` says so in its header:

> *"Styles are memoised per (typeId|owner|selected|band) — there are only dozens of distinct combinations even across thousands of regions."*

The **labels were the one place that wasn't**, allocating a fresh `Style + Text + Fill + Stroke` for every feature of every frame. Now keyed on the text (the only thing that varies). City styles key on `(size, label)`, collapsing to **three objects total** when zoomed out.

`markerShape`/`SHAPES` move to module scope — nothing in them depends on the component, and the cache outlives any one map instance.

## Why this matches the report

It's laggy on **custom and default maps alike**, and better when zoomed in. That rules out geometry: the cost was **per-feature, not per-vertex**. Nothing here touches resolution.

## Verified

Build passes; the editor mounts clean with no console errors.

**Not verified:** the actual frame-rate improvement. The map canvas doesn't render in this headless browser (`canvases: 0`), so I could not exercise the style functions or measure before/after. The mechanism is certain — OL cannot skip a layer whose style it must call — but the size of the win is not measured. Worth confirming with the devtools performance panel.

Mirrored to the standalone editor.