### PR TITLE
Community install counts: one deduped source + edge-cache the reads

### DIFF
--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -30,9 +30,6 @@ const HUB_OWNER = "Open-Historia";
 const HUB_REPO = "Open-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 const HUB_API_ISSUES = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
-// Official bundles live as assets on the "bundles" release — GitHub counts
-// every download of those, which is the install number shown on the cards.
-const HUB_API_BUNDLES_RELEASE = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/releases/tags/bundles`;
 const HUB_NEW_POST_URL = `${HUB_URL}/issues/new?template=scenario.yml`;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -51,21 +48,6 @@ const COVER_IMAGE_PATTERN =
 
 let hubCache = { at: 0, posts: null };
 
-// Installs per bundle file (release-asset download counts). Community posts
-// attach their bundles to the issue instead, which GitHub can't count — those
-// show no install number.
-const fetchInstallCounts = async () => {
-  try {
-    const response = await fetch(HUB_API_BUNDLES_RELEASE, {
-      headers: { Accept: "application/vnd.github+json" },
-    });
-    if (!response.ok) return new Map();
-    const release = await response.json();
-    return new Map((release.assets ?? []).map((asset) => [asset.name, asset.download_count ?? 0]));
-  } catch {
-    return new Map();
-  }
-};
 
 // Self-hosted import counts (keyed by hub issue number), read back through the
 // server proxy from our own counter Worker. Unlike GitHub's release download
@@ -86,7 +68,7 @@ const fetchImportCounts = async () => {
 // by GitHub itself (author_association). Titles and body text can't fake this.
 const OFFICIAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
-const parsePost = (issue, installsByFile, importsById) => {
+const parsePost = (issue, importsById) => {
   const body = String(issue.body ?? "");
   const bundleUrl = body.match(BUNDLE_LINK_PATTERN)?.[0] ?? null;
   // The issue-form body is a series of "### <label>\n<value>" sections. Show only
@@ -108,11 +90,13 @@ const parsePost = (issue, installsByFile, importsById) => {
     .trim();
   const coverImageMatch = body.match(COVER_IMAGE_PATTERN);
   const coverImageUrl = coverImageMatch ? (coverImageMatch[1] ?? coverImageMatch[2] ?? null) : null;
-  // Import count: prefer our own counter (covers every scenario, deduped per
-  // person); fall back to the GitHub release download count; null if neither.
-  const selfHostedImports = importsById?.[String(issue.number)]?.count;
-  const githubInstalls = bundleUrl && installsByFile ? installsByFile.get(bundleUrl.split("/").pop()) : undefined;
-  const installs = selfHostedImports != null ? selfHostedImports : (githubInstalls ?? null);
+  // Import count comes ONLY from our own counter Worker, keyed by hub issue number.
+  // It is deduped per person (an account, or an IP hash) and covers every scenario —
+  // release assets and attachment posts alike. We deliberately do NOT fall back to
+  // GitHub's release download count: that counts every file download, including
+  // repeat downloads by the same person and non-import curiosity clicks, so it both
+  // over-counts and disagrees between posts. One accurate source for all.
+  const installs = importsById?.[String(issue.number)]?.count ?? null;
   return {
     id: issue.number,
     title: String(issue.title ?? "").replace(/^\[Scenario\]\s*/i, "").trim() || `Scenario #${issue.number}`,
@@ -142,9 +126,8 @@ export const fetchHubPosts = async ({ force = false } = {}) => {
   if (!force && hubCache.posts && Date.now() - hubCache.at < CACHE_TTL_MS) {
     return hubCache.posts;
   }
-  const [response, installsByFile, importsById] = await Promise.all([
+  const [response, importsById] = await Promise.all([
     fetch(HUB_API_ISSUES, { headers: { Accept: "application/vnd.github+json" } }),
-    fetchInstallCounts(),
     fetchImportCounts(),
   ]);
   if (!response.ok) {
@@ -157,7 +140,7 @@ export const fetchHubPosts = async ({ force = false } = {}) => {
   const issues = await response.json();
   const posts = (Array.isArray(issues) ? issues : [])
     .filter((issue) => !issue.pull_request)
-    .map((issue) => parsePost(issue, installsByFile, importsById));
+    .map((issue) => parsePost(issue, importsById));
   hubCache = { at: Date.now(), posts };
   return posts;
 };

--- a/tools/import-counter/worker.js
+++ b/tools/import-counter/worker.js
@@ -60,7 +60,7 @@ async function dedupKeyFor(request, env, id) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     if (request.method === "OPTIONS") return new Response(null, { headers: CORS });
     if (!env.IMPORTS) return json({ error: "KV namespace binding 'IMPORTS' is not configured" }, 500);
@@ -86,6 +86,15 @@ export default {
       }
 
       if (request.method === "GET" && url.pathname === "/counts") {
+        // Edge-cache the whole map for a minute. The community tab is read FAR more
+        // than scenarios are imported, and each uncached read is a KV list() over
+        // every counter key — so without this a busy hub could burn through the KV
+        // read allowance on refreshes alone. A ≤60s-stale install number is fine; a
+        // fresh /hit still lands immediately, it just shows on the next cache cycle.
+        const cache = caches.default;
+        const cacheKey = new Request(`${url.origin}/counts`);
+        const hit = await cache.match(cacheKey);
+        if (hit) return hit;
         const out = {};
         let cursor;
         do {
@@ -93,7 +102,11 @@ export default {
           for (const k of page.keys) out[k.name.slice(2)] = k.metadata || { count: 0 };
           cursor = page.list_complete ? undefined : page.cursor;
         } while (cursor);
-        return json(out);
+        const resp = new Response(JSON.stringify(out), {
+          headers: { "Content-Type": "application/json", ...CORS, "Cache-Control": "public, max-age=60" },
+        });
+        ctx.waitUntil(cache.put(cacheKey, resp.clone()));
+        return resp;
       }
 
       if (request.method === "GET" && url.pathname.startsWith("/count/")) {


### PR DESCRIPTION
Follow-up to the just-merged scenario-hub fixes. Two changes to how community install counts work:

- **One accurate, deduped source.** Show the install number ONLY from our own counter Worker (keyed by hub issue number, deduped per person — account or IP hash), for every scenario. Drops GitHub's release download-count fallback, which counted every file download (including repeat downloads by the same person), so it over-counted and disagreed between posts. Also removes a GitHub API call per hub refresh.
- **Cache the reads.** Edge-cache the counter's `/counts` for 60s. The community tab is read far more than scenarios are imported, and each uncached read is a KV `list()` over every counter key — so a busy hub could otherwise burn the KV read allowance on refreshes alone. (Writes are unchanged: only a NEW unique install writes; a repeat import by the same person is deduped to a read.)