### PR TITLE
Community scenarios: web-import fix, .zip sharing, tag click-out, accurate cached install counts

### DIFF
--- a/src/Editor/fields.jsx
+++ b/src/Editor/fields.jsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // Small form-field building blocks + color helpers for the editor panels.
 
@@ -119,22 +119,55 @@ export const SelectField = ({ value, onChange, options, width }) => (
 // open (alt-history can't be enumerated), so `suggestions` only feeds a datalist —
 // it steers spelling toward one form without ever rejecting a new tag.
 //
-// Commit on Enter/comma/blur; Backspace on an empty box removes the last chip.
-// The comma split is what makes pasting "socialist, authoritarian, anti-nato"
-// work, which is how anyone with a list in hand will actually enter these.
+// Commit on Enter/comma/blur, on a click anywhere outside the field, or when the
+// field unmounts; Backspace on an empty box removes the last chip. The comma split
+// is what makes pasting "socialist, authoritarian, anti-nato" work, which is how
+// anyone with a list in hand will actually enter these.
 export const TagField = ({ value, onChange, suggestions = [], placeholder = "add a tag…" }) => {
   const [draft, setDraft] = useState("");
   const tags = Array.isArray(value) ? value : [];
   const listId = "oh-tag-suggestions";
+  const wrapRef = useRef(null);
+  const inputRef = useRef(null);
 
   const commit = (raw) => {
     const parts = String(raw).split(",").map((t) => t.trim()).filter(Boolean);
-    if (parts.length) onChange([...tags, ...parts]);
     setDraft("");
+    // Clear the DOM value too, not just React state: a click-out commits here, but
+    // a blur can still fire later in the same gesture — reading an already-empty
+    // box stops it re-adding the tag before React has re-rendered the input.
+    if (inputRef.current) inputRef.current.value = "";
+    if (parts.length) onChange([...tags, ...parts]);
   };
+  // The listeners below are bound once; route through a ref so they always see the
+  // latest tags (a stale closure would drop tags added earlier this session).
+  const commitRef = useRef(commit);
+  commitRef.current = commit;
+
+  // Commit a half-typed tag on a pointer-down ANYWHERE outside the field — the map
+  // included — and when the field unmounts (e.g. you click another region). Without
+  // this you had to press Enter: the editor map is an OpenLayers canvas that calls
+  // preventDefault on pointerdown, which cancels this input's blur, so onBlur alone
+  // never fired and the tag was silently lost. A capture-phase listener runs first,
+  // before that preventDefault.
+  useEffect(() => {
+    const onPointerDown = (e) => {
+      const input = inputRef.current;
+      const wrap = wrapRef.current;
+      if (input && wrap && input.value.trim() && !wrap.contains(e.target)) {
+        commitRef.current(input.value);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      // Flush a pending tag on unmount so switching regions mid-type never drops it.
+      if (inputRef.current?.value.trim()) commitRef.current(inputRef.current.value);
+    };
+  }, []);
 
   return (
-    <span style={{ display: "flex", flexDirection: "column", gap: 4, width: "100%" }}>
+    <span ref={wrapRef} style={{ display: "flex", flexDirection: "column", gap: 4, width: "100%" }}>
       {tags.length > 0 && (
         <span style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
           {tags.map((tag) => (
@@ -162,6 +195,7 @@ export const TagField = ({ value, onChange, suggestions = [], placeholder = "add
         </span>
       )}
       <input
+        ref={inputRef}
         value={draft}
         list={listId}
         placeholder={placeholder}
@@ -175,7 +209,10 @@ export const TagField = ({ value, onChange, suggestions = [], placeholder = "add
           if (e.key === "Enter") { e.preventDefault(); commit(draft); }
           else if (e.key === "Backspace" && !draft && tags.length) onChange(tags.slice(0, -1));
         }}
-        onBlur={() => draft.trim() && commit(draft)}
+        // Read the live value, not the `draft` closure: keeps blur and the
+        // click-out path from disagreeing, and both are deduped by commit()
+        // clearing the box.
+        onBlur={(e) => { if (e.target.value.trim()) commit(e.target.value); }}
         style={{ ...inputStyle, width: "100%", padding: "5px 7px" }}
       />
       <datalist id={listId}>

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -173,9 +173,6 @@ const saveBlobToDisk = (blob, fileName) => {
   URL.revokeObjectURL(url);
 };
 
-const saveJsonToDisk = (data, fileName) =>
-  saveBlobToDisk(new Blob([JSON.stringify(data, null, 2)], { type: "application/json" }), fileName);
-
 const cardSurface = {
   background: "rgba(255,255,255,0.04)",
   border: "1px solid rgba(255,255,255,0.09)",
@@ -558,28 +555,32 @@ const CommunityPanel = ({ onImported }) => {
       // If this scenario's custom basemap is already on the community hub,
       // reference it instead of re-embedding the whole image (smaller bundle).
       const dedup = await dedupeScenarioBundleBackground(bundle).catch(() => ({ referenced: false, needsPublish: false }));
-      // A not-yet-shared custom image basemap ships bundled as ONE .zip
-      // (scenario.json + the raw basemap image + a preview) so the author drags a
-      // single file and the image travels as real bytes, not a bloated data URL.
       const split = dedup.referenced ? null : await splitScenarioBundleImage(bundle).catch(() => null);
-      let fileName;
+      // ALWAYS ship a .zip. GitHub issue attachments reject a bare .json, so a
+      // scenario with no splittable image — e.g. a geometry-only preset like WWII,
+      // whose custom borders live in an embedded regions.geojson, not a basemap —
+      // could never actually be dragged into the post: the download looked fine, but
+      // the share was impossible. Wrapping scenario.json in a zip makes EVERY scenario
+      // attachable. A custom image basemap still rides alongside as a real file
+      // (scenario.json + basemap + preview) when there is one, instead of bloating the
+      // JSON as a base64 data URL.
+      const files = {};
       let extra;
       if (split) {
         delete bundle.assets.backgroundData; // the image now rides in the zip as a real file
-        const files = { "scenario.json": JSON.stringify(bundle), [split.imageName]: split.imageBytes };
+        files[split.imageName] = split.imageBytes;
         if (split.previewBytes) files[split.previewName] = split.previewBytes;
-        fileName = `${scenario.id}-scenario.zip`;
-        saveBlobToDisk(await zipBundle(files), fileName);
         extra =
           " Its custom basemap is bundled inside the .zip, so the scenario is self-contained — just drag the one file." +
           " (To also list the basemap on its own in the community Basemaps tab, open the editor's Basemap picker and hit ⤴ on it.)";
       } else {
-        fileName = `${scenario.id}-scenario.json`;
-        saveJsonToDisk(bundle, fileName);
         extra = dedup.referenced
           ? " Its custom basemap was reused from the community hub, so the file stays small."
           : "";
       }
+      files["scenario.json"] = JSON.stringify(bundle);
+      const fileName = `${scenario.id}-scenario.zip`;
+      saveBlobToDisk(await zipBundle(files), fileName);
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
       // dedupe it against dedicated posts. Harmless if the scenario form has no such

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -30,9 +30,6 @@ const HUB_OWNER = "Open-Historia";
 const HUB_REPO = "Open-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 const HUB_API_ISSUES = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
-// Official bundles live as assets on the "bundles" release — GitHub counts
-// every download of those, which is the install number shown on the cards.
-const HUB_API_BUNDLES_RELEASE = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/releases/tags/bundles`;
 const HUB_NEW_POST_URL = `${HUB_URL}/issues/new?template=scenario.yml`;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -51,21 +48,6 @@ const COVER_IMAGE_PATTERN =
 
 let hubCache = { at: 0, posts: null };
 
-// Installs per bundle file (release-asset download counts). Community posts
-// attach their bundles to the issue instead, which GitHub can't count — those
-// show no install number.
-const fetchInstallCounts = async () => {
-  try {
-    const response = await fetch(HUB_API_BUNDLES_RELEASE, {
-      headers: { Accept: "application/vnd.github+json" },
-    });
-    if (!response.ok) return new Map();
-    const release = await response.json();
-    return new Map((release.assets ?? []).map((asset) => [asset.name, asset.download_count ?? 0]));
-  } catch {
-    return new Map();
-  }
-};
 
 // Self-hosted import counts (keyed by hub issue number), read back through the
 // server proxy from our own counter Worker. Unlike GitHub's release download
@@ -86,7 +68,7 @@ const fetchImportCounts = async () => {
 // by GitHub itself (author_association). Titles and body text can't fake this.
 const OFFICIAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
-const parsePost = (issue, installsByFile, importsById) => {
+const parsePost = (issue, importsById) => {
   const body = String(issue.body ?? "");
   const bundleUrl = body.match(BUNDLE_LINK_PATTERN)?.[0] ?? null;
   // The issue-form body is a series of "### <label>\n<value>" sections. Show only
@@ -108,11 +90,13 @@ const parsePost = (issue, installsByFile, importsById) => {
     .trim();
   const coverImageMatch = body.match(COVER_IMAGE_PATTERN);
   const coverImageUrl = coverImageMatch ? (coverImageMatch[1] ?? coverImageMatch[2] ?? null) : null;
-  // Import count: prefer our own counter (covers every scenario, deduped per
-  // person); fall back to the GitHub release download count; null if neither.
-  const selfHostedImports = importsById?.[String(issue.number)]?.count;
-  const githubInstalls = bundleUrl && installsByFile ? installsByFile.get(bundleUrl.split("/").pop()) : undefined;
-  const installs = selfHostedImports != null ? selfHostedImports : (githubInstalls ?? null);
+  // Import count comes ONLY from our own counter Worker, keyed by hub issue number.
+  // It is deduped per person (an account, or an IP hash) and covers every scenario —
+  // release assets and attachment posts alike. We deliberately do NOT fall back to
+  // GitHub's release download count: that counts every file download, including
+  // repeat downloads by the same person and non-import curiosity clicks, so it both
+  // over-counts and disagrees between posts. One accurate source for all.
+  const installs = importsById?.[String(issue.number)]?.count ?? null;
   return {
     id: issue.number,
     title: String(issue.title ?? "").replace(/^\[Scenario\]\s*/i, "").trim() || `Scenario #${issue.number}`,
@@ -142,9 +126,8 @@ export const fetchHubPosts = async ({ force = false } = {}) => {
   if (!force && hubCache.posts && Date.now() - hubCache.at < CACHE_TTL_MS) {
     return hubCache.posts;
   }
-  const [response, installsByFile, importsById] = await Promise.all([
+  const [response, importsById] = await Promise.all([
     fetch(HUB_API_ISSUES, { headers: { Accept: "application/vnd.github+json" } }),
-    fetchInstallCounts(),
     fetchImportCounts(),
   ]);
   if (!response.ok) {
@@ -157,7 +140,7 @@ export const fetchHubPosts = async ({ force = false } = {}) => {
   const issues = await response.json();
   const posts = (Array.isArray(issues) ? issues : [])
     .filter((issue) => !issue.pull_request)
-    .map((issue) => parsePost(issue, installsByFile, importsById));
+    .map((issue) => parsePost(issue, importsById));
   hubCache = { at: Date.now(), posts };
   return posts;
 };

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -34,6 +34,12 @@ import { useIsMobile } from "../../runtime/useIsMobile.js";
 import { DIFFICULTY_LEVELS } from "../../runtime/difficulty.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagEmojiFromGid } from "../../runtime/countryFlags.js";
+import {
+  splitScenarioBundleImage,
+  embedScenarioBundleImage,
+  embedScenarioBundleVector,
+} from "../../runtime/communityBasemaps.js";
+import { zipBundle, unzipBundle, looksLikeZip } from "../../runtime/bundleZip.js";
 
 const UNIT_TYPE_LABELS = {
   infantry: "Infantry",
@@ -223,8 +229,7 @@ const buildGameEditorState = (details) => {
   };
 };
 
-const saveJsonBundleToDisk = (bundle, fileName) => {
-  const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: "application/json" });
+const saveBlobToDisk = (blob, fileName) => {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
@@ -233,6 +238,10 @@ const saveJsonBundleToDisk = (bundle, fileName) => {
   anchor.click();
   anchor.remove();
   URL.revokeObjectURL(url);
+};
+
+const saveJsonBundleToDisk = (bundle, fileName) => {
+  saveBlobToDisk(new Blob([JSON.stringify(bundle, null, 2)], { type: "application/json" }), fileName);
 };
 
 const AssetBadgeRow = ({ badges }) =>
@@ -872,10 +881,13 @@ const EditorDrawer = ({
       {editorSection === "bundles" && kind === "scenario" && (
         <div style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "18px", marginBottom: "0.95rem", padding: "0.9rem" }}>
           <div style={{ color: "rgba(255,255,255,0.58)", fontSize: "0.82rem", lineHeight: 1.5, marginBottom: "0.85rem" }}>
-            Download the scenario as one self-contained JSON file — any custom map geometry, cities and basemap travel inside it, so it's ready to share or re-import.
+            Download the scenario as one self-contained file — custom map geometry, cities and basemap all travel with it, ready to share or re-import. The <strong>.zip</strong> carries a custom basemap as a real image file (smaller, and the form the community hub expects); the <strong>JSON</strong> packs everything into one text file.
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.55rem" }}>
-            <button onClick={() => onExportBundle("light")} style={actionButtonStyle} type="button">
+            <button onClick={() => onExportBundle("light", "zip")} style={actionButtonStyle} type="button">
+              Download .zip
+            </button>
+            <button onClick={() => onExportBundle("light", "json")} style={actionButtonStyle} type="button">
               Download JSON
             </button>
           </div>
@@ -1403,7 +1415,7 @@ const LibraryTopBar = () => {
     }
   };
 
-  const handleExportBundle = async (mode) => {
+  const handleExportBundle = async (mode, format = "json") => {
     if (editorKind !== "scenario" || !editorDetails) {
       return;
     }
@@ -1412,8 +1424,26 @@ const LibraryTopBar = () => {
     setIsBusy(true);
 
     try {
-      const bundle = await exportScenarioBundle(editorDetails.scenario.id, mode);
-      saveJsonBundleToDisk(bundle, `${editorDetails.scenario.id}-${mode}.json`);
+      const id = editorDetails.scenario.id;
+      const bundle = await exportScenarioBundle(id, mode);
+      if (format === "zip") {
+        // Package the scenario as a real .zip. When it carries a custom basemap, that
+        // image/geojson rides inside as an actual file (+ a small preview) instead of a
+        // base64 data URL bloating the JSON — the same self-contained form the community
+        // hub shares. With no custom basemap there's nothing to split out, so the zip
+        // just holds scenario.json (still a valid, self-contained bundle).
+        const split = await splitScenarioBundleImage(bundle).catch(() => null);
+        const files = { "scenario.json": JSON.stringify(bundle) };
+        if (split) {
+          delete bundle.assets.backgroundData; // the basemap now travels as a real file
+          files["scenario.json"] = JSON.stringify(bundle);
+          files[split.imageName] = split.imageBytes;
+          if (split.previewBytes) files[split.previewName] = split.previewBytes;
+        }
+        saveBlobToDisk(await zipBundle(files), `${id}-scenario.zip`);
+      } else {
+        saveJsonBundleToDisk(bundle, `${id}-${mode}.json`);
+      }
     } catch (nextError) {
       setEditorError(nextError.message);
     } finally {
@@ -1433,8 +1463,27 @@ const LibraryTopBar = () => {
     setIsBusy(true);
 
     try {
-      const text = await file.text();
-      const bundle = JSON.parse(text);
+      // A scenario exported with a custom basemap arrives as a .zip (scenario.json +
+      // the raw basemap file); everything else is a plain JSON bundle. Detect the zip
+      // by its magic bytes so a renamed file still works, then re-embed the basemap so
+      // the importer sees a normal self-contained bundle.
+      const buffer = await file.arrayBuffer();
+      let bundle;
+      if (looksLikeZip(new Uint8Array(buffer))) {
+        const zip = await unzipBundle(buffer);
+        const scenarioText = await zip.text("scenario.json");
+        if (!scenarioText) throw new Error("That .zip is missing scenario.json.");
+        bundle = JSON.parse(scenarioText);
+        const imageName = zip.names().find((n) => /(^|\/)basemap\.(png|jpe?g|webp|gif|svg)$/i.test(n));
+        if (imageName) {
+          embedScenarioBundleImage(bundle, await zip.bytes(imageName), imageName);
+        } else {
+          const vectorName = zip.names().find((n) => /(^|\/)basemap\.geojson$/i.test(n));
+          if (vectorName) embedScenarioBundleVector(bundle, await zip.bytes(vectorName));
+        }
+      } else {
+        bundle = JSON.parse(new TextDecoder().decode(buffer));
+      }
       const details = await importScenarioBundle(bundle);
       setActiveTab("scenarios");
       setIsPanelOpen(true);
@@ -1957,7 +2006,7 @@ const LibraryTopBar = () => {
 
       <input
         ref={importScenarioInputRef}
-        accept=".json,application/json"
+        accept=".json,application/json,.zip,application/zip"
         onChange={handleImportScenarioFile}
         style={{ display: "none" }}
         type="file"

--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -873,10 +873,20 @@ const importScenarioBundle = async (bundle) => {
     if (key === COVER_IMAGE_ASSET_KEY) {
       if (embedded && descriptor.data) await uploadScenarioAsset(newId, key, base64ToBytes(descriptor.data), descriptor.contentType);
       else await removeScenarioAsset(newId, key);
-    } else if (key === "colors") {
-      if (embedded && descriptor.data !== undefined) { const r = await getScenario(newId); r.colors = descriptor.data; writeScenarioMeta(r, {}); await putScenario(r); }
-      else await removeScenarioAsset(newId, key);
-    } else if (embedded && descriptor.data) {
+    } else if (OPTIONAL_JSON_ASSET_KEYS.includes(key)) {
+      // colors / flags / tags are JSON descriptor assets: `descriptor.data` is the
+      // object itself, NOT base64. Store it verbatim on the record. Passing it to
+      // base64ToBytes (as the binary branch below does) makes atob throw
+      // "string to be decoded is not correctly encoded" — which made EVERY scenario
+      // carrying tags or flags (e.g. the WWII preset) fail to import on the web build.
+      const r = await getScenario(newId);
+      if (embedded && descriptor.data !== undefined) r[key] = descriptor.data;
+      else delete r[key];
+      writeScenarioMeta(r, {});
+      await putScenario(r);
+    } else if (embedded && typeof descriptor.data === "string") {
+      // geojson / pmtiles: base64-encoded binary. The typeof guard keeps any stray
+      // non-string payload from reaching atob and crashing the whole import.
       await uploadScenarioAsset(newId, key, base64ToBytes(descriptor.data), descriptor.contentType);
     } else {
       await removeScenarioAsset(newId, key);

--- a/tools/import-counter/worker.js
+++ b/tools/import-counter/worker.js
@@ -60,7 +60,7 @@ async function dedupKeyFor(request, env, id) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     if (request.method === "OPTIONS") return new Response(null, { headers: CORS });
     if (!env.IMPORTS) return json({ error: "KV namespace binding 'IMPORTS' is not configured" }, 500);
@@ -86,6 +86,15 @@ export default {
       }
 
       if (request.method === "GET" && url.pathname === "/counts") {
+        // Edge-cache the whole map for a minute. The community tab is read FAR more
+        // than scenarios are imported, and each uncached read is a KV list() over
+        // every counter key — so without this a busy hub could burn through the KV
+        // read allowance on refreshes alone. A ≤60s-stale install number is fine; a
+        // fresh /hit still lands immediately, it just shows on the next cache cycle.
+        const cache = caches.default;
+        const cacheKey = new Request(`${url.origin}/counts`);
+        const hit = await cache.match(cacheKey);
+        if (hit) return hit;
         const out = {};
         let cursor;
         do {
@@ -93,7 +102,11 @@ export default {
           for (const k of page.keys) out[k.name.slice(2)] = k.metadata || { count: 0 };
           cursor = page.list_complete ? undefined : page.cursor;
         } while (cursor);
-        return json(out);
+        const resp = new Response(JSON.stringify(out), {
+          headers: { "Content-Type": "application/json", ...CORS, "Cache-Control": "public, max-age=60" },
+        });
+        ctx.waitUntil(cache.put(cacheKey, resp.clone()));
+        return resp;
       }
 
       if (request.method === "GET" && url.pathname.startsWith("/count/")) {


### PR DESCRIPTION
Four fixes (supersedes the earlier PR — adds the install-counter changes). Applies cleanly on all channels.

1. **Web scenario import crash** — importing any scenario carrying country **tags/flags** (e.g. WWII) threw `atob … not correctly encoded` on the web build; now stored as JSON. This also unblocks install-counting (the counter only fires after a successful import). Verified against the real 16.7 MB WWII bundle.
2. **Publish/share as .zip** — always a self-contained `.zip`; the Bundles tab gains Download .zip and imports `.zip` too.
3. **Editor tag field** — commits a tag on click-out, not only Enter.
4. **Install counts** — shown ONLY from the deduped counter Worker (one accurate per-person source for every scenario; drops GitHub's over-counting download numbers and a per-refresh API call), and the counter's `/counts` is edge-cached 60s so community-tab refreshes don't spend the KV read allowance.