### PR TITLE
Editor: 4.5x the border detail (z5 → z8 region seed)

### DIFF
--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed.geojson", "bytes": 12708948, "sha256": "5c468ae1fc0607f90d1a30f22ea12a97acbc464f733b307fc2a1ad32ec660aca" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }


### PR DESCRIPTION
The editor's regions were stitched from the pmtiles at **zoom 5** — 156 vertices per region, against the **z10** the pmtiles actually hold. So every border you traced along or cut against was five zoom levels coarser than the geometry around it. That's what made drawn regions look wrong next to their neighbours.

Re-extracted at **z8**:

| | before (z5) | after (z8) |
|---|---|---|
| vertices/region | 156 | **705** |
| total vertices | 570k | **2.58M** |
| seed | 12.1 MB | 52.8 MB |
| gzipped | 3.3 MB | 15.8 MB |

## Only affordable now

A plain vector layer redrew every one of those paths every frame. The editor moved to `VectorImageLayer` in #275 — it rasterises once and re-blits — so vertex count no longer drives frame cost. This would have been unusable a commit ago.

## z10 is impossible, not just expensive

The extractor runs to completion at z10 and then **dies in `JSON.stringify`**: the result exceeds V8's **512 MB maximum string length**. It cannot be serialised, let alone loaded by a browser.

That is exactly why the pmtiles exist — **316,600 small tiles instead of one impossible file**. z8 is the practical ceiling for a single-file seed. True z10 needs viewport-loading from the pmtiles, which is a separate feature.

## Published as a NEW asset, deliberately

`regions-seed-z8.geojson`, not a replacement for `regions-seed.geojson`.

The manifest pins a **sha256 per asset**. Overwriting in place would hand every not-yet-updated checkout a file its manifest says is wrong, and `fetch-map-assets.mjs` would fail the hash **on a map that had been working**. Both files now sit on the `map-data` release; old manifests keep resolving the old asset.

## Verified

Deleted the local seed and re-fetched from the release: downloads, **passes the hash check**, 3,662 regions. Manifest bytes/sha match the uploaded asset exactly.

## Worth knowing

The seed also feeds `build-default-map.mjs` and `build-preset.mjs`. Those aren't regenerated here — the default scenario keeps its existing z5 `regions.geojson`. Since it sets `customRegions: true`, **every player currently renders z5 borders**; regenerating it at z8 would take that file from 12.2 MB to ~53 MB shipped to everyone. That's a separate decision.
