### PR TITLE
Editor and game both at z9, so authored borders match rendered ones

### DIFF
--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed.geojson", "bytes": 12708948, "sha256": "5c468ae1fc0607f90d1a30f22ea12a97acbc464f733b307fc2a1ad32ec660aca" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,7 +760,13 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
-      <Source id="countries-source" type="vector" url={countriesUrl}>
+      {/* maxzoom 9, not the archive's 10: the map editor stitches its region seed
+          from these tiles at z9 (extract-regions.mjs — z10 cannot be stitched at
+          all, the result exceeds V8's 512MB max string length), so rendering the
+          game at z10 drew borders one level finer than any map anyone can author
+          against them. Capping here makes the two agree. Past z9 MapLibre
+          overzooms, exactly as it already did past z10. */}
+      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={9}>
         <Layer
           id="countries-fill"
           type="fill"
@@ -775,7 +781,7 @@ const WorldMap = ({ isGlobe = false }) => {
         />
       </Source>
 
-      <Source id="regions-source" type="vector" url={regionsUrl}>
+      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={9}>
         <Layer
           id="regions-fill"
           type="fill"


### PR DESCRIPTION
The editor stitched its region seed from the pmtiles at **z5** — 156 vertices per region — while the game rendered those same borders at **z10**. So anything you traced or cut against in the editor was **five zoom levels coarser** than what the game drew around it. That's what made authored regions look wrong next to stock ones.

Both ends now sit at **z9**.

| | before | after |
|---|---|---|
| seed | z5 — 156 verts/region, 12.1 MB | **z9 — 1,116 verts/region (7×), 83.4 MB** |
| game | rendered z10 | **capped at `maxzoom={9}`** |

## Why z9 and not z10

**z10 isn't available at either end.** The extractor runs to completion and then **dies in `JSON.stringify`**: the result exceeds V8's **512 MB maximum string length**. A z10 seed cannot be serialised, let alone loaded by a browser.

So z9 is the finest the editor can *ever* offer as a single file — and rendering the game at z10 only meant drawing detail **no map could be authored against**. Past z9 MapLibre overzooms, exactly as it already did past z10.

The full curve, measured:

| zoom | raw | gzip | verts/region | parse |
|---|---|---|---|---|
| z5 | 12.1 MB | 3.3 MB | 156 | 104 ms |
| z7 | 32.4 MB | 9.6 MB | 430 | 330 ms |
| z8 | 52.8 MB | 15.8 MB | 705 | 480 ms |
| **z9** | **83.4 MB** | **24.8 MB** | **1,116** | 669 ms |
| z10 | — | — | — | **impossible** |

## Only affordable now

4M vertices would have been unusable before #275 moved the editor to `VectorImageLayer` — a plain vector layer redrew every path every frame. Rasterising once decoupled frame cost from vertex count.

## Published as a new asset

`regions-seed-z9.geojson`, not a replacement. The manifest pins a **sha256 per asset**, so overwriting would hand every not-yet-updated checkout a file its manifest calls wrong — failing the hash on a map that had been working.

## Verified

Deleted the local seed, re-fetched from the release: downloads, **passes the hash**, 3,662 regions. Both builds pass.

## Note

Supersedes #276 (z8) — close that one. The seed also feeds `build-default-map.mjs`; the default scenario keeps its z5 `regions.geojson` for now, and since it sets `customRegions: true`, **players still render z5 borders there**. Regenerating it at z9 would take that file from 12.2 MB to ~83 MB shipped to everyone — a separate decision.
