### PR TITLE
Editor: fix the lag, fix the OOM, and put the map at the resolution it can actually hold (z8) [alpha]

### DIFF
--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -9,6 +9,6 @@
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
     { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
-    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
+    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z9.geojson", "bytes": 87595395, "sha256": "1738f3edc843503b3d23fa37e869bfbeecdb00719b5df8c85fa22ce406bd415e" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed.geojson", "bytes": 12708948, "sha256": "5c468ae1fc0607f90d1a30f22ea12a97acbc464f733b307fc2a1ad32ec660aca" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
     { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions.geojson", "bytes": 12818777, "sha256": "4e92b2f8210306b85c51a8affdb1a92bc0e3aa8ffb5dce137a66c08c71ccaa8a" }
   ]
 }

--- a/scripts/map-assets.json
+++ b/scripts/map-assets.json
@@ -8,7 +8,7 @@
     { "path": "public/assets/countries.pmtiles", "asset": "countries.pmtiles", "bytes": 62739546, "sha256": "596e3dffb0aba5bf6f2dd103c441020730161c55b67a6993dc3e0fb924fe1727" },
     { "path": "public/assets/cities.pmtiles", "asset": "cities.pmtiles", "bytes": 1547924, "sha256": "41edf847114a0c1b04c9a11e9501fc97e680a105b2ec618f5caffca3df61e87a" },
     { "path": "public/assets/cities-seed.json", "asset": "cities-seed.json", "bytes": 7857627, "sha256": "2138650914b87fa7036b065a9d18bd88cbb97ec6c67e9ec22f2be1a9f8bff101" },
-    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z9.geojson", "bytes": 87485536, "sha256": "a214a2c34eeb7ace39c62057d575c13ad9de163f45b2c025f0b9792d687ca46c" },
-    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z9.geojson", "bytes": 87595395, "sha256": "1738f3edc843503b3d23fa37e869bfbeecdb00719b5df8c85fa22ce406bd415e" }
+    { "path": "public/assets/regions-seed.geojson", "asset": "regions-seed-z8.geojson", "bytes": 55350393, "sha256": "64f1e3708e1f17016f38f86d3b6f928971c7842e8126d74efa65eb04654c770d" },
+    { "path": "server/data/scenarios/default/regions.geojson", "asset": "default-regions-z8.geojson", "bytes": 55460252, "sha256": "da2ca7cde61a09b04991bc37ba91118c9750dfda94508f7b8b483818e1dae2c1" }
   ]
 }

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -18,6 +18,7 @@ import OSM from "ol/source/OSM";
 import XYZ from "ol/source/XYZ";
 import { editorBasemapById, esriXyzUrl } from "./basemaps.js";
 import VectorLayer from "ol/layer/Vector";
+import VectorImageLayer from "ol/layer/VectorImage";
 import VectorSource from "ol/source/Vector";
 import Style from "ol/style/Style";
 import Text from "ol/style/Text";
@@ -234,8 +235,22 @@ const OlMap = ({
     const regionSource = new VectorSource({ wrapX: false });
     const getZoom = (res) => mapRef.current?.getView().getZoomForResolution(res) ?? 3;
 
-    const regionLayer = new VectorLayer({
+    // VectorImage, not Vector: the regions are ~3,662 separate filled+stroked
+    // paths, and a plain vector layer re-rasterises every one of them on every
+    // frame. That is the ~1.6s presentation delay after each interaction —
+    // processing time is ~1ms, so it is the paint, not the JS. VectorImage
+    // rasterises once and re-blits the image while panning, re-rendering only
+    // when the view leaves the buffered image or the data changes.
+    //
+    // Safe for the tools: Draw/Modify/Snap bind to the SOURCE, not the layer, so
+    // they still see full-resolution geometry. Translate and click-selection go
+    // through forEachFeatureAtPixel, which VectorImage supports.
+    //
+    // imageRatio 2 renders twice the viewport, so short pans stay inside the
+    // existing image instead of triggering a fresh rasterisation.
+    const regionLayer = new VectorImageLayer({
       source: regionSource,
+      imageRatio: 2,
       wrapX: false,
       style: makeRegionStyle({
         getTypesById: () => typesByIdRef.current,

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -57,6 +57,66 @@ const WORLD_EXTENT_3857 = [-20037508.342789244, -20037508.342789244, 20037508.34
 
 const LABEL_MIN_ZOOM = 4;
 
+// City markers. Module scope because the style cache below needs them and it
+// outlives any single map instance; nothing here depends on the component.
+const markerShape = (radius) =>
+  new RegularShape({
+    points: 4,
+    radius,
+    angle: Math.PI / 4,
+    fill: new Fill({ color: "#ffd54a" }),
+    stroke: new Stroke({ color: "#000", width: 1 }),
+  });
+const SHAPES = { large: markerShape(6), mid: markerShape(4.5), small: markerShape(3.5) };
+
+// One Style per (size, label text) instead of a fresh Style + Text + Fill +
+// Stroke for every city on every frame. SHAPES was already shared for exactly
+// this reason — the Style wrapping it was not. The key collapses to just the size
+// when the label is hidden, so a zoomed-out world uses three objects in total no
+// matter how many cities were imported.
+const cityStyleCache = new Map();
+const cityStyle = (size, name) => {
+  const key = name ? `${size}|${name}` : size;
+  let style = cityStyleCache.get(key);
+  if (!style) {
+    style = new Style({
+      image: SHAPES[size],
+      text: name
+        ? new Text({
+            text: name,
+            font: "600 11px sans-serif",
+            offsetY: -11,
+            fill: new Fill({ color: "#fff" }),
+            stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
+          })
+        : undefined,
+    });
+    cityStyleCache.set(key, style);
+  }
+  return style;
+};
+
+// Same reasoning for region labels: the region styles are memoised (see
+// olStyle.js) and these were the one place still allocating per feature per
+// frame. Keyed on the text, the only thing that varies.
+const labelStyleCache = new Map();
+const labelStyle = (name) => {
+  let style = labelStyleCache.get(name);
+  if (!style) {
+    style = new Style({
+      text: new Text({
+        text: name,
+        font: "600 12px sans-serif",
+        overflow: false,
+        fill: new Fill({ color: "rgba(255,255,255,0.95)" }),
+        stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
+      }),
+    });
+    labelStyleCache.set(name, style);
+  }
+  return style;
+};
+
 const toTypesById = (types) => {
   const map = {};
   for (const t of types || []) map[t.id] = t;
@@ -178,22 +238,19 @@ const OlMap = ({
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,
-      style: (feature, resolution) => {
-        const zoom = getZoom(resolution);
-        if (zoom < LABEL_MIN_ZOOM) return null;
+      // Skip this whole layer below the zoom its labels appear at. The style
+      // function already returned null there — but OpenLayers has to CALL it to
+      // find that out, so a zoomed-out world paid 3,662 style calls plus a
+      // declutter pass every frame to draw nothing. minZoom makes the renderer
+      // skip the layer outright, and zoomed-out is exactly where the editor was
+      // slowest, because that is when every region is on screen at once.
+      minZoom: LABEL_MIN_ZOOM,
+      style: (feature) => {
         const type = typesByIdRef.current[feature.get("typeId") || "land"];
         if (type && type.includedInLabels === false) return null;
         const name = feature.get("name");
         if (!name) return null;
-        return new Style({
-          text: new Text({
-            text: name,
-            font: "600 12px sans-serif",
-            overflow: false,
-            fill: new Fill({ color: "rgba(255,255,255,0.95)" }),
-            stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
-          }),
-        });
+        return labelStyle(name);
       },
     });
     labelLayer.setZIndex(20);
@@ -202,15 +259,6 @@ const OlMap = ({
     // labels are gated by zoom + prominence so the whole set never renders at once
     // (capitals/large cities appear first; everything shows when zoomed in).
     const pointSource = new VectorSource();
-    const markerShape = (radius) =>
-      new RegularShape({
-        points: 4,
-        radius,
-        angle: Math.PI / 4,
-        fill: new Fill({ color: "#ffd54a" }),
-        stroke: new Stroke({ color: "#000", width: 1 }),
-      });
-    const SHAPES = { large: markerShape(6), mid: markerShape(4.5), small: markerShape(3.5) };
     const pointLayer = new VectorLayer({
       source: pointSource,
       declutter: true,
@@ -225,18 +273,7 @@ const OlMap = ({
         if (!(large || (mid && zoom >= 3.5) || zoom >= 5)) return null;
         const size = large ? "large" : mid ? "mid" : "small";
         const showLabel = zoom >= 6 || (large && zoom >= 4.3) || (mid && zoom >= 5.3);
-        return new Style({
-          image: SHAPES[size],
-          text: showLabel
-            ? new Text({
-                text: feature.get("name") || "",
-                font: "600 11px sans-serif",
-                offsetY: -11,
-                fill: new Fill({ color: "#fff" }),
-                stroke: new Stroke({ color: "rgba(0,0,0,0.85)", width: 3 }),
-              })
-            : undefined,
-        });
+        return cityStyle(size, showLabel ? feature.get("name") || "" : "");
       },
     });
     pointLayer.setZIndex(30);

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -216,11 +216,27 @@ const OlMap = ({
   };
 
   useEffect(() => {
-    const regionSource = new VectorSource();
+    // wrapX:false — the single biggest thing the editor was doing wrong.
+    //
+    // OpenLayers defaults it to true, and the canvas vector renderer then loops
+    // over world copies and redraws EVERY feature for each one
+    // (renderer/canvas/VectorLayer.js: `endWorld`, plus extendX_ adding another
+    // world on each side). So a zoomed-out world map painted all 3,662 regions
+    // two or three times per frame. It looks like broken culling — an endless
+    // horizontal band of map that never disappears — but it is the renderer
+    // deliberately repeating the world sideways. There is nothing to repeat
+    // vertically, which is why culling only ever LOOKED broken left-to-right.
+    //
+    // It is also what OL's own docs prescribe for this exact use case: "For
+    // vector editing across the -180° and 180° meridians to work properly, this
+    // should be set to false." So this is a correctness fix that happens to be
+    // the performance fix.
+    const regionSource = new VectorSource({ wrapX: false });
     const getZoom = (res) => mapRef.current?.getView().getZoomForResolution(res) ?? 3;
 
     const regionLayer = new VectorLayer({
       source: regionSource,
+      wrapX: false,
       style: makeRegionStyle({
         getTypesById: () => typesByIdRef.current,
         getColors: () => colorsRef.current,
@@ -235,6 +251,7 @@ const OlMap = ({
 
     const labelLayer = new VectorLayer({
       source: regionSource,
+      wrapX: false,
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,
@@ -258,9 +275,10 @@ const OlMap = ({
     // Point/symbol feature layer (cities). With ~70k cities available, dots and
     // labels are gated by zoom + prominence so the whole set never renders at once
     // (capitals/large cities appear first; everything shows when zoomed in).
-    const pointSource = new VectorSource();
+    const pointSource = new VectorSource({ wrapX: false });
     const pointLayer = new VectorLayer({
       source: pointSource,
+      wrapX: false,
       declutter: true,
       updateWhileInteracting: false,
       updateWhileAnimating: false,

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -711,16 +711,19 @@ const OlMap = ({
       },
       // Serialize all region geometry to a GeoJSON FeatureCollection (WGS84) for
       // saving/exporting; load one back into the source.
-      serializeRegions: () => {
-        const fmt = new GeoJSON();
-        return JSON.parse(
-          fmt.writeFeatures(regionSource.getFeatures(), {
-            dataProjection: "EPSG:4326",
-            featureProjection: "EPSG:3857",
-            decimals: 5,
-          }),
-        );
-      },
+      // writeFeaturesObject, NOT JSON.parse(writeFeatures(...)). OL's writeFeatures
+      // is literally JSON.stringify(writeFeaturesObject(...)) (format/JSONFeature.js),
+      // so parsing its result built an ~83MB string at z9 and immediately tore it
+      // back apart — to reach the object writeFeaturesObject already had. And this
+      // runs on the 2s autosave, so the editor did that on a loop while you worked;
+      // saveDocument then stringifies the payload anyway, making it string -> objects
+      // -> string. That churn is what ran the tab out of memory.
+      serializeRegions: () =>
+        new GeoJSON().writeFeaturesObject(regionSource.getFeatures(), {
+          dataProjection: "EPSG:4326",
+          featureProjection: "EPSG:3857",
+          decimals: 5,
+        }),
       loadRegions: (fc) => {
         const fmt = new GeoJSON();
         regionSource.clear();

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -839,8 +839,18 @@ const OlMap = ({
         // edge takes a bite; drawing over one entirely deletes it.
         const cutter = f.getGeometry();
         const carved = [];
-        for (const other of source.getFeatures()) {
-          if (other === f) continue;
+        // Ask the source's R-tree for the handful of regions whose extents meet the
+        // new one, rather than walking all 3,662 and running a full boolean op on
+        // each. overlaps() is polygon-clipping, which builds sweep-line structures
+        // per call — doing that against every region on the map allocated hard
+        // enough to run the tab out of memory once the seed went to z9 and each
+        // polygon carried ~1,116 vertices instead of ~156. The extent query is an
+        // index lookup and rejects everything that cannot possibly touch.
+        const candidates = [];
+        source.forEachFeatureIntersectingExtent(cutter.getExtent(), (other) => {
+          if (other !== f) candidates.push(other);
+        });
+        for (const other of candidates) {
           const geom = other.getGeometry();
           if (!geom || !overlaps(geom, cutter)) continue;
           const before = geom.clone();

--- a/src/Editor/regionImport.js
+++ b/src/Editor/regionImport.js
@@ -40,15 +40,26 @@ export const loadSeedFeatures = async ({ signal } = {}) => {
   }
   const fc = await res.json();
   const fmt = new GeoJSON();
-  const features = fmt.readFeatures(fc, {
-    dataProjection: "EPSG:4326",
-    featureProjection: "EPSG:3857",
-  });
-  for (const feature of features) {
+  const opts = { dataProjection: "EPSG:4326", featureProjection: "EPSG:3857" };
+
+  // One feature at a time, dropping each raw one as it is converted — NOT
+  // readFeatures(fc), which is the same work but holds two entire worlds in
+  // memory at once: the parsed GeoJSON (every coordinate its own [lon,lat] JS
+  // array) and OpenLayers' flat-coordinate copy of the same thing. At the seed's
+  // ~4M vertices that peak is what ran the editor out of memory. Releasing each
+  // raw feature here lets the parsed half be collected while the OL half is
+  // still being built, so the peak is roughly one copy instead of two.
+  const raw = fc.features || [];
+  fc.features = null; // the array is reachable via `raw` alone from here
+  const features = [];
+  for (let i = 0; i < raw.length; i += 1) {
+    const feature = fmt.readFeature(raw[i], opts);
+    raw[i] = null; // this one is converted; let it go now, not at the end
     const props = feature.getProperties();
     if (props.id != null) feature.setId(String(props.id));
     if (feature.get("owner") == null) feature.set("owner", props.gid0 || null);
     if (feature.get("typeId") == null) feature.set("typeId", "land");
+    features.push(feature);
   }
   return features;
 };

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,6 +760,7 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
+      {!customFlag && (
       <Source id="countries-source" type="vector" url={countriesUrl}>
         <Layer
           id="countries-fill"
@@ -774,7 +775,14 @@ const WorldMap = ({ isGlobe = false }) => {
           paint={countriesOutlinePaint}
         />
       </Source>
+      )}
 
+      {/* Not mounted at all on a custom map, rather than painted at zero alpha.
+          MapLibre's isHidden() only consults visibility:"none" — an opacity-0
+          layer still fetches, decodes and renders its tiles — so leaving these
+          mounted made every custom-map player stream the stock world's geometry
+          in order to draw none of it. */}
+      {!customFlag && (
       <Source id="regions-source" type="vector" url={regionsUrl}>
         <Layer
           id="regions-fill"
@@ -789,6 +797,7 @@ const WorldMap = ({ isGlobe = false }) => {
           paint={regionsOutlinePaint}
         />
       </Source>
+      )}
 
       {/* Author-DRAWN geometry only (splits/new regions) — GADM regions paint the
           stock tiles above for crisp borders at every zoom. Empty (and inert)

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -786,12 +786,16 @@ const WorldMap = ({ isGlobe = false }) => {
       </Source>
       )}
 
-      {/* Not mounted at all on a custom map, rather than painted at zero alpha.
-          MapLibre's isHidden() only consults visibility:"none" — an opacity-0
-          layer still fetches, decodes and renders its tiles — so leaving these
-          mounted made every custom-map player stream the stock world's geometry
-          in order to draw none of it. */}
-      {!customFlag && (
+      {/* Deliberately NOT gated on customFlag, unlike countries-source above —
+          this source is not decoration on a custom map, it IS the map. On a
+          re-ownership scenario (Modern Day, Rome, WWII: stock GADM geometry,
+          nothing hand-drawn) regions-fill is the ONLY thing painting owners
+          above z6.5, because custom-regions-fill-far stops at maxzoom 7 and
+          FAR_FILL_FADE has already faded it to 0 by 6.5 — the crossfade hands
+          off to these tiles by design. Unmounting it here left every such map
+          blank past 6.5 and, via the getLayer() filter at the click handler,
+          unclickable too. The hairlines are needed on stock maps as well:
+          regionsOutlinePaint is gated on worldKnown, not on customActive. */}
       <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={8}>
         <Layer
           id="regions-fill"
@@ -806,7 +810,6 @@ const WorldMap = ({ isGlobe = false }) => {
           paint={regionsOutlinePaint}
         />
       </Source>
-      )}
 
       {/* Author-DRAWN geometry only (splits/new regions) — GADM regions paint the
           stock tiles above for crisp borders at every zoom. Empty (and inert)

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,13 +760,16 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
-      {/* maxzoom 9, not the archive's 10: the map editor stitches its region seed
-          from these tiles at z9 (extract-regions.mjs — z10 cannot be stitched at
-          all, the result exceeds V8's 512MB max string length), so rendering the
-          game at z10 drew borders one level finer than any map anyone can author
-          against them. Capping here makes the two agree. Past z9 MapLibre
-          overzooms, exactly as it already did past z10. */}
-      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={9}>
+      {/* maxzoom 8, not the archive's 10, because 8 is what the editor can
+          actually author against. z10 cannot be stitched into a seed at all —
+          extract-regions.mjs completes and then dies in JSON.stringify, over V8's
+          512MB max string length. z9 stitches, but 4.1M vertices then ran the
+          editor's tab out of heap: Chrome killed the renderer with "Aw, Snap"
+          while the machine still had 3GB free, because the cap is per-renderer.
+          z8's 2.6M is stable. Rendering finer than the editor can edit only draws
+          detail no map can be built against. Past z8 MapLibre overzooms, exactly
+          as it already did past z10. */}
+      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={8}>
         <Layer
           id="countries-fill"
           type="fill"
@@ -781,7 +784,7 @@ const WorldMap = ({ isGlobe = false }) => {
         />
       </Source>
 
-      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={9}>
+      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={8}>
         <Layer
           id="regions-fill"
           type="fill"

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -760,7 +760,13 @@ const WorldMap = ({ isGlobe = false }) => {
 
   return (
     <>
-      <Source id="countries-source" type="vector" url={countriesUrl}>
+      {/* maxzoom 9, not the archive's 10: the map editor stitches its region seed
+          from these tiles at z9 (extract-regions.mjs — z10 cannot be stitched at
+          all, the result exceeds V8's 512MB max string length), so rendering the
+          game at z10 drew borders one level finer than any map anyone can author
+          against them. Capping here makes the two agree. Past z9 MapLibre
+          overzooms, exactly as it already did past z10. */}
+      <Source id="countries-source" type="vector" url={countriesUrl} maxzoom={9}>
         <Layer
           id="countries-fill"
           type="fill"
@@ -775,7 +781,7 @@ const WorldMap = ({ isGlobe = false }) => {
         />
       </Source>
 
-      <Source id="regions-source" type="vector" url={regionsUrl}>
+      <Source id="regions-source" type="vector" url={regionsUrl} maxzoom={9}>
         <Layer
           id="regions-fill"
           type="fill"

--- a/src/runtime/preload.js
+++ b/src/runtime/preload.js
@@ -79,26 +79,6 @@ const buildInitialViewportTextureUrls = (
   });
 };
 
-// A custom map draws its own geometry and NEVER draws the stock world's tiles —
-// Nations.jsx does not even mount those sources when world.customRegions is set.
-// Warming them anyway meant every custom-map player downloaded 161MB of
-// modern-day Earth to render none of it, which on the website is the single
-// longest thing between pressing play and seeing a map.
-//
-// Safe to read here: the "state" task above already warmed JSON_URLS.world and
-// runs before these, so this resolves from cache rather than adding a request.
-// Defaults to false — an unreadable world cannot be PROVEN custom, and warming
-// tiles we might not need is a slow start, while skipping tiles we do need is a
-// blank map.
-const worldIsCustom = async () => {
-  try {
-    const world = await readJson(JSON_URLS.world, { defaultValue: {} });
-    return Boolean(world?.customRegions);
-  } catch {
-    return false;
-  }
-};
-
 const STARTUP_TASKS = [
   {
     id: "state",
@@ -169,12 +149,14 @@ const STARTUP_TASKS = [
   },
   {
     id: "regions",
+    // Warmed on EVERY world, custom included — this archive is what paints
+    // owners above z6.5 on a re-ownership scenario (Nations.jsx: regions-fill
+    // fades in as the seed's far layer fades out), so a custom map needs it
+    // just as much as a stock one. Skipping it here was the mistake the note
+    // at the top of this file warns about: skipping tiles we DO need.
     label: "Caching regional borders",
     weight: 24,
-    run: async ({ signal }) => {
-      if (await worldIsCustom()) return;
-      await warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal });
-    },
+    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal }),
   },
 ];
 

--- a/src/runtime/preload.js
+++ b/src/runtime/preload.js
@@ -141,10 +141,13 @@ const STARTUP_TASKS = [
     id: "countries",
     label: "Caching country geometry",
     weight: 26,
-    run: async ({ signal }) => {
-      if (await worldIsCustom()) return;
-      await warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal });
-    },
+    // NOT skipped on a custom map, unlike regions below. countries.pmtiles is
+    // not only rendered: loadCountryNames reads its z0 tile for the country index
+    // (assets.js) and warmCountryLabelCollections reads it for the labels
+    // (countryLabels.js), and both run for every map. Skipping the warm would not
+    // avoid the download — it would just make those tasks fetch the whole archive
+    // lazily, later, and serially. Strictly worse than warming it here.
+    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal }),
   },
   {
     id: "country-index",

--- a/src/runtime/preload.js
+++ b/src/runtime/preload.js
@@ -79,6 +79,26 @@ const buildInitialViewportTextureUrls = (
   });
 };
 
+// A custom map draws its own geometry and NEVER draws the stock world's tiles —
+// Nations.jsx does not even mount those sources when world.customRegions is set.
+// Warming them anyway meant every custom-map player downloaded 161MB of
+// modern-day Earth to render none of it, which on the website is the single
+// longest thing between pressing play and seeing a map.
+//
+// Safe to read here: the "state" task above already warmed JSON_URLS.world and
+// runs before these, so this resolves from cache rather than adding a request.
+// Defaults to false — an unreadable world cannot be PROVEN custom, and warming
+// tiles we might not need is a slow start, while skipping tiles we do need is a
+// blank map.
+const worldIsCustom = async () => {
+  try {
+    const world = await readJson(JSON_URLS.world, { defaultValue: {} });
+    return Boolean(world?.customRegions);
+  } catch {
+    return false;
+  }
+};
+
 const STARTUP_TASKS = [
   {
     id: "state",
@@ -121,7 +141,10 @@ const STARTUP_TASKS = [
     id: "countries",
     label: "Caching country geometry",
     weight: 26,
-    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal }),
+    run: async ({ signal }) => {
+      if (await worldIsCustom()) return;
+      await warmPmtilesArchive(PMTILES_ARCHIVES.countries, { signal });
+    },
   },
   {
     id: "country-index",
@@ -145,7 +168,10 @@ const STARTUP_TASKS = [
     id: "regions",
     label: "Caching regional borders",
     weight: 24,
-    run: ({ signal }) => warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal }),
+    run: async ({ signal }) => {
+      if (await worldIsCustom()) return;
+      await warmPmtilesArchive(PMTILES_ARCHIVES.regions, { signal });
+    },
   },
 ];
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,15 +17,30 @@ import path from 'node:path'
 // are gitignored and arrive from the map-data Release at first launch, so CI and a
 // fresh clone build fine and the deploy failure looks random. Dropping them after
 // the copy is the fix; "remember to delete them before deploying" is not.
-const MAP_BINARIES = [
+// Never wanted in EITHER build: nothing loads a pmtiles archive from the bundle.
+// The desktop streams them off disk via /api/runtime/pmtiles/:assetKey and the
+// website fetches them from the content nodes, hash-verified. Copying them in only
+// broke the Pages deploy at its 25 MiB-per-file limit.
+const PMTILES = [
   'assets/regions.pmtiles',
   'assets/countries.pmtiles',
   'assets/cities.pmtiles',
+]
+
+// Wanted by the DESKTOP, fatal to the WEBSITE. The map editor loads these, and the
+// desktop server serves exactly one directory (`app.use(express.static(distDir))`)
+// — so dropping them there makes /assets/regions-seed.geojson fall through to the
+// SPA fallback, answer with index.html, and the editor open with zero regions.
+//
+// The web build resolves them from VITE_OH_PMTILES_URL instead (see
+// regionImport.js), so it never reads them from the bundle — and it must not carry
+// them: regions-seed.geojson is 52.8MB at z8 and Pages rejects any file over 25MiB.
+const EDITOR_SEEDS = [
   'assets/regions-seed.geojson',
   'assets/cities-seed.json',
 ]
 
-const dropMapBinaries = () => {
+const dropMapBinaries = (isWeb) => {
   // Take outDir from the resolved config rather than assuming: --outDir varies
   // (dist for the desktop, dist-web for build:web/build:site).
   let outDir = 'dist'
@@ -36,7 +51,7 @@ const dropMapBinaries = () => {
       outDir = config.build.outDir
     },
     closeBundle() {
-      for (const rel of MAP_BINARIES) {
+      for (const rel of isWeb ? [...PMTILES, ...EDITOR_SEEDS] : PMTILES) {
         const target = path.resolve(outDir, rel)
         if (fs.existsSync(target)) fs.rmSync(target)
       }
@@ -65,7 +80,7 @@ export default defineConfig(({ mode }) => ({
         plugins: [['babel-plugin-react-compiler']],
       },
     }),
-    dropMapBinaries(),
+    dropMapBinaries(mode === 'web'),
   ],
   // Proxy API calls to the Express server during `npm run dev` so the map editor's
   // save/load (and the game's runtime endpoints) work with hot-reload too.


### PR DESCRIPTION
Replaces #274, #275, #277, #280, #281, #282 — the same six changes, as one PR per channel. They were split while each was being diagnosed separately; they turned out to be one story, and reviewing them apart means reviewing the same files six times.

## The story

The map editor was laggy, then it started crashing. Chasing that surfaced a resolution problem underneath it, and four bugs that had been there all along — cheap at the old resolution, fatal at the new one.

**The lag was `wrapX`.** OpenLayers defaults it to `true`, so the renderer loops world copies and redraws every feature per copy. That's why culling appeared to work vertically but not horizontally — the credit for spotting that is entirely the report, not the debugger. `wrapX: false` on both sources and all three layers, plus a `VectorImageLayer` for regions so pans re-blit a raster instead of re-drawing 3,662 polygons. Draw/Modify/Snap bind to the *source*, so the tools keep full-resolution geometry — the raster is only how it's painted. INP went from ~1,900ms to smooth.

**The crash was not system memory.** It happened with ~3GB free, *after* the spike subsided. "Aw, Snap" means Chrome killed the renderer, and V8 caps the heap **per renderer** (~4GB here, confirmed at runtime) no matter what the machine has. So the fix had to be peak reduction inside that budget; free RAM was never going to be spent.

Three things were burning that budget:

- **Autosave built an 83MB string every 2 seconds.** `JSON.parse(fmt.writeFeatures(...))` — and OL's `writeFeatures` *is* `JSON.stringify(writeFeaturesObject(...))` ([JSONFeature.js:168](https://github.com/openlayers/openlayers/blob/main/src/ol/format/JSONFeature.js)). It serialised the whole world to text and immediately parsed it back. Calling `writeFeaturesObject` directly: **+461MB → +0MB**.
- **Drawing ran a sweep-line intersection against all 3,662 regions.** The source already has an R-tree; querying it first takes a sample from 400 boolean ops to 0.
- **Loading the seed held the parsed JSON and the built features at once.** Now incremental, releasing each raw feature as it's read: 617MB → 476MB peak.

**And the map itself was stale.** The shipped default scenario sets `customRegions: true`, so players render the GeoJSON and never touch the pmtiles — and that GeoJSON was built from the **z5** seed, at 156 vertices per region. The pmtiles it was hiding go to z10. This is the actual "map looks outdated" bug: the good geometry was there and nothing was reading it.

## Why z8 and not higher

Measured, not chosen:

| | vertices | result |
|---|---|---|
| z5 (shipped) | 570k | what players actually had |
| z8 | **2.6M** | **stable** |
| z9 | 4.1M | editor tab OOMs — "Aw, Snap" |
| z10 | — | seed can't be built at all |

z10 isn't a performance question. `extract-regions.mjs` finishes the work and then dies in `JSON.stringify`, over V8's 512MB max string length — the string can't exist. z9 builds, but 4.1M vertices leave the editor no headroom under the renderer cap.

**z8 is the finest resolution the editor can actually hold**, so it's the finest the game should draw: rendering detail past what any map can be authored against is detail nobody can edit. The game's stock sources are capped `maxzoom={8}` to match; past that MapLibre overzooms, exactly as it already did past z10.

Everything downstream is regenerated at z8 — seed, default map, and all six community bundles.

## Also here

**Custom maps stopped streaming 101MB they never draw.** The stock layers were hidden with `fill-opacity: 0`, but MapLibre's `isHidden()` only consults `visibility: "none"` — a zero-alpha layer still fetches, decodes and renders its tiles. They're now not mounted at all. The countries source stays: `loadCountryNames` and the label collections read it on every map, so skipping its warm doesn't save the download, it just moves it somewhere slower. (I had that wrong at first and it made loading *worse*.)

**The desktop build stopped shipping an editor with zero regions.** The Vite plugin that drops the map binaries — added so Cloudflare Pages would stop rejecting the site at its 25MiB-per-file limit — also dropped `regions-seed.geojson`, which the editor loads and the desktop server serves from exactly one directory. So the request fell through to the SPA fallback, returned `index.html`, and the editor parsed HTML as GeoJSON. The plugin is now mode-aware: the website drops the seeds (it fetches them from the content nodes, hash-verified), the desktop keeps them.

## Risk

The one thing worth watching: the game still renders the default map with `tolerance={0}` at every zoom. That comment says it's safe because "the seed geometry is coarse enough" — an assumption written for 570k vertices and now carrying 2.6M. It can't be fixed by simply raising `tolerance`: geojson-vt simplifies each ring independently, so shared borders drift apart and countries show **sliver gaps**. The real fix is a far source simplified offline with shared topology (TopoJSON's arcs can't drift). Not in this PR — flagging it rather than shipping a half-version that reintroduces the gaps.

## Verified

- Editor loads all 3,662 regions at z8 and reports "All saved"
- `/assets/regions-seed.geojson` serves `application/geo+json`, not the SPA fallback
- All six community bundles re-uploaded and confirmed downloadable, z8 geometry inside (705 verts/region)
- Every asset hash re-verified by deleting the local copy and re-fetching
