### PR TITLE
Rebuild the modern-day map at z9 — players were rendering z5 borders

### DIFF
--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -9,6 +9,6 @@
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
     { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
-    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
+    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z9.geojson", "bytes": 87595395, "sha256": "1738f3edc843503b3d23fa37e869bfbeecdb00719b5df8c85fa22ce406bd415e" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed.geojson", "bytes": 12708948, "sha256": "5c468ae1fc0607f90d1a30f22ea12a97acbc464f733b307fc2a1ad32ec660aca" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,7 +760,13 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
-      <Source id="countries-source" type="vector" url={countriesUrl}>
+      {/* maxzoom 9, not the archive's 10: the map editor stitches its region seed
+          from these tiles at z9 (extract-regions.mjs — z10 cannot be stitched at
+          all, the result exceeds V8's 512MB max string length), so rendering the
+          game at z10 drew borders one level finer than any map anyone can author
+          against them. Capping here makes the two agree. Past z9 MapLibre
+          overzooms, exactly as it already did past z10. */}
+      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={9}>
         <Layer
           id="countries-fill"
           type="fill"
@@ -775,7 +781,7 @@ const WorldMap = ({ isGlobe = false }) => {
         />
       </Source>
 
-      <Source id="regions-source" type="vector" url={regionsUrl}>
+      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={9}>
         <Layer
           id="regions-fill"
           type="fill"


### PR DESCRIPTION
**Players have been looking at z5 borders on the modern-day map.**

The default scenario sets `customRegions: true`, so the game renders its `regions.geojson` and never touches the stock pmtiles for that map. That file is generated from the editor's region seed by `build-default-map.mjs` — and it hadn't been rebuilt since the seed was **z5**.

So the modern-day map draws **156 vertices per region**, while the pmtiles sitting next to it hold ten times that, and the editor (now z9 via #278) shows borders **five zoom levels finer than the game draws**. That mismatch is exactly what makes authored regions look wrong beside stock ones.

| | before | after |
|---|---|---|
| vertices | 570,361 | **4,087,257** |
| per region | 156 | **1,116** |
| size | 12.2 MB | 83.5 MB |

## The cost, stated plainly

`default-regions` is a map-data release asset, so this is **+71 MB for every player**. What it buys is the modern-day map finally rendering at the resolution its own data supports, and agreeing with the editor.

Worth weighing against #274: with `customRegions: true` on the default scenario, that PR already stops the stock `regions.pmtiles` (101 MB) being warmed for this map — because nothing draws it.

## Published as a new asset

`default-regions-z9.geojson`. The manifest pins a **sha256 per asset**; overwriting would fail the hash on every checkout that hasn't updated.

## Verified

Deleted both local files and re-fetched from the release: **2 downloaded, hashes verified**, 3,662 regions each.

Stacks on #278 (the z9 seed + game cap).
