### PR TITLE
z8 everywhere: the finest resolution the editor can actually hold

### DIFF
--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -9,6 +9,6 @@
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
     { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
-    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
+    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z9.geojson", "bytes": 87595395, "sha256": "1738f3edc843503b3d23fa37e869bfbeecdb00719b5df8c85fa22ce406bd415e" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed.geojson", "bytes": 12708948, "sha256": "5c468ae1fc0607f90d1a30f22ea12a97acbc464f733b307fc2a1ad32ec660aca" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
-    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z9.geojson", "bytes": 87595395, "sha256": "1738f3edc843503b3d23fa37e869bfbeecdb00719b5df8c85fa22ce406bd415e" }
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
+    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z8.geojson", "bytes": 55460252, "sha256": "da2ca7cde61a09b04991bc37ba91118c9750dfda94508f7b8b483818e1dae2c1" }
   ]
 }

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -18,6 +18,7 @@ import OSM from "ol/source/OSM";
 import XYZ from "ol/source/XYZ";
 import { editorBasemapById, esriXyzUrl } from "./basemaps.js";
 import VectorLayer from "ol/layer/Vector";
+import VectorImageLayer from "ol/layer/VectorImage";
 import VectorSource from "ol/source/Vector";
 import Style from "ol/style/Style";
 import Text from "ol/style/Text";
@@ -234,8 +235,22 @@ const OlMap = ({
     const regionSource = new VectorSource({ wrapX: false });
     const getZoom = (res) => mapRef.current?.getView().getZoomForResolution(res) ?? 3;
 
-    const regionLayer = new VectorLayer({
+    // VectorImage, not Vector: the regions are ~3,662 separate filled+stroked
+    // paths, and a plain vector layer re-rasterises every one of them on every
+    // frame. That is the ~1.6s presentation delay after each interaction —
+    // processing time is ~1ms, so it is the paint, not the JS. VectorImage
+    // rasterises once and re-blits the image while panning, re-rendering only
+    // when the view leaves the buffered image or the data changes.
+    //
+    // Safe for the tools: Draw/Modify/Snap bind to the SOURCE, not the layer, so
+    // they still see full-resolution geometry. Translate and click-selection go
+    // through forEachFeatureAtPixel, which VectorImage supports.
+    //
+    // imageRatio 2 renders twice the viewport, so short pans stay inside the
+    // existing image instead of triggering a fresh rasterisation.
+    const regionLayer = new VectorImageLayer({
       source: regionSource,
+      imageRatio: 2,
       wrapX: false,
       style: makeRegionStyle({
         getTypesById: () => typesByIdRef.current,

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -57,6 +57,66 @@ const WORLD_EXTENT_3857 = [-20037508.342789244, -20037508.342789244, 20037508.34
 
 const LABEL_MIN_ZOOM = 4;
 
+// City markers. Module scope because the style cache below needs them and it
+// outlives any single map instance; nothing here depends on the component.
+const markerShape = (radius) =>
+  new RegularShape({
+    points: 4,
+    radius,
+    angle: Math.PI / 4,
+    fill: new Fill({ color: "#ffd54a" }),
+    stroke: new Stroke({ color: "#000", width: 1 }),
+  });
+const SHAPES = { large: markerShape(6), mid: markerShape(4.5), small: markerShape(3.5) };
+
+// One Style per (size, label text) instead of a fresh Style + Text + Fill +
+// Stroke for every city on every frame. SHAPES was already shared for exactly
+// this reason — the Style wrapping it was not. The key collapses to just the size
+// when the label is hidden, so a zoomed-out world uses three objects in total no
+// matter how many cities were imported.
+const cityStyleCache = new Map();
+const cityStyle = (size, name) => {
+  const key = name ? `${size}|${name}` : size;
+  let style = cityStyleCache.get(key);
+  if (!style) {
+    style = new Style({
+      image: SHAPES[size],
+      text: name
+        ? new Text({
+            text: name,
+            font: "600 11px sans-serif",
+            offsetY: -11,
+            fill: new Fill({ color: "#fff" }),
+            stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
+          })
+        : undefined,
+    });
+    cityStyleCache.set(key, style);
+  }
+  return style;
+};
+
+// Same reasoning for region labels: the region styles are memoised (see
+// olStyle.js) and these were the one place still allocating per feature per
+// frame. Keyed on the text, the only thing that varies.
+const labelStyleCache = new Map();
+const labelStyle = (name) => {
+  let style = labelStyleCache.get(name);
+  if (!style) {
+    style = new Style({
+      text: new Text({
+        text: name,
+        font: "600 12px sans-serif",
+        overflow: false,
+        fill: new Fill({ color: "rgba(255,255,255,0.95)" }),
+        stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
+      }),
+    });
+    labelStyleCache.set(name, style);
+  }
+  return style;
+};
+
 const toTypesById = (types) => {
   const map = {};
   for (const t of types || []) map[t.id] = t;
@@ -178,22 +238,19 @@ const OlMap = ({
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,
-      style: (feature, resolution) => {
-        const zoom = getZoom(resolution);
-        if (zoom < LABEL_MIN_ZOOM) return null;
+      // Skip this whole layer below the zoom its labels appear at. The style
+      // function already returned null there — but OpenLayers has to CALL it to
+      // find that out, so a zoomed-out world paid 3,662 style calls plus a
+      // declutter pass every frame to draw nothing. minZoom makes the renderer
+      // skip the layer outright, and zoomed-out is exactly where the editor was
+      // slowest, because that is when every region is on screen at once.
+      minZoom: LABEL_MIN_ZOOM,
+      style: (feature) => {
         const type = typesByIdRef.current[feature.get("typeId") || "land"];
         if (type && type.includedInLabels === false) return null;
         const name = feature.get("name");
         if (!name) return null;
-        return new Style({
-          text: new Text({
-            text: name,
-            font: "600 12px sans-serif",
-            overflow: false,
-            fill: new Fill({ color: "rgba(255,255,255,0.95)" }),
-            stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
-          }),
-        });
+        return labelStyle(name);
       },
     });
     labelLayer.setZIndex(20);
@@ -202,15 +259,6 @@ const OlMap = ({
     // labels are gated by zoom + prominence so the whole set never renders at once
     // (capitals/large cities appear first; everything shows when zoomed in).
     const pointSource = new VectorSource();
-    const markerShape = (radius) =>
-      new RegularShape({
-        points: 4,
-        radius,
-        angle: Math.PI / 4,
-        fill: new Fill({ color: "#ffd54a" }),
-        stroke: new Stroke({ color: "#000", width: 1 }),
-      });
-    const SHAPES = { large: markerShape(6), mid: markerShape(4.5), small: markerShape(3.5) };
     const pointLayer = new VectorLayer({
       source: pointSource,
       declutter: true,
@@ -225,18 +273,7 @@ const OlMap = ({
         if (!(large || (mid && zoom >= 3.5) || zoom >= 5)) return null;
         const size = large ? "large" : mid ? "mid" : "small";
         const showLabel = zoom >= 6 || (large && zoom >= 4.3) || (mid && zoom >= 5.3);
-        return new Style({
-          image: SHAPES[size],
-          text: showLabel
-            ? new Text({
-                text: feature.get("name") || "",
-                font: "600 11px sans-serif",
-                offsetY: -11,
-                fill: new Fill({ color: "#fff" }),
-                stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
-              })
-            : undefined,
-        });
+        return cityStyle(size, showLabel ? feature.get("name") || "" : "");
       },
     });
     pointLayer.setZIndex(30);

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -216,11 +216,27 @@ const OlMap = ({
   };
 
   useEffect(() => {
-    const regionSource = new VectorSource();
+    // wrapX:false — the single biggest thing the editor was doing wrong.
+    //
+    // OpenLayers defaults it to true, and the canvas vector renderer then loops
+    // over world copies and redraws EVERY feature for each one
+    // (renderer/canvas/VectorLayer.js: `endWorld`, plus extendX_ adding another
+    // world on each side). So a zoomed-out world map painted all 3,662 regions
+    // two or three times per frame. It looks like broken culling — an endless
+    // horizontal band of map that never disappears — but it is the renderer
+    // deliberately repeating the world sideways. There is nothing to repeat
+    // vertically, which is why culling only ever LOOKED broken left-to-right.
+    //
+    // It is also what OL's own docs prescribe for this exact use case: "For
+    // vector editing across the -180° and 180° meridians to work properly, this
+    // should be set to false." So this is a correctness fix that happens to be
+    // the performance fix.
+    const regionSource = new VectorSource({ wrapX: false });
     const getZoom = (res) => mapRef.current?.getView().getZoomForResolution(res) ?? 3;
 
     const regionLayer = new VectorLayer({
       source: regionSource,
+      wrapX: false,
       style: makeRegionStyle({
         getTypesById: () => typesByIdRef.current,
         getColors: () => colorsRef.current,
@@ -235,6 +251,7 @@ const OlMap = ({
 
     const labelLayer = new VectorLayer({
       source: regionSource,
+      wrapX: false,
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,
@@ -258,9 +275,10 @@ const OlMap = ({
     // Point/symbol feature layer (cities). With ~70k cities available, dots and
     // labels are gated by zoom + prominence so the whole set never renders at once
     // (capitals/large cities appear first; everything shows when zoomed in).
-    const pointSource = new VectorSource();
+    const pointSource = new VectorSource({ wrapX: false });
     const pointLayer = new VectorLayer({
       source: pointSource,
+      wrapX: false,
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -711,16 +711,19 @@ const OlMap = ({
       },
       // Serialize all region geometry to a GeoJSON FeatureCollection (WGS84) for
       // saving/exporting; load one back into the source.
-      serializeRegions: () => {
-        const fmt = new GeoJSON();
-        return JSON.parse(
-          fmt.writeFeatures(regionSource.getFeatures(), {
-            dataProjection: "EPSG:4326",
-            featureProjection: "EPSG:3857",
-            decimals: 5,
-          }),
-        );
-      },
+      // writeFeaturesObject, NOT JSON.parse(writeFeatures(...)). OL's writeFeatures
+      // is literally JSON.stringify(writeFeaturesObject(...)) (format/JSONFeature.js),
+      // so parsing its result built an ~83MB string at z9 and immediately tore it
+      // back apart — to reach the object writeFeaturesObject already had. And this
+      // runs on the 2s autosave, so the editor did that on a loop while you worked;
+      // saveDocument then stringifies the payload anyway, making it string -> objects
+      // -> string. That churn is what ran the tab out of memory.
+      serializeRegions: () =>
+        new GeoJSON().writeFeaturesObject(regionSource.getFeatures(), {
+          dataProjection: "EPSG:4326",
+          featureProjection: "EPSG:3857",
+          decimals: 5,
+        }),
       loadRegions: (fc) => {
         const fmt = new GeoJSON();
         regionSource.clear();

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -839,8 +839,18 @@ const OlMap = ({
         // edge takes a bite; drawing over one entirely deletes it.
         const cutter = f.getGeometry();
         const carved = [];
-        for (const other of source.getFeatures()) {
-          if (other === f) continue;
+        // Ask the source's R-tree for the handful of regions whose extents meet the
+        // new one, rather than walking all 3,662 and running a full boolean op on
+        // each. overlaps() is polygon-clipping, which builds sweep-line structures
+        // per call — doing that against every region on the map allocated hard
+        // enough to run the tab out of memory once the seed went to z9 and each
+        // polygon carried ~1,116 vertices instead of ~156. The extent query is an
+        // index lookup and rejects everything that cannot possibly touch.
+        const candidates = [];
+        source.forEachFeatureIntersectingExtent(cutter.getExtent(), (other) => {
+          if (other !== f) candidates.push(other);
+        });
+        for (const other of candidates) {
           const geom = other.getGeometry();
           if (!geom || !overlaps(geom, cutter)) continue;
           const before = geom.clone();

--- a/src/Editor/regionImport.js
+++ b/src/Editor/regionImport.js
@@ -40,15 +40,26 @@ export const loadSeedFeatures = async ({ signal } = {}) => {
   }
   const fc = await res.json();
   const fmt = new GeoJSON();
-  const features = fmt.readFeatures(fc, {
-    dataProjection: "EPSG:4326",
-    featureProjection: "EPSG:3857",
-  });
-  for (const feature of features) {
+  const opts = { dataProjection: "EPSG:4326", featureProjection: "EPSG:3857" };
+
+  // One feature at a time, dropping each raw one as it is converted — NOT
+  // readFeatures(fc), which is the same work but holds two entire worlds in
+  // memory at once: the parsed GeoJSON (every coordinate its own [lon,lat] JS
+  // array) and OpenLayers' flat-coordinate copy of the same thing. At the seed's
+  // ~4M vertices that peak is what ran the editor out of memory. Releasing each
+  // raw feature here lets the parsed half be collected while the OL half is
+  // still being built, so the peak is roughly one copy instead of two.
+  const raw = fc.features || [];
+  fc.features = null; // the array is reachable via `raw` alone from here
+  const features = [];
+  for (let i = 0; i < raw.length; i += 1) {
+    const feature = fmt.readFeature(raw[i], opts);
+    raw[i] = null; // this one is converted; let it go now, not at the end
     const props = feature.getProperties();
     if (props.id != null) feature.setId(String(props.id));
     if (feature.get("owner") == null) feature.set("owner", props.gid0 || null);
     if (feature.get("typeId") == null) feature.set("typeId", "land");
+    features.push(feature);
   }
   return features;
 };

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,13 +760,16 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
-      {/* maxzoom 9, not the archive's 10: the map editor stitches its region seed
-          from these tiles at z9 (extract-regions.mjs — z10 cannot be stitched at
-          all, the result exceeds V8's 512MB max string length), so rendering the
-          game at z10 drew borders one level finer than any map anyone can author
-          against them. Capping here makes the two agree. Past z9 MapLibre
-          overzooms, exactly as it already did past z10. */}
-      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={9}>
+      {/* maxzoom 8, not the archive's 10, because 8 is what the editor can
+          actually author against. z10 cannot be stitched into a seed at all —
+          extract-regions.mjs completes and then dies in JSON.stringify, over V8's
+          512MB max string length. z9 stitches, but 4.1M vertices then ran the
+          editor's tab out of heap: Chrome killed the renderer with "Aw, Snap"
+          while the machine still had 3GB free, because the cap is per-renderer.
+          z8's 2.6M is stable. Rendering finer than the editor can edit only draws
+          detail no map can be built against. Past z8 MapLibre overzooms, exactly
+          as it already did past z10. */}
+      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={8}>
         <Layer
           id="countries-fill"
           type="fill"
@@ -781,7 +784,7 @@ const WorldMap = ({ isGlobe = false }) => {
         />
       </Source>
 
-      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={9}>
+      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={8}>
         <Layer
           id="regions-fill"
           type="fill"

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,7 +760,13 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
-      <Source id="countries-source" type="vector" url={countriesUrl}>
+      {/* maxzoom 9, not the archive's 10: the map editor stitches its region seed
+          from these tiles at z9 (extract-regions.mjs — z10 cannot be stitched at
+          all, the result exceeds V8's 512MB max string length), so rendering the
+          game at z10 drew borders one level finer than any map anyone can author
+          against them. Capping here makes the two agree. Past z9 MapLibre
+          overzooms, exactly as it already did past z10. */}
+      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={9}>
         <Layer
           id="countries-fill"
           type="fill"
@@ -775,7 +781,7 @@ const WorldMap = ({ isGlobe = false }) => {
         />
       </Source>
 
-      <Source id="regions-source" type="vector" url={regionsUrl}>
+      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={9}>
         <Layer
           id="regions-fill"
           type="fill"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,15 +17,30 @@ import path from 'node:path'
 // are gitignored and arrive from the map-data Release at first launch, so CI and a
 // fresh clone build fine and the deploy failure looks random. Dropping them after
 // the copy is the fix; "remember to delete them before deploying" is not.
-const MAP_BINARIES = [
+// Never wanted in EITHER build: nothing loads a pmtiles archive from the bundle.
+// The desktop streams them off disk via /api/runtime/pmtiles/:assetKey and the
+// website fetches them from the content nodes, hash-verified. Copying them in only
+// broke the Pages deploy at its 25 MiB-per-file limit.
+const PMTILES = [
   'assets/regions.pmtiles',
   'assets/countries.pmtiles',
   'assets/cities.pmtiles',
+]
+
+// Wanted by the DESKTOP, fatal to the WEBSITE. The map editor loads these, and the
+// desktop server serves exactly one directory (`app.use(express.static(distDir))`)
+// — so dropping them there makes /assets/regions-seed.geojson fall through to the
+// SPA fallback, answer with index.html, and the editor open with zero regions.
+//
+// The web build resolves them from VITE_OH_PMTILES_URL instead (see
+// regionImport.js), so it never reads them from the bundle — and it must not carry
+// them: regions-seed.geojson is 52.8MB at z8 and Pages rejects any file over 25MiB.
+const EDITOR_SEEDS = [
   'assets/regions-seed.geojson',
   'assets/cities-seed.json',
 ]
 
-const dropMapBinaries = () => {
+const dropMapBinaries = (isWeb) => {
   // Take outDir from the resolved config rather than assuming: --outDir varies
   // (dist for the desktop, dist-web for build:web/build:site).
   let outDir = 'dist'
@@ -36,7 +51,7 @@ const dropMapBinaries = () => {
       outDir = config.build.outDir
     },
     closeBundle() {
-      for (const rel of MAP_BINARIES) {
+      for (const rel of isWeb ? [...PMTILES, ...EDITOR_SEEDS] : PMTILES) {
         const target = path.resolve(outDir, rel)
         if (fs.existsSync(target)) fs.rmSync(target)
       }
@@ -65,7 +80,7 @@ export default defineConfig(({ mode }) => ({
         plugins: [['babel-plugin-react-compiler']],
       },
     }),
-    dropMapBinaries(),
+    dropMapBinaries(mode === 'web'),
   ],
   // Proxy API calls to the Express server during `npm run dev` so the map editor's
   // save/load (and the game's runtime endpoints) work with hot-reload too.


### PR DESCRIPTION
**z9 crashed the editor.** Chrome killed the renderer with "Aw, Snap" shortly after drawing a region — while the machine still had **3 GB free**. The heap cap is per-renderer, so free RAM was never the constraint. At 4.1M vertices the tab sat against that ceiling; z8's 2.6M doesn't. Confirmed by testing: **the crash is gone and the borders still look right**.

So z8 is the real ceiling, and everything now agrees on it:

| | |
|---|---|
| editor seed | **z8** — 705 verts/region (z5 was 156) |
| default map | **z8** — rebuilt from the same seed |
| game stock tiles | **`maxzoom={8}`** |
| community bundles | **z8** — all six replaced on the scenarios release |

## Capping the game at z8 isn't a downgrade

Rendering finer than the editor can author against only draws detail **no map can be built to match** — which is the mismatch this whole line of work set out to fix. Past z8 MapLibre overzooms, exactly as it already did past the archive's z10.

## Why not higher

- **z10** cannot be stitched into a seed at all: `extract-regions.mjs` runs to completion and dies in `JSON.stringify`, over V8's **512 MB max string length**.
- **z9** stitches, but doesn't fit in a browser tab (above).
- **z8** is what's left — and the difference from z9 is a level of coastline detail that's hard to see at any zoom the game allows.

## The full curve, measured

| zoom | verts/region | seed | status |
|---|---|---|---|
| z5 | 156 | 12.1 MB | the old default |
| **z8** | **705** | **52.8 MB** | **stable** |
| z9 | 1,116 | 83.4 MB | crashes the tab |
| z10 | — | — | can't be serialised |

## Assets

Published as `default-regions-z8.geojson` / `regions-seed-z8.geojson` rather than overwriting: the manifest pins a **sha256 per asset**, so replacing one in place fails the hash on every checkout that hasn't updated. Verified by deleting both local files and re-fetching from the release.

Community bundles on the `bundles` release: **104 MB → 431 MB** (6 × ~72 MB). That's the real cost — every scenario download grows ~4×, in exchange for the community maps finally matching the game's own resolution.

Supersedes #278 (z9).
