### PR TITLE
Community scenarios: fix web import, always-zip sharing, tag-field click-out

### DIFF
--- a/src/Editor/fields.jsx
+++ b/src/Editor/fields.jsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // Small form-field building blocks + color helpers for the editor panels.
 
@@ -119,22 +119,55 @@ export const SelectField = ({ value, onChange, options, width }) => (
 // open (alt-history can't be enumerated), so `suggestions` only feeds a datalist —
 // it steers spelling toward one form without ever rejecting a new tag.
 //
-// Commit on Enter/comma/blur; Backspace on an empty box removes the last chip.
-// The comma split is what makes pasting "socialist, authoritarian, anti-nato"
-// work, which is how anyone with a list in hand will actually enter these.
+// Commit on Enter/comma/blur, on a click anywhere outside the field, or when the
+// field unmounts; Backspace on an empty box removes the last chip. The comma split
+// is what makes pasting "socialist, authoritarian, anti-nato" work, which is how
+// anyone with a list in hand will actually enter these.
 export const TagField = ({ value, onChange, suggestions = [], placeholder = "add a tag…" }) => {
   const [draft, setDraft] = useState("");
   const tags = Array.isArray(value) ? value : [];
   const listId = "oh-tag-suggestions";
+  const wrapRef = useRef(null);
+  const inputRef = useRef(null);
 
   const commit = (raw) => {
     const parts = String(raw).split(",").map((t) => t.trim()).filter(Boolean);
-    if (parts.length) onChange([...tags, ...parts]);
     setDraft("");
+    // Clear the DOM value too, not just React state: a click-out commits here, but
+    // a blur can still fire later in the same gesture — reading an already-empty
+    // box stops it re-adding the tag before React has re-rendered the input.
+    if (inputRef.current) inputRef.current.value = "";
+    if (parts.length) onChange([...tags, ...parts]);
   };
+  // The listeners below are bound once; route through a ref so they always see the
+  // latest tags (a stale closure would drop tags added earlier this session).
+  const commitRef = useRef(commit);
+  commitRef.current = commit;
+
+  // Commit a half-typed tag on a pointer-down ANYWHERE outside the field — the map
+  // included — and when the field unmounts (e.g. you click another region). Without
+  // this you had to press Enter: the editor map is an OpenLayers canvas that calls
+  // preventDefault on pointerdown, which cancels this input's blur, so onBlur alone
+  // never fired and the tag was silently lost. A capture-phase listener runs first,
+  // before that preventDefault.
+  useEffect(() => {
+    const onPointerDown = (e) => {
+      const input = inputRef.current;
+      const wrap = wrapRef.current;
+      if (input && wrap && input.value.trim() && !wrap.contains(e.target)) {
+        commitRef.current(input.value);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      // Flush a pending tag on unmount so switching regions mid-type never drops it.
+      if (inputRef.current?.value.trim()) commitRef.current(inputRef.current.value);
+    };
+  }, []);
 
   return (
-    <span style={{ display: "flex", flexDirection: "column", gap: 4, width: "100%" }}>
+    <span ref={wrapRef} style={{ display: "flex", flexDirection: "column", gap: 4, width: "100%" }}>
       {tags.length > 0 && (
         <span style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
           {tags.map((tag) => (
@@ -162,6 +195,7 @@ export const TagField = ({ value, onChange, suggestions = [], placeholder = "add
         </span>
       )}
       <input
+        ref={inputRef}
         value={draft}
         list={listId}
         placeholder={placeholder}
@@ -175,7 +209,10 @@ export const TagField = ({ value, onChange, suggestions = [], placeholder = "add
           if (e.key === "Enter") { e.preventDefault(); commit(draft); }
           else if (e.key === "Backspace" && !draft && tags.length) onChange(tags.slice(0, -1));
         }}
-        onBlur={() => draft.trim() && commit(draft)}
+        // Read the live value, not the `draft` closure: keeps blur and the
+        // click-out path from disagreeing, and both are deduped by commit()
+        // clearing the box.
+        onBlur={(e) => { if (e.target.value.trim()) commit(e.target.value); }}
         style={{ ...inputStyle, width: "100%", padding: "5px 7px" }}
       />
       <datalist id={listId}>

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -173,9 +173,6 @@ const saveBlobToDisk = (blob, fileName) => {
   URL.revokeObjectURL(url);
 };
 
-const saveJsonToDisk = (data, fileName) =>
-  saveBlobToDisk(new Blob([JSON.stringify(data, null, 2)], { type: "application/json" }), fileName);
-
 const cardSurface = {
   background: "rgba(255,255,255,0.04)",
   border: "1px solid rgba(255,255,255,0.09)",
@@ -558,28 +555,32 @@ const CommunityPanel = ({ onImported }) => {
       // If this scenario's custom basemap is already on the community hub,
       // reference it instead of re-embedding the whole image (smaller bundle).
       const dedup = await dedupeScenarioBundleBackground(bundle).catch(() => ({ referenced: false, needsPublish: false }));
-      // A not-yet-shared custom image basemap ships bundled as ONE .zip
-      // (scenario.json + the raw basemap image + a preview) so the author drags a
-      // single file and the image travels as real bytes, not a bloated data URL.
       const split = dedup.referenced ? null : await splitScenarioBundleImage(bundle).catch(() => null);
-      let fileName;
+      // ALWAYS ship a .zip. GitHub issue attachments reject a bare .json, so a
+      // scenario with no splittable image — e.g. a geometry-only preset like WWII,
+      // whose custom borders live in an embedded regions.geojson, not a basemap —
+      // could never actually be dragged into the post: the download looked fine, but
+      // the share was impossible. Wrapping scenario.json in a zip makes EVERY scenario
+      // attachable. A custom image basemap still rides alongside as a real file
+      // (scenario.json + basemap + preview) when there is one, instead of bloating the
+      // JSON as a base64 data URL.
+      const files = {};
       let extra;
       if (split) {
         delete bundle.assets.backgroundData; // the image now rides in the zip as a real file
-        const files = { "scenario.json": JSON.stringify(bundle), [split.imageName]: split.imageBytes };
+        files[split.imageName] = split.imageBytes;
         if (split.previewBytes) files[split.previewName] = split.previewBytes;
-        fileName = `${scenario.id}-scenario.zip`;
-        saveBlobToDisk(await zipBundle(files), fileName);
         extra =
           " Its custom basemap is bundled inside the .zip, so the scenario is self-contained — just drag the one file." +
           " (To also list the basemap on its own in the community Basemaps tab, open the editor's Basemap picker and hit ⤴ on it.)";
       } else {
-        fileName = `${scenario.id}-scenario.json`;
-        saveJsonToDisk(bundle, fileName);
         extra = dedup.referenced
           ? " Its custom basemap was reused from the community hub, so the file stays small."
           : "";
       }
+      files["scenario.json"] = JSON.stringify(bundle);
+      const fileName = `${scenario.id}-scenario.zip`;
+      saveBlobToDisk(await zipBundle(files), fileName);
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
       // dedupe it against dedicated posts. Harmless if the scenario form has no such

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -34,6 +34,12 @@ import { useIsMobile } from "../../runtime/useIsMobile.js";
 import { DIFFICULTY_LEVELS } from "../../runtime/difficulty.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagEmojiFromGid } from "../../runtime/countryFlags.js";
+import {
+  splitScenarioBundleImage,
+  embedScenarioBundleImage,
+  embedScenarioBundleVector,
+} from "../../runtime/communityBasemaps.js";
+import { zipBundle, unzipBundle, looksLikeZip } from "../../runtime/bundleZip.js";
 
 const UNIT_TYPE_LABELS = {
   infantry: "Infantry",
@@ -223,8 +229,7 @@ const buildGameEditorState = (details) => {
   };
 };
 
-const saveJsonBundleToDisk = (bundle, fileName) => {
-  const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: "application/json" });
+const saveBlobToDisk = (blob, fileName) => {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
@@ -233,6 +238,10 @@ const saveJsonBundleToDisk = (bundle, fileName) => {
   anchor.click();
   anchor.remove();
   URL.revokeObjectURL(url);
+};
+
+const saveJsonBundleToDisk = (bundle, fileName) => {
+  saveBlobToDisk(new Blob([JSON.stringify(bundle, null, 2)], { type: "application/json" }), fileName);
 };
 
 const AssetBadgeRow = ({ badges }) =>
@@ -872,10 +881,13 @@ const EditorDrawer = ({
       {editorSection === "bundles" && kind === "scenario" && (
         <div style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "18px", marginBottom: "0.95rem", padding: "0.9rem" }}>
           <div style={{ color: "rgba(255,255,255,0.58)", fontSize: "0.82rem", lineHeight: 1.5, marginBottom: "0.85rem" }}>
-            Download the scenario as one self-contained JSON file — any custom map geometry, cities and basemap travel inside it, so it's ready to share or re-import.
+            Download the scenario as one self-contained file — custom map geometry, cities and basemap all travel with it, ready to share or re-import. The <strong>.zip</strong> carries a custom basemap as a real image file (smaller, and the form the community hub expects); the <strong>JSON</strong> packs everything into one text file.
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.55rem" }}>
-            <button onClick={() => onExportBundle("light")} style={actionButtonStyle} type="button">
+            <button onClick={() => onExportBundle("light", "zip")} style={actionButtonStyle} type="button">
+              Download .zip
+            </button>
+            <button onClick={() => onExportBundle("light", "json")} style={actionButtonStyle} type="button">
               Download JSON
             </button>
           </div>
@@ -1403,7 +1415,7 @@ const LibraryTopBar = () => {
     }
   };
 
-  const handleExportBundle = async (mode) => {
+  const handleExportBundle = async (mode, format = "json") => {
     if (editorKind !== "scenario" || !editorDetails) {
       return;
     }
@@ -1412,8 +1424,26 @@ const LibraryTopBar = () => {
     setIsBusy(true);
 
     try {
-      const bundle = await exportScenarioBundle(editorDetails.scenario.id, mode);
-      saveJsonBundleToDisk(bundle, `${editorDetails.scenario.id}-${mode}.json`);
+      const id = editorDetails.scenario.id;
+      const bundle = await exportScenarioBundle(id, mode);
+      if (format === "zip") {
+        // Package the scenario as a real .zip. When it carries a custom basemap, that
+        // image/geojson rides inside as an actual file (+ a small preview) instead of a
+        // base64 data URL bloating the JSON — the same self-contained form the community
+        // hub shares. With no custom basemap there's nothing to split out, so the zip
+        // just holds scenario.json (still a valid, self-contained bundle).
+        const split = await splitScenarioBundleImage(bundle).catch(() => null);
+        const files = { "scenario.json": JSON.stringify(bundle) };
+        if (split) {
+          delete bundle.assets.backgroundData; // the basemap now travels as a real file
+          files["scenario.json"] = JSON.stringify(bundle);
+          files[split.imageName] = split.imageBytes;
+          if (split.previewBytes) files[split.previewName] = split.previewBytes;
+        }
+        saveBlobToDisk(await zipBundle(files), `${id}-scenario.zip`);
+      } else {
+        saveJsonBundleToDisk(bundle, `${id}-${mode}.json`);
+      }
     } catch (nextError) {
       setEditorError(nextError.message);
     } finally {
@@ -1433,8 +1463,27 @@ const LibraryTopBar = () => {
     setIsBusy(true);
 
     try {
-      const text = await file.text();
-      const bundle = JSON.parse(text);
+      // A scenario exported with a custom basemap arrives as a .zip (scenario.json +
+      // the raw basemap file); everything else is a plain JSON bundle. Detect the zip
+      // by its magic bytes so a renamed file still works, then re-embed the basemap so
+      // the importer sees a normal self-contained bundle.
+      const buffer = await file.arrayBuffer();
+      let bundle;
+      if (looksLikeZip(new Uint8Array(buffer))) {
+        const zip = await unzipBundle(buffer);
+        const scenarioText = await zip.text("scenario.json");
+        if (!scenarioText) throw new Error("That .zip is missing scenario.json.");
+        bundle = JSON.parse(scenarioText);
+        const imageName = zip.names().find((n) => /(^|\/)basemap\.(png|jpe?g|webp|gif|svg)$/i.test(n));
+        if (imageName) {
+          embedScenarioBundleImage(bundle, await zip.bytes(imageName), imageName);
+        } else {
+          const vectorName = zip.names().find((n) => /(^|\/)basemap\.geojson$/i.test(n));
+          if (vectorName) embedScenarioBundleVector(bundle, await zip.bytes(vectorName));
+        }
+      } else {
+        bundle = JSON.parse(new TextDecoder().decode(buffer));
+      }
       const details = await importScenarioBundle(bundle);
       setActiveTab("scenarios");
       setIsPanelOpen(true);
@@ -1957,7 +2006,7 @@ const LibraryTopBar = () => {
 
       <input
         ref={importScenarioInputRef}
-        accept=".json,application/json"
+        accept=".json,application/json,.zip,application/zip"
         onChange={handleImportScenarioFile}
         style={{ display: "none" }}
         type="file"

--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -873,10 +873,20 @@ const importScenarioBundle = async (bundle) => {
     if (key === COVER_IMAGE_ASSET_KEY) {
       if (embedded && descriptor.data) await uploadScenarioAsset(newId, key, base64ToBytes(descriptor.data), descriptor.contentType);
       else await removeScenarioAsset(newId, key);
-    } else if (key === "colors") {
-      if (embedded && descriptor.data !== undefined) { const r = await getScenario(newId); r.colors = descriptor.data; writeScenarioMeta(r, {}); await putScenario(r); }
-      else await removeScenarioAsset(newId, key);
-    } else if (embedded && descriptor.data) {
+    } else if (OPTIONAL_JSON_ASSET_KEYS.includes(key)) {
+      // colors / flags / tags are JSON descriptor assets: `descriptor.data` is the
+      // object itself, NOT base64. Store it verbatim on the record. Passing it to
+      // base64ToBytes (as the binary branch below does) makes atob throw
+      // "string to be decoded is not correctly encoded" — which made EVERY scenario
+      // carrying tags or flags (e.g. the WWII preset) fail to import on the web build.
+      const r = await getScenario(newId);
+      if (embedded && descriptor.data !== undefined) r[key] = descriptor.data;
+      else delete r[key];
+      writeScenarioMeta(r, {});
+      await putScenario(r);
+    } else if (embedded && typeof descriptor.data === "string") {
+      // geojson / pmtiles: base64-encoded binary. The typeof guard keeps any stray
+      // non-string payload from reaching atob and crashing the whole import.
       await uploadScenarioAsset(newId, key, base64ToBytes(descriptor.data), descriptor.contentType);
     } else {
       await removeScenarioAsset(newId, key);


### PR DESCRIPTION
Three fixes, all verified. Applies cleanly on all channels (they're byte-identical).

**Web scenario import was crashing** (`atob … not correctly encoded`) on any scenario carrying author-set country **tags** or **flags** — e.g. the WWII preset. The web importer only special-cased the `colors` JSON asset; `tags`/`flags` fell through to base64-decode. Now every `OPTIONAL_JSON_ASSET_KEY` is stored as JSON, with a guard so a non-string payload can't reach `atob`. This also unblocks the self-hosted **install counter** for user-attachment scenarios (import-log only fires after a successful import). *Web-only; the desktop/server importer already handled these.* Verified by building the web bundle and re-importing the real 16.7 MB issue-#11 WWII bundle → succeeds with the full 12.6 MB geometry.

**Publish/share as .zip** — publishing now always produces a `.zip` (scenario.json + a custom image basemap as a real file when present) instead of a bare `.json`; smaller and self-contained. The library's **Bundles** tab gains a *Download .zip*, and its importer now accepts a `.zip` (magic-byte detected) as well as JSON.

**Editor tag field** — commits a half-typed country tag when you click anywhere outside the box (the OpenLayers map `preventDefault`s pointerdown, cancelling the input's blur, so only Enter worked before).