### PR TITLE
Fix website images at root, timeline jump revert, and scenario card covers

### DIFF
--- a/scripts/assemble-site.mjs
+++ b/scripts/assemble-site.mjs
@@ -25,6 +25,19 @@ const ROOT_PAGES = [
   "guides.css", "robots.txt", "sitemap.xml",
 ];
 
+// Image assets referenced with absolute "/…" paths by BOTH the root guide pages and
+// the web game (logo, startup images, PWA icons). The game lives under /play/, so an
+// absolute "/logo.png" resolves against the ORIGIN, not the /play/ base — without a
+// copy at the site root these 404 on openhistoria.com (the game keeps its own copy at
+// /play/ regardless). Skipped silently if one is renamed away; a missing image is a
+// cosmetic 404, not a crawler-visible broken page, so it must not fail the build.
+const ROOT_ASSETS = [
+  "logo.png",
+  "loading_screen.jpg", "loading_screen_2.jpg", "loading_screen_3.jpg",
+  "loading_screen_4.jpg", "loading_screen_5.png",
+  "icon-192.png", "icon-512.png", "screenshot.png",
+];
+
 if (!existsSync(path.join(gameDir, "index.html"))) {
   console.error("dist-web/ is missing — build the game first: vite build --mode web --base /play/ --outDir dist-web");
   process.exit(1);
@@ -43,4 +56,9 @@ cpSync(gameDir, path.join(outDir, "play"), { recursive: true }); // game at /pla
 for (const name of ROOT_PAGES) {                                 // guides + robots/sitemap at /
   cpSync(path.join(gameDir, name), path.join(outDir, name), { recursive: true });
 }
-console.log(`Assembled dist-site/: landing page at /, game at /play/, ${ROOT_PAGES.length} root page(s) at /.`);
+let rootAssets = 0;
+for (const name of ROOT_ASSETS) {                                // logo + startup images at /
+  const src = path.join(gameDir, name);
+  if (existsSync(src)) { cpSync(src, path.join(outDir, name)); rootAssets += 1; }
+}
+console.log(`Assembled dist-site/: landing page at /, game at /play/, ${ROOT_PAGES.length} root page(s) + ${rootAssets} asset(s) at /.`);

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -564,6 +564,20 @@ const CommunityPanel = ({ onImported }) => {
       files["scenario.json"] = JSON.stringify(bundle);
       const fileName = `${scenario.id}-scenario.zip`;
       saveBlobToDisk(await zipBundle(files), fileName);
+      // Also download the scenario's cover image as its own file so the author can drag
+      // it into the post: GitHub renders a dragged image inline, and the hub reads that
+      // as the card cover — exactly like a basemap/flag preview. (The cover still rides
+      // inside the .zip, so the scenario stays self-contained; this copy is for display.)
+      let hasCover = false;
+      const cover = bundle.assets?.cover;
+      if (cover?.mode === "embedded" && cover.data) {
+        const ext = /png/i.test(cover.contentType || "") ? "png" : /webp/i.test(cover.contentType || "") ? "webp" : "jpg";
+        try {
+          const coverBlob = await (await fetch(`data:${cover.contentType || "image/jpeg"};base64,${cover.data}`)).blob();
+          saveBlobToDisk(coverBlob, `${scenario.id}-cover.${ext}`);
+          hasCover = true;
+        } catch { /* the cover is a nicety — never block the publish over it */ }
+      }
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
       // dedupe it against dedicated posts. Harmless if the scenario form has no such
@@ -573,7 +587,9 @@ const CommunityPanel = ({ onImported }) => {
         (split ? `&technical=${encodeURIComponent(`Basemap-Hash: ${split.hash}\nBasemap-Kind: ${split.kind}`)}` : "");
       window.open(scenarioUrl, "_blank", "noopener");
       setNotice(
-        `"${fileName}" was downloaded. On the GitHub page that just opened, drag that file into the Description box, then submit.${extra}`,
+        `${hasCover ? `"${fileName}" and its cover image were` : `"${fileName}" was`} downloaded. ` +
+          `On the GitHub page that just opened, drag ${hasCover ? "both files" : "that file"} into the Description box, then submit.` +
+          `${hasCover ? " The cover image becomes the card's preview in the hub." : ""}${extra}`,
       );
     } catch (nextError) {
       setError(`Publish failed: ${nextError.message}`);

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -1223,6 +1223,12 @@ const DateWidget = ({
     const [fallbackWarning, setFallbackWarning] = useState("");
     // Holds the in-flight jump's AbortController so the Cancel button can stop it.
     const jumpAbortRef = React.useRef(null);
+    // Mirrors the latest applied turn (round + date) so the 5s refresh poll can tell a
+    // stale read from a genuinely newer one — and never revert a just-completed jump.
+    const gameStampRef = React.useRef({ round: 0, date: "" });
+    React.useEffect(() => {
+        gameStampRef.current = { round: Number(gameData?.round) || 0, date: gameData?.gameDate || "" };
+    }, [gameData]);
     const [visibleEventCount, setVisibleEventCount] = useState(1);
     const [undoCount, setUndoCount] = useState(0);
     const openPanel = typeof onSetPanel === "function" ? activePanel : localOpenPanel;
@@ -1279,6 +1285,18 @@ const DateWidget = ({
                 ]);
 
                 if (cancelled) {
+                    return;
+                }
+
+                // Never let this background poll overwrite a fresher turn with an older
+                // read. A jump advances the round (and date); if the store read comes
+                // back behind what's already on screen — a write still settling, an
+                // eventually-consistent read, a poll that fired mid-jump — applying it
+                // would revert the date and wipe the just-generated events. Skip it.
+                const local = gameStampRef.current;
+                const polledRound = Number(game?.round) || 0;
+                const polledDate = game?.gameDate || "";
+                if (polledRound < local.round || (polledRound === local.round && polledDate < local.date)) {
                     return;
                 }
 


### PR DESCRIPTION
Three reported fixes.

1. **Website logo / loading-screen images 404** — the web game runs under `/play/` but references `/logo.png`, `/loading_screen*.jpg` etc. absolutely (they resolve against the origin), and the root guide pages do too. `assemble-site` only lifted HTML pages to the site root, so those images 404'd on openhistoria.com. Now the logo + startup images + icons are copied to the root as well.
2. **Timeline jump reverts after ~1s** — a 5s background poll re-reads game/events/world and applied them even when the read came back *behind* the turn already on screen (write still settling / eventually-consistent read / poll fired mid-jump), reverting the date to the start and wiping the fresh events. It now skips any read whose round/date is older than what's displayed.
3. **Community scenario cards show no cover** — publishing only handed over the `.zip`; the card renders `coverImageUrl` but scenarios had no image (unlike basemaps/flags). Publish now also downloads the scenario's cover image and tells the author to drag it into the post, so GitHub renders it as the card preview.