### PR TITLE
Faction creator + landless play, and mobile-fit the editor [alpha]

### DIFF
--- a/src/Editor/DocumentsMenu.jsx
+++ b/src/Editor/DocumentsMenu.jsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import Icon from "./Icon.jsx";
 import { panelSurface } from "./editorStyles.js";
 import { listDocuments, deleteDocument } from "./documentIO.js";
+import { useIsMobile } from "../runtime/useIsMobile.js";
 
 const menuItem = {
   display: "flex",
@@ -29,6 +30,10 @@ const menuItem = {
 const DocumentsMenu = ({ docName, currentId, author, onAuthorChange, onNew, onSave, onExport, onExportGame, onOpen }) => {
   const [open, setOpen] = useState(false);
   const [docs, setDocs] = useState([]);
+  // On a phone the three top bars (this one, the centred toolbar, the top-right
+  // action buttons) fight for the same row. Collapse to just the icon so this one
+  // stays narrow and clear of the toolbar.
+  const isMobile = useIsMobile();
 
   const refresh = async () => setDocs(await listDocuments());
   const toggle = async () => {
@@ -42,20 +47,26 @@ const DocumentsMenu = ({ docName, currentId, author, onAuthorChange, onNew, onSa
     <div style={{ position: "fixed", top: 12, left: 12, zIndex: 36 }}>
       <button
         onClick={toggle}
+        title={isMobile ? (docName || "Untitled Map") : undefined}
         style={{
           ...panelSurface,
           display: "flex",
           alignItems: "center",
-          gap: 8,
-          padding: "7px 12px",
-          fontSize: 13,
+          gap: isMobile ? 0 : 8,
+          padding: isMobile ? "8px 10px" : "7px 12px",
+          fontSize: isMobile ? 16 : 13,
           fontWeight: 700,
           cursor: "pointer",
           color: "white",
         }}
       >
-        🗺️ <span style={{ maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{docName || "Untitled Map"}</span>
-        <Icon name="plus" size={12} style={{ transform: "rotate(45deg)", opacity: 0.5 }} />
+        🗺️
+        {!isMobile && (
+          <>
+            <span style={{ maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{docName || "Untitled Map"}</span>
+            <Icon name="plus" size={12} style={{ transform: "rotate(45deg)", opacity: 0.5 }} />
+          </>
+        )}
       </button>
 
       {open && (

--- a/src/Editor/FlagPicker.jsx
+++ b/src/Editor/FlagPicker.jsx
@@ -21,6 +21,7 @@ import {
 } from "../runtime/communityFlags.js";
 import { FLAG_ACCEPT, fileToFlagDataUrl } from "./flagImage.js";
 import { listFlags, saveFlag, deleteFlag } from "../runtime/flagLibrary.js";
+import { useIsMobile } from "../runtime/useIsMobile.js";
 
 const overlay = {
   position: "fixed",
@@ -167,6 +168,7 @@ const FlagCard = ({ title, subtitle, imageUrl, active, onClick, onPublish, onDel
 const grid = { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(8rem, 1fr))", gap: "0.7rem" };
 
 const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, author = "", onPick }) => {
+  const isMobile = useIsMobile();
   const [tab, setTab] = useState("mine"); // mine | community
   const [query, setQuery] = useState("");
   const [error, setError] = useState("");
@@ -262,8 +264,12 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
   return (
     <div style={overlay} onClick={onClose}>
       <div style={panel} onClick={(e) => e.stopPropagation()}>
-        <div style={headerBar}>
-          <div style={{ fontSize: "1.05rem", fontWeight: 800, marginRight: "0.4rem" }}>
+        {/* Wraps to a second row rather than overflowing off-screen when it can't
+            fit — which is what a phone does with the title, both tabs, the search,
+            Upload and the close button all on one line. On mobile the search grows
+            to fill its row and Upload drops its label to an icon. */}
+        <div style={{ ...headerBar, flexWrap: "wrap", gap: isMobile ? "0.4rem" : "0.6rem" }}>
+          <div style={{ fontSize: isMobile ? "0.95rem" : "1.05rem", fontWeight: 800, marginRight: "0.4rem" }}>
             Flags{ownerCode ? ` — ${ownerCode}` : ""}
           </div>
           <button type="button" style={tabBtn(tab === "mine")} onClick={() => setTab("mine")}>In the game</button>
@@ -274,12 +280,15 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
             placeholder="Search…"
             style={{
               background: "rgba(0,0,0,0.3)", border: "1px solid rgba(255,255,255,0.14)",
-              borderRadius: 8, color: "#fff", fontSize: "0.8rem", padding: "0.35rem 0.6rem", width: "9rem",
+              borderRadius: 8, color: "#fff", fontSize: "0.8rem", padding: "0.35rem 0.6rem",
+              width: isMobile ? "auto" : "9rem", flex: isMobile ? "1 1 6rem" : "0 0 auto", minWidth: "5rem",
             }}
           />
-          <div style={{ flex: 1 }} />
-          <label style={uploadBtn}>
-            ⬆ Upload your own
+          {/* The flex spacer that right-aligns Upload only helps when everything is
+              on one row; on mobile it would eat a whole wrapped line, so drop it. */}
+          {!isMobile && <div style={{ flex: 1 }} />}
+          <label style={uploadBtn} title="Upload your own">
+            {isMobile ? "⬆" : "⬆ Upload your own"}
             <input
               type="file"
               accept={FLAG_ACCEPT}
@@ -289,10 +298,10 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
           </label>
           {currentFlag && (
             <button type="button" style={closeBtn} title="Use the standard flag again" onClick={() => pick(null)}>
-              Remove
+              {isMobile ? "↺" : "Remove"}
             </button>
           )}
-          <button type="button" style={closeBtn} onClick={onClose}>✕</button>
+          <button type="button" style={{ ...closeBtn, marginLeft: isMobile ? "auto" : undefined }} onClick={onClose}>✕</button>
         </div>
 
         <div style={bodyBox}>

--- a/src/Editor/MapEditor.jsx
+++ b/src/Editor/MapEditor.jsx
@@ -29,6 +29,7 @@ import { loadBackgroundFile, rebuildPersistedBackground, vectorLayerToGeoJSON } 
 import { addBackgroundToLibrary, getBasemapPayload } from "../runtime/basemapLibrary.js";
 import { saveDocument, loadDocument, downloadJson } from "./documentIO.js";
 import { migrateDocumentOwners, OWNER_SCHEMA } from "./documentMigration.js";
+import { useIsMobile } from "../runtime/useIsMobile.js";
 import { buildGameSeed } from "./exportPreset.js";
 import { panelSurface, inputStyle } from "./editorStyles.js";
 import FmgPanel from "./fmg/FmgPanel.jsx";
@@ -37,6 +38,7 @@ import { fmgToEditorSeed } from "./fmg/fmgImport.js";
 
 const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}) => {
   const d = useMapDocument();
+  const isMobile = useIsMobile();
   // Opened from a scenario: the scenario's own map (regions/cities/colors) is
   // loaded once it arrives, so never auto-seed the default world underneath it.
   const scenarioMode = Boolean(onApplyToScenario);
@@ -465,7 +467,10 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
       />
 
       {(onClose || onApplyToScenario) && (
-        <div style={{ position: "fixed", top: 12, right: 12, zIndex: 40, display: "flex", gap: 8 }}>
+        // On a phone the buttons stack vertically (Apply above Close) and drop their
+        // labels, so the block is one icon wide and does not overlap the centred
+        // toolbar. On desktop it stays a labelled horizontal row.
+        <div style={{ position: "fixed", top: 12, right: 12, zIndex: 40, display: "flex", flexDirection: isMobile ? "column" : "row", gap: 8 }}>
           {onApplyToScenario && (
             <button
               onClick={applyToScenario}
@@ -473,20 +478,21 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
               title={`Save this map into ${scenarioName || "the scenario"} and start playing it`}
               style={{
                 ...panelSurface,
-                padding: "8px 15px",
+                padding: isMobile ? "9px 11px" : "8px 15px",
                 cursor: applying ? "default" : "pointer",
                 color: "white",
                 fontWeight: 700,
-                fontSize: 13,
+                fontSize: isMobile ? 16 : 13,
                 display: "flex",
                 alignItems: "center",
-                gap: 6,
+                justifyContent: "center",
+                gap: isMobile ? 0 : 6,
                 background: applying ? "rgba(59,130,246,0.35)" : "rgba(59,130,246,0.85)",
                 border: "1px solid rgba(147,197,253,0.5)",
                 opacity: applying ? 0.8 : 1,
               }}
             >
-              {applying ? "Applying…" : "▶ Apply & Play"}
+              {isMobile ? (applying ? "…" : "▶") : (applying ? "Applying…" : "▶ Apply & Play")}
             </button>
           )}
           {onClose && (
@@ -509,17 +515,18 @@ const MapEditor = ({ onClose, scenarioName, onApplyToScenario, initialMap } = {}
               title="Close map editor"
               style={{
                 ...panelSurface,
-                padding: "8px 13px",
+                padding: isMobile ? "9px 11px" : "8px 13px",
                 cursor: "pointer",
                 color: "white",
                 fontWeight: 700,
-                fontSize: 13,
+                fontSize: isMobile ? 16 : 13,
                 display: "flex",
                 alignItems: "center",
-                gap: 6,
+                justifyContent: "center",
+                gap: isMobile ? 0 : 6,
               }}
             >
-              ✕ Close
+              {isMobile ? "✕" : "✕ Close"}
             </button>
           )}
         </div>

--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -206,18 +206,40 @@ export const buildUnitsSummaryText = (world) => {
 
 const loadRegions = async () => loadRegionCatalog().catch(() => []);
 
+// The land the player's polity holds — or an explicit statement that it holds none.
+// A landless player is a deliberate scenario, not missing data (a government in
+// exile, a stateless movement leading a campaign to take a nation back), so it must
+// read to the model as an intentional condition rather than an empty field, or the
+// model tries to run a normal territorial power and invents holdings.
+const LANDLESS_PLAYER_TEXT =
+  "This polity is LANDLESS — it currently holds no territory. It is a stateless "
+  + "actor (a government-in-exile, a movement, or a power that has lost its land), "
+  + "and its story is about influence, alliances, insurgency, and the fight to gain "
+  + "or retake territory — not about administering provinces it does not have.";
+
 export const buildPlayerPolityRegionsText = async (bundle, regionCatalog = null) => {
   const playerCode = normalizeString(bundle.game.country);
   if (!playerCode) return "No player polity is currently set.";
-  const entries = Object.entries(normalizeWorldState(bundle.world).regionOwnershipOverrides);
-  if (entries.length === 0) return "No explicit player region override list is currently recorded.";
+  const world = normalizeWorldState(bundle.world);
+  const entries = Object.entries(world.regionOwnershipOverrides);
+  const owns = entries.some(([, ownerCode]) => normalizeString(ownerCode).toLowerCase() === playerCode.toLowerCase());
+  // Zero regions AND the polity exists = deliberately landless. Distinguish that
+  // from a scenario that simply ships no override list (a stock modern map, where
+  // the player owns their country through the base tiles, not an override).
+  if (!owns) {
+    const isKnownPolity = Boolean(normalizeWorldState(bundle.world).polityOverrides?.[playerCode]);
+    if (entries.length === 0 && !isKnownPolity) {
+      return "No explicit player region override list is currently recorded.";
+    }
+    return LANDLESS_PLAYER_TEXT;
+  }
   const regions = regionCatalog ?? await loadRegions();
   const lookup = new Map(regions.map((region) => [region.id, region]));
   const names = entries
     .filter(([, ownerCode]) => normalizeString(ownerCode).toLowerCase() === playerCode.toLowerCase())
     .slice(0, 24)
     .map(([regionId]) => lookup.get(regionId)?.name || regionId);
-  return names.length > 0 ? names.join(", ") : "No explicit player region override list is currently recorded.";
+  return names.join(", ");
 };
 
 export const buildWorldSummary = async (bundle, regionCatalog = null) => {
@@ -235,7 +257,10 @@ export const buildWorldSummary = async (bundle, regionCatalog = null) => {
   const politySummary = polities.length === 0
     ? "No dynamic polity overrides are currently recorded."
     : polities.slice(0, 16).map((entry) =>
-      `- ${entry.code}: ${entry.name || entry.code}${entry.color ? ` (${entry.color})` : ""}${entry.aliases.length > 0 ? ` aliases ${entry.aliases.join(", ")}` : ""}`,
+      // `note` is the polity's lore — the author's (or the faction creator's) own
+      // description of who this power is. It was persisted but never reached the
+      // model, so a player-written backstory did nothing. It steers the story now.
+      `- ${entry.code}: ${entry.name || entry.code}${entry.color ? ` (${entry.color})` : ""}${entry.aliases.length > 0 ? ` aliases ${entry.aliases.join(", ")}` : ""}${entry.note ? ` — ${entry.note}` : ""}`,
     ).join("\n");
 
   // What each country IS: the map-maker's tags with the AI's own changes layered

--- a/src/Game/GameUI/CountryPickerMap.jsx
+++ b/src/Game/GameUI/CountryPickerMap.jsx
@@ -21,6 +21,15 @@ const codeToColor = (code) => {
   return `hsl(${hue}, 52%, 42%)`;
 };
 
+// "#rrggbb" + alpha -> an rgba() OL accepts. The faction's chosen colour is a hex
+// string; region fills need it translucent so the dark basemap reads through.
+const withAlpha = (hex, alpha) => {
+  const m = /^#?([0-9a-f]{6})$/i.exec(String(hex || "").trim());
+  if (!m) return `rgba(124,58,237,${alpha})`;
+  const n = parseInt(m[1], 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+};
+
 const parseGeoJSONFeatures = (geojson) => {
   const fmt = new GeoJSON();
   const features = fmt.readFeatures(geojson, {
@@ -36,13 +45,43 @@ const parseGeoJSONFeatures = (geojson) => {
   return features;
 };
 
-const CountryPickerMap = ({ countryOptions, onPickCountry, regionsGeojson }) => {
+const CountryPickerMap = ({
+  countryOptions,
+  onPickCountry,
+  regionsGeojson,
+  // "country" (default): click a whole country to pick it — the new-game selector.
+  // "regions": click regions to toggle them in/out of a selection — the faction
+  // creator picking its starting territory. selectedRegionIds + onToggleRegion +
+  // selectionColor drive it. Kept as one component so both share the OL map, the
+  // seed load and the hover machinery.
+  selectionMode = "country",
+  selectedRegionIds = null,
+  onToggleRegion = null,
+  selectionColor = "#7c3aed",
+}) => {
   const containerRef = useRef(null);
   const layerRef = useRef(null);
   const sourceRef = useRef(null);
   const hoveredCodeRef = useRef(null);
+  const hoveredRegionRef = useRef(null);
   const playableCodesRef = useRef(new Set());
   const [query, setQuery] = useState("");
+
+  // Refs the once-created map's handlers read at click time — so switching mode or
+  // toggling a region never rebuilds the map.
+  const modeRef = useRef(selectionMode);
+  modeRef.current = selectionMode;
+  const onToggleRegionRef = useRef(onToggleRegion);
+  onToggleRegionRef.current = onToggleRegion;
+  const selectedRegionsRef = useRef(new Set());
+  const selectionColorRef = useRef(selectionColor);
+  selectionColorRef.current = selectionColor;
+  useEffect(() => {
+    selectedRegionsRef.current = selectedRegionIds instanceof Set
+      ? selectedRegionIds
+      : new Set(selectedRegionIds || []);
+    if (layerRef.current) layerRef.current.changed();
+  }, [selectedRegionIds]);
 
   playableCodesRef.current = useMemo(
     () => new Set(countryOptions.map((c) => c.code)),
@@ -83,7 +122,27 @@ const CountryPickerMap = ({ countryOptions, onPickCountry, regionsGeojson }) => 
       }),
     });
 
+    const regionIdOf = (feature) =>
+      (feature.getId?.() ?? feature.get("id") ?? feature.get("GID_1") ?? null);
+
     const styleFn = (feature) => {
+      if (modeRef.current === "regions") {
+        const id = regionIdOf(feature);
+        const isSelected = id != null && selectedRegionsRef.current.has(String(id));
+        const isHovered = id != null && String(id) === hoveredRegionRef.current;
+        return new Style({
+          fill: new Fill({
+            color: isSelected
+              ? withAlpha(selectionColorRef.current, 0.6)
+              : isHovered ? "rgba(124,58,237,0.28)" : "rgba(60,65,80,0.3)",
+          }),
+          stroke: new Stroke({
+            color: isSelected ? withAlpha(selectionColorRef.current, 0.95) : "rgba(150,155,170,0.4)",
+            width: isSelected ? 1.6 : isHovered ? 1.4 : 0.6,
+          }),
+        });
+      }
+
       const code = feature.get("owner") || feature.get("gid0");
       const isPlayable = code && playableCodesRef.current.has(code);
       const isHovered = code === hoveredCodeRef.current;
@@ -118,11 +177,15 @@ const CountryPickerMap = ({ countryOptions, onPickCountry, regionsGeojson }) => 
         (f) => f,
         { hitTolerance: 5 },
       );
-      if (hit) {
-        const code = hit.get("owner") || hit.get("gid0");
-        if (code && playableCodesRef.current.has(code)) {
-          onPickCountry(code);
-        }
+      if (!hit) return;
+      if (modeRef.current === "regions") {
+        const id = regionIdOf(hit);
+        if (id != null && onToggleRegionRef.current) onToggleRegionRef.current(String(id));
+        return;
+      }
+      const code = hit.get("owner") || hit.get("gid0");
+      if (code && playableCodesRef.current.has(code)) {
+        onPickCountry(code);
       }
     });
 
@@ -132,6 +195,16 @@ const CountryPickerMap = ({ countryOptions, onPickCountry, regionsGeojson }) => 
         (f) => f,
         { hitTolerance: 5 },
       );
+      if (modeRef.current === "regions") {
+        const id = hit ? regionIdOf(hit) : null;
+        olMap.getTargetElement().style.cursor = id != null ? "pointer" : "";
+        const key = id != null ? String(id) : null;
+        if (hoveredRegionRef.current !== key) {
+          hoveredRegionRef.current = key;
+          layer.changed();
+        }
+        return;
+      }
       const code = hit ? hit.get("owner") || hit.get("gid0") : null;
       const isClickable = code && playableCodesRef.current.has(code);
       olMap.getTargetElement().style.cursor = isClickable ? "pointer" : "";
@@ -171,30 +244,40 @@ const CountryPickerMap = ({ countryOptions, onPickCountry, regionsGeojson }) => 
       .catch(() => {});
   }, [!!regionsGeojson]);
 
-  // Re-style when countryOptions change
+  // Re-style when the playable set OR the selection mode changes (the style fn
+  // reads modeRef, so the layer must be told to repaint when the mode flips).
   useEffect(() => {
     const source = sourceRef.current;
     if (source) source.changed();
-  }, [countryOptions]);
+  }, [countryOptions, selectionMode, selectionColor]);
+
+  const regionMode = selectionMode === "regions";
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-      <input
-        autoFocus
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search countries…"
-        style={{
-          padding: "0.55rem 0.7rem",
-          borderRadius: 8,
-          border: "1px solid rgba(255,255,255,0.16)",
-          background: "rgba(0,0,0,0.28)",
-          color: "#fff",
-          outline: "none",
-          fontFamily: "sans-serif",
-          fontSize: "0.85rem",
-        }}
-      />
+      {regionMode ? (
+        <div style={{ color: "rgba(255,255,255,0.6)", fontSize: "0.78rem" }}>
+          Click regions on the map to claim them as your faction's starting
+          territory. Click again to release one.
+        </div>
+      ) : (
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search countries…"
+          style={{
+            padding: "0.55rem 0.7rem",
+            borderRadius: 8,
+            border: "1px solid rgba(255,255,255,0.16)",
+            background: "rgba(0,0,0,0.28)",
+            color: "#fff",
+            outline: "none",
+            fontFamily: "sans-serif",
+            fontSize: "0.85rem",
+          }}
+        />
+      )}
       <div
         ref={containerRef}
         style={{
@@ -208,7 +291,7 @@ const CountryPickerMap = ({ countryOptions, onPickCountry, regionsGeojson }) => 
       />
       <div
         style={{
-          display: "flex",
+          display: regionMode ? "none" : "flex",
           flexDirection: "column",
           gap: 2,
           maxHeight: query.trim() ? 180 : 120,

--- a/src/Game/GameUI/FactionCreator.jsx
+++ b/src/Game/GameUI/FactionCreator.jsx
@@ -7,6 +7,7 @@
 // game's world.json, colors.json and flags.json.
 
 import { lazy, Suspense, useState } from "react";
+import { createPortal } from "react-dom";
 import CountryPickerMap from "./CountryPickerMap.jsx";
 
 // The editor's flag picker drops in unchanged — it is prop-driven and pulls in no
@@ -173,16 +174,27 @@ const FactionCreator = ({ regionsGeojson, onCreate, onCancel, busy }) => {
         <button type="button" onClick={onCancel} style={{ ...pill(false), padding: "0.55rem 1rem" }}>Cancel</button>
       </div>
 
-      {flagOpen && (
+      {/* Portalled to <body>, exactly as the editor mounts it outside its own
+          backdrop-filtered panel. Two things trap it otherwise: the new-game modal
+          card has backdrop-filter, which makes a containing block for position:fixed
+          — so the picker's full-screen overlay resolves to the card's box, not the
+          viewport, and its top is cut off (its own comment documents this). And the
+          picker's overlay is z-index 130 while the modal is 10060, so even freed it
+          would sit behind. The portal escapes the containing block; the wrapper's
+          stacking context (above the modal) lifts it in front. */}
+      {flagOpen && createPortal(
         <Suspense fallback={null}>
-          <FlagPicker
-            open
-            onClose={() => setFlagOpen(false)}
-            ownerCode={trimmedName}
-            currentFlag={flag}
-            onPick={(picked) => setFlag(picked || null)}
-          />
-        </Suspense>
+          <div style={{ position: "relative", zIndex: 10070 }}>
+            <FlagPicker
+              open
+              onClose={() => setFlagOpen(false)}
+              ownerCode={trimmedName}
+              currentFlag={flag}
+              onPick={(picked) => setFlag(picked || null)}
+            />
+          </div>
+        </Suspense>,
+        document.body,
       )}
     </div>
   );

--- a/src/Game/GameUI/FactionCreator.jsx
+++ b/src/Game/GameUI/FactionCreator.jsx
@@ -1,0 +1,191 @@
+/*! Open Historia — new-game faction creator © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// The "Create faction" tab of the new-game country picker. Lets a player invent
+// the power they want to lead — name, flag, colour, lore — and either claim a set
+// of starting regions or begin LANDLESS (a government-in-exile, a movement with no
+// territory yet). It collects the choice and hands one object to onCreate; the
+// parent (libraryBar) owns persistence, because a faction is written across the
+// game's world.json, colors.json and flags.json.
+
+import { lazy, Suspense, useState } from "react";
+import CountryPickerMap from "./CountryPickerMap.jsx";
+
+// The editor's flag picker drops in unchanged — it is prop-driven and pulls in no
+// editor stores. It returns a flag STRING (a flagcdn URL or a PNG data URL) or
+// null via onPick.
+const FlagPicker = lazy(() => import("../../Editor/FlagPicker.jsx"));
+
+const label = { color: "rgba(255,255,255,0.7)", fontSize: "0.78rem", fontWeight: 700, margin: "0.1rem 0 0.3rem" };
+const field = {
+  background: "rgba(0,0,0,0.28)",
+  border: "1px solid rgba(255,255,255,0.16)",
+  borderRadius: 8,
+  color: "#fff",
+  fontFamily: "sans-serif",
+  fontSize: "0.85rem",
+  outline: "none",
+  padding: "0.55rem 0.7rem",
+  width: "100%",
+  boxSizing: "border-box",
+};
+const pill = (active) => ({
+  background: active ? "rgba(124,58,237,0.28)" : "rgba(255,255,255,0.06)",
+  border: `1px solid ${active ? "rgba(124,58,237,0.7)" : "rgba(255,255,255,0.1)"}`,
+  borderRadius: 999,
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: "0.8rem",
+  fontWeight: 700,
+  padding: "0.35rem 0.85rem",
+});
+
+const FactionCreator = ({ regionsGeojson, onCreate, onCancel, busy }) => {
+  const [name, setName] = useState("");
+  const [color, setColor] = useState("#7c3aed");
+  const [flag, setFlag] = useState(null); // string (URL / data URL) or null
+  const [lore, setLore] = useState("");
+  const [landless, setLandless] = useState(true);
+  const [regionIds, setRegionIds] = useState(() => new Set());
+  const [flagOpen, setFlagOpen] = useState(false);
+
+  const toggleRegion = (id) => {
+    setRegionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const trimmedName = name.trim();
+  const canCreate = trimmedName.length > 0 && !busy;
+
+  const submit = () => {
+    if (!canCreate) return;
+    onCreate({
+      name: trimmedName,
+      color,
+      flag: flag || null,
+      lore: lore.trim(),
+      // Landless is the explicit toggle. Even with the "claim territory" mode open,
+      // a faction that selected nothing starts landless — the toggle just makes that
+      // a deliberate, visible choice rather than an accident.
+      regionIds: landless ? [] : [...regionIds],
+    });
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.6rem" }}>
+      <div>
+        <div style={label}>Name</div>
+        <input
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Free Cascadia, the Provisional Government…"
+          style={field}
+        />
+      </div>
+
+      <div style={{ display: "flex", gap: "0.8rem", alignItems: "flex-end" }}>
+        <div>
+          <div style={label}>Colour</div>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            style={{ width: 48, height: 34, background: "none", border: "1px solid rgba(255,255,255,0.16)", borderRadius: 8, cursor: "pointer" }}
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={label}>Flag</div>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            {flag ? (
+              <img src={flag} alt="" style={{ width: 34, height: 22, objectFit: "contain", borderRadius: 3, border: "1px solid rgba(255,255,255,0.25)" }} />
+            ) : (
+              <span aria-hidden="true" style={{ fontSize: "1.4rem" }}>🏳️</span>
+            )}
+            <button type="button" onClick={() => setFlagOpen(true)} style={pill(false)}>
+              {flag ? "Change flag" : "Choose flag"}
+            </button>
+            {flag && (
+              <button type="button" onClick={() => setFlag(null)} style={pill(false)}>Remove</button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div style={label}>Lore</div>
+        <textarea
+          value={lore}
+          onChange={(e) => setLore(e.target.value)}
+          placeholder="Who is this power? Its history, cause, and ambitions. This steers the story the AI tells."
+          rows={3}
+          style={{ ...field, resize: "vertical", minHeight: "3.4rem" }}
+        />
+      </div>
+
+      <div>
+        <div style={label}>Starting territory</div>
+        <div style={{ display: "flex", gap: "0.4rem", marginBottom: "0.4rem" }}>
+          <button type="button" onClick={() => setLandless(true)} style={pill(landless)}>Start landless</button>
+          <button type="button" onClick={() => setLandless(false)} style={pill(!landless)}>Claim regions</button>
+        </div>
+        {landless ? (
+          <div style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.76rem" }}>
+            You begin with no territory — a stateless power. Your campaign is to gain
+            or retake land.
+          </div>
+        ) : (
+          <>
+            <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.76rem", marginBottom: "0.3rem" }}>
+              {regionIds.size} region{regionIds.size === 1 ? "" : "s"} claimed
+            </div>
+            <Suspense fallback={<div style={{ color: "rgba(255,255,255,0.5)", padding: "2rem 0", textAlign: "center" }}>Loading map…</div>}>
+              <CountryPickerMap
+                countryOptions={[]}
+                onPickCountry={() => {}}
+                regionsGeojson={regionsGeojson}
+                selectionMode="regions"
+                selectedRegionIds={regionIds}
+                onToggleRegion={toggleRegion}
+                selectionColor={color}
+              />
+            </Suspense>
+          </>
+        )}
+      </div>
+
+      <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.2rem" }}>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canCreate}
+          style={{
+            ...pill(true),
+            flex: 1,
+            opacity: canCreate ? 1 : 0.5,
+            cursor: canCreate ? "pointer" : "not-allowed",
+            padding: "0.55rem",
+          }}
+        >
+          {busy ? "Creating…" : "Create & play"}
+        </button>
+        <button type="button" onClick={onCancel} style={{ ...pill(false), padding: "0.55rem 1rem" }}>Cancel</button>
+      </div>
+
+      {flagOpen && (
+        <Suspense fallback={null}>
+          <FlagPicker
+            open
+            onClose={() => setFlagOpen(false)}
+            ownerCode={trimmedName}
+            currentFlag={flag}
+            onPick={(picked) => setFlag(picked || null)}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+};
+
+export default FactionCreator;

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -1040,11 +1040,18 @@ const LibraryTopBar = () => {
         name: (polityName && polityName !== code ? polityName : null) || scenarioName || fallbackName,
       };
     };
-    const options = !ownerCodes || !ownerCodes.length
-      ? list.map((entry) => resolveOption(entry.code, entry.name))
-      : ownerCodes
-        .filter((code) => !TECHNICAL_OWNER_CODES.has(code))
-        .map((code) => resolveOption(code, nameByCode.get(code) || code));
+    // ownerCodes lists only owners that hold territory (it is the deduped values of
+    // regionOwnershipOverrides). A LANDLESS faction — a polity that owns no regions,
+    // e.g. a government-in-exile — is defined in polityOverrides but appears in no
+    // ownership override, so it would never reach this list. Union the two: a
+    // faction is playable if it holds land OR exists as a polity. The map surface
+    // needs no change — a landless faction has nothing to click, and the list
+    // button is selection enough.
+    const codes = new Set(ownerCodes && ownerCodes.length ? ownerCodes : list.map((e) => e.code));
+    for (const code of Object.keys(polity)) codes.add(code);
+    const options = [...codes]
+      .filter((code) => !TECHNICAL_OWNER_CODES.has(code))
+      .map((code) => resolveOption(code, nameByCode.get(code) || code));
     return options
       .sort((left, right) => left.name.localeCompare(right.name));
   };

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -27,7 +27,8 @@ import {
   uploadScenarioAsset,
   useLibraryState,
 } from "../../runtime/library.js";
-import { loadCountryNames } from "../../runtime/assets.js";
+import { loadCountryNames, readJson, writeJson, JSON_URLS } from "../../runtime/assets.js";
+import FactionCreator from "./FactionCreator.jsx";
 import { UNIT_TYPES } from "../../runtime/gameState.js";
 import { useIsMobile } from "../../runtime/useIsMobile.js";
 import { DIFFICULTY_LEVELS } from "../../runtime/difficulty.js";
@@ -51,6 +52,16 @@ const CommunityPanel = lazy(() => import("./communityHub.jsx"));
 const CountryPickerMap = lazy(() => import("./CountryPickerMap.jsx"));
 
 const BAR_HEIGHT = 64;
+
+// "#rrggbb" -> [r,g,b], the shape colors.json stores. Faults to a neutral grey
+// rather than throwing, so a bad colour never blocks creating the faction.
+const hexToRgbArray = (hex) => {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(String(hex || "").trim());
+  if (!m) return [128, 128, 128];
+  const n = parseInt(m[1], 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+};
+
 const TECHNICAL_OWNER_CODES = new Set([
   "NA",
   "XCA",
@@ -1015,6 +1026,74 @@ const LibraryTopBar = () => {
     }
   };
 
+  // Create a game led by a player-invented faction. It is written into the game's
+  // OWN world/colors/flags — a game carries its own copies and falls back to the
+  // scenario only for what it doesn't set, so the scenario is never touched.
+  const startGameForFaction = async (scenario, faction, difficulty) => {
+    setCountryPicker(null);
+    setCustomRegionData(null);
+    setEditorError(null);
+    setIsBusy(true);
+    try {
+      const details = await createGame({
+        name: `${faction.name} — ${scenario.name}`,
+        scenarioId: scenario.id,
+        setActive: true,
+      });
+      const gameId = details.game.id;
+
+      // Read the game's world, which createGame seeded from the scenario, and merge
+      // the faction into its existing maps. This read-merge-write is load-bearing:
+      // saveGame writes `world` whole (a worldPatch would SHALLOW-merge, replacing
+      // polityOverrides/ownerCodes/regionOwnershipOverrides outright and wiping
+      // every other country on the map).
+      const gameDetails = await loadGameDetails(gameId).catch(() => null);
+      const world = { ...(gameDetails?.data?.world ?? {}) };
+      const name = faction.name;
+      const hexColor = /^#[0-9a-fA-F]{6}$/.test(faction.color) ? faction.color : "#7c3aed";
+
+      world.polityOverrides = {
+        ...(world.polityOverrides ?? {}),
+        [name]: { name, aliases: [], color: hexColor, note: faction.lore || "" },
+      };
+      world.regionOwnershipOverrides = { ...(world.regionOwnershipOverrides ?? {}) };
+      for (const regionId of faction.regionIds ?? []) {
+        world.regionOwnershipOverrides[regionId] = name;
+      }
+      // ownerCodes lists who is playable — include the faction even when landless.
+      world.ownerCodes = [...new Set([...(world.ownerCodes ?? []), name])].sort();
+      // A faction that claimed drawn/overridden territory needs the custom-region
+      // renderer on so its regions paint; a landless faction leaves the flag as-is.
+      if ((faction.regionIds ?? []).length) world.customRegions = true;
+
+      await saveGame(gameId, { world, gamePatch: { country: name, ...(difficulty ? { difficulty } : null) } });
+
+      // Colour and flag live in their own runtime assets. createGame set this game
+      // active, so JSON_URLS.colors/flags now resolve to it — and reading them gives
+      // the EFFECTIVE asset (the scenario's, since a fresh game has none of its own).
+      // Read-merge-write materialises that whole palette into the game with the
+      // faction added; writing only the faction would shadow the scenario file and
+      // leave every other country uncoloured. This is the "Add Country" cheat's path.
+      try {
+        const colors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
+        await writeJson(JSON_URLS.colors, { ...colors, [name]: hexToRgbArray(hexColor) }, { pretty: true });
+      } catch { /* colours are cosmetic — a landless faction paints nothing anyway */ }
+
+      if (faction.flag) {
+        try {
+          const flags = await readJson(JSON_URLS.flags, { defaultValue: {}, force: true });
+          await writeJson(JSON_URLS.flags, { ...flags, [name]: faction.flag }, { pretty: true });
+        } catch { /* flag is cosmetic */ }
+      }
+
+      await openGameEditor(gameId);
+    } catch (nextError) {
+      setEditorError(nextError.message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
   // Build the start-country list for a scenario: only the factions that actually
   // exist in it (world.ownerCodes), named as era polities where defined. Falls
   // back to every country for scenarios without an owner list.
@@ -1065,6 +1144,7 @@ const LibraryTopBar = () => {
     setCountryOptions([]);
     setCustomRegionData(null);
     setPlayGameId(null);
+    setPickerTab("country");
     setCountryPicker(scenario);
     Promise.all([loadCountryNames().catch(() => []), loadScenarioDetails(scenario.id).catch(() => null)])
       .then(([allCountries, details]) => {
@@ -1410,6 +1490,8 @@ const LibraryTopBar = () => {
   const [countryOptions, setCountryOptions] = useState([]);
   const [customRegionData, setCustomRegionData] = useState(null);
   const [countryQuery, setCountryQuery] = useState("");
+  // Which tab of the new-game dialog: pick an existing country, or invent one.
+  const [pickerTab, setPickerTab] = useState("country"); // "country" | "faction"
   // When set, the country picker refines the country of this already-active game
   // (the Apply-&-Play flow) instead of creating a brand new game.
   const [playGameId, setPlayGameId] = useState(null);
@@ -1587,10 +1669,18 @@ const LibraryTopBar = () => {
   // Picking a country moves to step two (difficulty); picking a difficulty
   // actually creates/updates the game.
   const pickCountry = (countryCode) => setDifficultyPick({ countryCode });
+  // A created faction routes through the SAME difficulty step as a picked country —
+  // it just carries a faction draft instead of a country code.
+  const pickFaction = (faction) => setDifficultyPick({ faction });
 
   const pickDifficulty = (difficultyId) => {
-    const countryCode = difficultyPick?.countryCode || "";
+    const draft = difficultyPick;
     setDifficultyPick(null);
+    if (draft?.faction) {
+      startGameForFaction(countryPicker, draft.faction, difficultyId);
+      return;
+    }
+    const countryCode = draft?.countryCode || "";
     if (playGameId) {
       choosePlayCountry(countryCode, difficultyId);
     } else {
@@ -1786,33 +1876,79 @@ const LibraryTopBar = () => {
               </>
             ) : (
               <>
-                <div style={{ fontWeight: 800, fontSize: "1rem" }}>Choose your country</div>
-                <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.75rem", margin: "0.15rem 0 0.7rem" }}>
+                <div style={{ fontWeight: 800, fontSize: "1rem" }}>
+                  {pickerTab === "faction" ? "Create your faction" : "Choose your country"}
+                </div>
+                <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.75rem", margin: "0.15rem 0 0.6rem" }}>
                   Starting “{countryPicker.name}”
                 </div>
-                <button
-                  type="button"
-                  onClick={() => pickCountry("")}
-                  style={{ ...actionButtonStyle, justifyContent: "flex-start", background: "rgba(124,58,237,0.18)", marginBottom: "0.4rem" }}
-                >
-                  {playGameId ? "Keep scenario default" : "Scenario default"}
-                </button>
-                <Suspense
-                  fallback={
-                    <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.85rem", padding: "3rem 0", textAlign: "center" }}>
-                      Loading map…
-                    </div>
-                  }
-                >
-                  <CountryPickerMap
-                    countryOptions={countryOptions}
+                {/* Refining an existing game (Apply-&-Play) only swaps the country;
+                    inventing a faction is a fresh-game concern, so the tabs show
+                    only for a true new game. */}
+                {!playGameId && (
+                  <div style={{ display: "flex", gap: "0.4rem", marginBottom: "0.7rem" }}>
+                    <button
+                      type="button"
+                      onClick={() => setPickerTab("country")}
+                      style={{
+                        ...actionButtonStyle,
+                        flex: 1,
+                        fontWeight: 700,
+                        background: pickerTab === "country" ? "rgba(124,58,237,0.28)" : "rgba(255,255,255,0.05)",
+                        borderColor: pickerTab === "country" ? "rgba(124,58,237,0.7)" : undefined,
+                      }}
+                    >
+                      Pick a country
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPickerTab("faction")}
+                      style={{
+                        ...actionButtonStyle,
+                        flex: 1,
+                        fontWeight: 700,
+                        background: pickerTab === "faction" ? "rgba(124,58,237,0.28)" : "rgba(255,255,255,0.05)",
+                        borderColor: pickerTab === "faction" ? "rgba(124,58,237,0.7)" : undefined,
+                      }}
+                    >
+                      Create a faction
+                    </button>
+                  </div>
+                )}
+                {pickerTab === "faction" && !playGameId ? (
+                  <FactionCreator
                     regionsGeojson={customRegionData}
-                    onPickCountry={(code) => pickCountry(code)}
+                    busy={isBusy}
+                    onCreate={(faction) => pickFaction(faction)}
+                    onCancel={() => { setCountryPicker(null); setPickerTab("country"); setCustomRegionData(null); }}
                   />
-                </Suspense>
-                <button type="button" onClick={() => { setCountryPicker(null); setPlayGameId(null); setCustomRegionData(null); }} style={{ ...actionButtonStyle, marginTop: "0.6rem" }}>
-                  {playGameId ? "Done" : "Cancel"}
-                </button>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => pickCountry("")}
+                      style={{ ...actionButtonStyle, justifyContent: "flex-start", background: "rgba(124,58,237,0.18)", marginBottom: "0.4rem" }}
+                    >
+                      {playGameId ? "Keep scenario default" : "Scenario default"}
+                    </button>
+                    <Suspense
+                      fallback={
+                        <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.85rem", padding: "3rem 0", textAlign: "center" }}>
+                          Loading map…
+                        </div>
+                      }
+                    >
+                      <CountryPickerMap
+                        countryOptions={countryOptions}
+                        regionsGeojson={customRegionData}
+                        onPickCountry={(code) => pickCountry(code)}
+                      />
+                    </Suspense>
+                    <button type="button" onClick={() => { setCountryPicker(null); setPlayGameId(null); setCustomRegionData(null); }} style={{ ...actionButtonStyle, marginTop: "0.6rem" }}>
+                      {playGameId ? "Done" : "Cancel"}
+                    </button>
+                  </>
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
Two things: you can now play as a nation or organization that owns **no territory**, and you can **invent the country you lead** when starting a game.

## Landless play

Lead a government-in-exile, or a stateless movement fighting to take a country back. The engine already tolerated it — there's no defeat or elimination check anywhere, and units, stats, diplomacy, reputation and the map all key by country name, not by owned land. Two gaps closed:

- **Selectable.** The picker listed only countries that hold territory (`ownerCodes` is the deduped values of `regionOwnershipOverrides`), so a landless faction defined only as a polity never appeared. It now unions that with the `polityOverrides` keys — playable if it holds land *or* exists as a polity.
- **The AI is told.** A player who owns zero regions but is a known polity now gets an explicit "this polity is LANDLESS" framing, distinct from a stock map where the player owns their country through the base tiles. And `promptContext` now feeds each polity's `note` to the model — the lore field was persisted but never read, so a written backstory did nothing.

## Faction creator

A "Create a faction" tab beside the country picker when starting a new game. Name it, pick its flag (the editor's flag picker, which drops into the game UI unchanged), pick a colour, write lore that steers the AI story, and either claim starting regions on the map or begin landless.

`CountryPickerMap` gained a `"regions"` multi-select mode for the region picking (default `"country"` unchanged). A new `FactionCreator` component collects the choice; the faction routes through the same difficulty step and the same game-open finish as a picked country.

**The load-bearing detail** is that creating a faction *read-merge-writes* the game's world rather than patching it. `saveGame` writes `world` whole and a `worldPatch` shallow-merges — so sending just the faction would **replace** `polityOverrides`/`ownerCodes`/`regionOwnershipOverrides` and wipe every other country. Same for the colour: it reads the effective palette (the scenario's, since a fresh game has none) and merges, or it would shadow the scenario's `colors.json` and leave every other country uncoloured. This is the path the in-game "Add Country" cheat already uses. It writes into the game's own copies, so the scenario is never touched.

Verified headlessly against the real modules: creating a faction preserves every other country's polity, ownership and colour; a landless faction is playable but owns nothing; a claiming faction takes territory without disturbing others; the merged palette keeps all scenario colours.

## Flag picker fix

The flag picker rendered wrong when opened from the faction creator — clipped to a small box inside the new-game modal instead of covering the screen. The modal card's `backdrop-filter` makes a containing block that traps the picker's `position: fixed` overlay (its own comment documents this trap; it's why the editor mounts it outside its backdrop-filtered panel), and its z-index (130) sits below the modal (10060). Fixed by portalling to `document.body` inside a stacking context above the modal — the pattern `CountryPanel` already uses here. Verified with a DOM probe: mounted in the card the overlay measures 672×135 and doesn't cover the viewport; portalled it measures the full 737×677 and renders on top.

## Mobile layout

The map editor's three top bars overlapped on a phone, and the flag picker's header ran off-screen. On mobile (≤700px) now: the file menu collapses to its 🗺️ icon; Apply & Play / Close stack vertically (Apply above Close) as icons (▶ / ✕); the flag picker header wraps instead of overflowing. All behind `useIsMobile` — desktop is untouched. Verified in the running editor at 375px (header `scrollWidth === clientWidth`, no overflow) and the buttons stacked/icon-only via a measured harness.

## Editor files

`FlagPicker.jsx`, `DocumentsMenu.jsx` and `MapEditor.jsx` are shared with the standalone editor and are mirrored there in a companion PR.
