### PR TITLE
Website images at root, timeline jump revert, scenario card covers (+ cover in the .zip)

### DIFF
--- a/scripts/assemble-site.mjs
+++ b/scripts/assemble-site.mjs
@@ -25,6 +25,19 @@ const ROOT_PAGES = [
   "guides.css", "robots.txt", "sitemap.xml",
 ];
 
+// Image assets referenced with absolute "/…" paths by BOTH the root guide pages and
+// the web game (logo, startup images, PWA icons). The game lives under /play/, so an
+// absolute "/logo.png" resolves against the ORIGIN, not the /play/ base — without a
+// copy at the site root these 404 on openhistoria.com (the game keeps its own copy at
+// /play/ regardless). Skipped silently if one is renamed away; a missing image is a
+// cosmetic 404, not a crawler-visible broken page, so it must not fail the build.
+const ROOT_ASSETS = [
+  "logo.png",
+  "loading_screen.jpg", "loading_screen_2.jpg", "loading_screen_3.jpg",
+  "loading_screen_4.jpg", "loading_screen_5.png",
+  "icon-192.png", "icon-512.png", "screenshot.png",
+];
+
 if (!existsSync(path.join(gameDir, "index.html"))) {
   console.error("dist-web/ is missing — build the game first: vite build --mode web --base /play/ --outDir dist-web");
   process.exit(1);
@@ -43,4 +56,9 @@ cpSync(gameDir, path.join(outDir, "play"), { recursive: true }); // game at /pla
 for (const name of ROOT_PAGES) {                                 // guides + robots/sitemap at /
   cpSync(path.join(gameDir, name), path.join(outDir, name), { recursive: true });
 }
-console.log(`Assembled dist-site/: landing page at /, game at /play/, ${ROOT_PAGES.length} root page(s) at /.`);
+let rootAssets = 0;
+for (const name of ROOT_ASSETS) {                                // logo + startup images at /
+  const src = path.join(gameDir, name);
+  if (existsSync(src)) { cpSync(src, path.join(outDir, name)); rootAssets += 1; }
+}
+console.log(`Assembled dist-site/: landing page at /, game at /play/, ${ROOT_PAGES.length} root page(s) + ${rootAssets} asset(s) at /.`);

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -561,23 +561,29 @@ const CommunityPanel = ({ onImported }) => {
           ? " Its custom basemap was reused from the community hub, so the file stays small."
           : "";
       }
-      files["scenario.json"] = JSON.stringify(bundle);
-      const fileName = `${scenario.id}-scenario.zip`;
-      saveBlobToDisk(await zipBundle(files), fileName);
-      // Also download the scenario's cover image as its own file so the author can drag
-      // it into the post: GitHub renders a dragged image inline, and the hub reads that
-      // as the card cover — exactly like a basemap/flag preview. (The cover still rides
-      // inside the .zip, so the scenario stays self-contained; this copy is for display.)
+      // The cover rides inside the .zip as its own file (cover.<ext>) so the bundle is
+      // complete and browsable on its own. It ALSO downloads separately, because GitHub
+      // can't render an image that lives inside a .zip: the author drags that copy into
+      // the post, where the hub reads it as the card cover — like a basemap/flag preview.
+      // The base64 copy already in scenario.json is what import reads, so the .zip stays
+      // self-contained with no import-side changes needed.
       let hasCover = false;
+      let coverBlob = null;
+      let coverDownloadName = "";
       const cover = bundle.assets?.cover;
       if (cover?.mode === "embedded" && cover.data) {
         const ext = /png/i.test(cover.contentType || "") ? "png" : /webp/i.test(cover.contentType || "") ? "webp" : "jpg";
         try {
-          const coverBlob = await (await fetch(`data:${cover.contentType || "image/jpeg"};base64,${cover.data}`)).blob();
-          saveBlobToDisk(coverBlob, `${scenario.id}-cover.${ext}`);
+          coverBlob = await (await fetch(`data:${cover.contentType || "image/jpeg"};base64,${cover.data}`)).blob();
+          files[`cover.${ext}`] = new Uint8Array(await coverBlob.arrayBuffer());
+          coverDownloadName = `${scenario.id}-cover.${ext}`;
           hasCover = true;
         } catch { /* the cover is a nicety — never block the publish over it */ }
       }
+      files["scenario.json"] = JSON.stringify(bundle);
+      const fileName = `${scenario.id}-scenario.zip`;
+      saveBlobToDisk(await zipBundle(files), fileName);
+      if (coverBlob && coverDownloadName) saveBlobToDisk(coverBlob, coverDownloadName);
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
       // dedupe it against dedicated posts. Harmless if the scenario form has no such

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -564,6 +564,20 @@ const CommunityPanel = ({ onImported }) => {
       files["scenario.json"] = JSON.stringify(bundle);
       const fileName = `${scenario.id}-scenario.zip`;
       saveBlobToDisk(await zipBundle(files), fileName);
+      // Also download the scenario's cover image as its own file so the author can drag
+      // it into the post: GitHub renders a dragged image inline, and the hub reads that
+      // as the card cover — exactly like a basemap/flag preview. (The cover still rides
+      // inside the .zip, so the scenario stays self-contained; this copy is for display.)
+      let hasCover = false;
+      const cover = bundle.assets?.cover;
+      if (cover?.mode === "embedded" && cover.data) {
+        const ext = /png/i.test(cover.contentType || "") ? "png" : /webp/i.test(cover.contentType || "") ? "webp" : "jpg";
+        try {
+          const coverBlob = await (await fetch(`data:${cover.contentType || "image/jpeg"};base64,${cover.data}`)).blob();
+          saveBlobToDisk(coverBlob, `${scenario.id}-cover.${ext}`);
+          hasCover = true;
+        } catch { /* the cover is a nicety — never block the publish over it */ }
+      }
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
       // dedupe it against dedicated posts. Harmless if the scenario form has no such
@@ -573,7 +587,9 @@ const CommunityPanel = ({ onImported }) => {
         (split ? `&technical=${encodeURIComponent(`Basemap-Hash: ${split.hash}\nBasemap-Kind: ${split.kind}`)}` : "");
       window.open(scenarioUrl, "_blank", "noopener");
       setNotice(
-        `"${fileName}" was downloaded. On the GitHub page that just opened, drag that file into the Description box, then submit.${extra}`,
+        `${hasCover ? `"${fileName}" and its cover image were` : `"${fileName}" was`} downloaded. ` +
+          `On the GitHub page that just opened, drag ${hasCover ? "both files" : "that file"} into the Description box, then submit.` +
+          `${hasCover ? " The cover image becomes the card's preview in the hub." : ""}${extra}`,
       );
     } catch (nextError) {
       setError(`Publish failed: ${nextError.message}`);

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -1223,6 +1223,12 @@ const DateWidget = ({
     const [fallbackWarning, setFallbackWarning] = useState("");
     // Holds the in-flight jump's AbortController so the Cancel button can stop it.
     const jumpAbortRef = React.useRef(null);
+    // Mirrors the latest applied turn (round + date) so the 5s refresh poll can tell a
+    // stale read from a genuinely newer one — and never revert a just-completed jump.
+    const gameStampRef = React.useRef({ round: 0, date: "" });
+    React.useEffect(() => {
+        gameStampRef.current = { round: Number(gameData?.round) || 0, date: gameData?.gameDate || "" };
+    }, [gameData]);
     const [visibleEventCount, setVisibleEventCount] = useState(1);
     const [undoCount, setUndoCount] = useState(0);
     const openPanel = typeof onSetPanel === "function" ? activePanel : localOpenPanel;
@@ -1279,6 +1285,18 @@ const DateWidget = ({
                 ]);
 
                 if (cancelled) {
+                    return;
+                }
+
+                // Never let this background poll overwrite a fresher turn with an older
+                // read. A jump advances the round (and date); if the store read comes
+                // back behind what's already on screen — a write still settling, an
+                // eventually-consistent read, a poll that fired mid-jump — applying it
+                // would revert the date and wipe the just-generated events. Skip it.
+                const local = gameStampRef.current;
+                const polledRound = Number(game?.round) || 0;
+                const polledDate = game?.gameDate || "";
+                if (polledRound < local.round || (polledRound === local.round && polledDate < local.date)) {
                     return;
                 }
 


### PR DESCRIPTION
Supersedes #307 — same three fixes, plus the scenario cover now also rides **inside** the .zip.

1. **Website images at root** — logo + startup/loading images are lifted to the site root, not only under `/play/`, so they stop 404ing on openhistoria.com.
2. **Timeline jump revert** — the 5s refresh poll no longer overwrites a just-completed jump with the pre-jump state (a Discord report: event generates, then reverts to Jan 1 2016).
3. **Scenario card covers** — publishing downloads the cover as its own image so the author can drag it into the post; the hub then shows it on the community card, like basemaps/flags.
4. **Cover inside the .zip** — the cover now also rides in the .zip as `cover.<ext>`, so the bundle is complete and browsable on its own. Import still reads the base64 in `scenario.json`, so nothing changes on the import side and the .zip can never lose its cover.