### PR TITLE
Community scenarios: Update button when the hub post has a newer bundle

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -555,6 +555,23 @@ const saveGameManifest = (manifest) => {
   });
 };
 
+// Provenance for scenarios imported straight from the community hub: which post
+// (issue number), which exact bundle file, and when. The bundle URL doubles as
+// the update signal — GitHub mints a new attachment URL for every re-upload, so
+// a post whose current bundleUrl differs from the recorded one has an update
+// (the hub-cache route relies on the same immutability).
+const normalizeHubOrigin = (raw) => {
+  if (!raw || typeof raw !== "object") return null;
+  const postId = Number(raw.postId);
+  const bundleUrl = String(raw.bundleUrl ?? "").trim();
+  if (!Number.isFinite(postId) || postId <= 0 || !bundleUrl) return null;
+  return {
+    bundleUrl,
+    postId,
+    syncedAt: String(raw.syncedAt ?? "").trim() || new Date().toISOString(),
+  };
+};
+
 const readScenarioMeta = (scenarioId) => {
   const raw = readJsonFile(getScenarioMetaPath(scenarioId), {});
   const name = String(raw?.name ?? "").trim() || DEFAULT_SCENARIO_META.name;
@@ -573,6 +590,7 @@ const readScenarioMeta = (scenarioId) => {
     eyebrow: String(raw?.eyebrow ?? "").trim() || DEFAULT_SCENARIO_META.eyebrow,
     heroSubtitle: String(raw?.heroSubtitle ?? "").trim() || description,
     heroTitle: String(raw?.heroTitle ?? "").trim() || name,
+    hubOrigin: normalizeHubOrigin(raw?.hubOrigin),
     id: scenarioId,
     name,
     subtitle,
@@ -595,6 +613,14 @@ const writeScenarioMeta = (scenarioId, updates) => {
     updates?.countryNameOverrides && typeof updates.countryNameOverrides === "object"
     ? updates.countryNameOverrides
     : current.countryNameOverrides,
+    // Hub provenance survives ONLY when a write explicitly carries it (the
+    // import/update paths stamp it last). Every other meta write is a local
+    // modification — a rename, an editor apply, a cover change — which turns
+    // the copy into a fork, and a fork must stop offering hub updates that
+    // would overwrite the player's work.
+    hubOrigin: Object.prototype.hasOwnProperty.call(updates ?? {}, "hubOrigin")
+      ? normalizeHubOrigin(updates.hubOrigin)
+      : null,
     id: scenarioId,
     updatedAt: new Date().toISOString(),
   };
@@ -2416,6 +2442,10 @@ const importScenarioBundle = (bundle, { setSelected = true } = {}) => {
   const scenario = bundle.scenario && typeof bundle.scenario === "object" ? bundle.scenario : {};
   const data = bundle.data && typeof bundle.data === "object" ? bundle.data : {};
   const assets = bundle.assets && typeof bundle.assets === "object" ? bundle.assets : {};
+  // Provenance the community hub attaches to a direct import (bundle.hubOrigin
+  // rides alongside the schema fields; absent on file imports). Stamped LAST so
+  // the import's own meta writes don't clear it.
+  const hubOrigin = normalizeHubOrigin(bundle.hubOrigin);
 
   const created = createScenario({
     accentColor: scenario.accentColor,
@@ -2448,43 +2478,103 @@ const importScenarioBundle = (bundle, { setSelected = true } = {}) => {
     if (!(assetKey in UPLOADABLE_SCENARIO_ASSET_FILES)) {
       continue;
     }
-
-    if (assetKey === COVER_IMAGE_ASSET_KEY) {
-      if (assetValue?.mode === "embedded") {
-        const decoded = Buffer.from(String(assetValue.data ?? ""), "base64");
-        fs.writeFileSync(getScenarioUploadPath(scenarioId, assetKey), decoded);
-        writeScenarioMeta(scenarioId, {
-          coverImageContentType: normalizeImageContentType(assetValue.contentType),
-        });
-      } else {
-        removeFileIfPresent(getScenarioUploadPath(scenarioId, assetKey));
-        writeScenarioMeta(scenarioId, { coverImageContentType: null });
-      }
-      continue;
-    }
-
-    if (assetValue?.mode === "embedded") {
-      if (assetKey in OPTIONAL_JSON_ASSET_FILES) {
-        writeJsonFile(getScenarioJsonPath(scenarioId, assetKey), assetValue.data ?? {});
-      } else {
-        const decoded = Buffer.from(String(assetValue.data ?? ""), "base64");
-        fs.writeFileSync(getScenarioUploadPath(scenarioId, assetKey), decoded);
-      }
-      continue;
-    }
-
-
-    if (assetKey in OPTIONAL_JSON_ASSET_FILES) {
-      removeFileIfPresent(getScenarioJsonPath(scenarioId, assetKey));
-    }
-    removeFileIfPresent(getScenarioUploadPath(scenarioId, assetKey));
+    applyScenarioBundleAsset(scenarioId, assetKey, assetValue);
   }
 
-  writeScenarioMeta(scenarioId, {});
+  writeScenarioMeta(scenarioId, hubOrigin ? { hubOrigin } : {});
 
   if (setSelected) {
     setSelectedScenario(scenarioId);
   }
+
+  return getScenarioDetails(scenarioId);
+};
+
+// Write one bundle asset slot onto a scenario: embedded content lands on disk,
+// anything else clears the slot. Shared by import (which visits the keys the
+// bundle carries) and update-in-place (which visits EVERY key, so an asset the
+// new version dropped doesn't linger from the old one).
+const applyScenarioBundleAsset = (scenarioId, assetKey, assetValue) => {
+  if (assetKey === COVER_IMAGE_ASSET_KEY) {
+    if (assetValue?.mode === "embedded") {
+      const decoded = Buffer.from(String(assetValue.data ?? ""), "base64");
+      fs.writeFileSync(getScenarioUploadPath(scenarioId, assetKey), decoded);
+      writeScenarioMeta(scenarioId, {
+        coverImageContentType: normalizeImageContentType(assetValue.contentType),
+      });
+    } else {
+      removeFileIfPresent(getScenarioUploadPath(scenarioId, assetKey));
+      writeScenarioMeta(scenarioId, { coverImageContentType: null });
+    }
+    return;
+  }
+
+  if (assetValue?.mode === "embedded") {
+    if (assetKey in OPTIONAL_JSON_ASSET_FILES) {
+      writeJsonFile(getScenarioJsonPath(scenarioId, assetKey), assetValue.data ?? {});
+    } else {
+      const decoded = Buffer.from(String(assetValue.data ?? ""), "base64");
+      fs.writeFileSync(getScenarioUploadPath(scenarioId, assetKey), decoded);
+    }
+    return;
+  }
+
+  if (assetKey in OPTIONAL_JSON_ASSET_FILES) {
+    removeFileIfPresent(getScenarioJsonPath(scenarioId, assetKey));
+  }
+  removeFileIfPresent(getScenarioUploadPath(scenarioId, assetKey));
+};
+
+// The "Update" path for a hub-imported scenario: replace an EXISTING scenario's
+// content with a fresh bundle. Keeps the local id (games reference scenarios by
+// id, so their link survives) and createdAt; the name, description, world, and
+// assets all come from the new bundle, and every uploadable asset the bundle
+// doesn't carry is cleared. The new hubOrigin is stamped last, so the card's
+// Update button reverts to New Game once the catalog refreshes.
+const updateScenarioFromBundle = (scenarioId, bundle) => {
+  ensureScenarioStore();
+
+  if (!bundle || typeof bundle !== "object") {
+    throw new Error("Scenario bundle must be a JSON object.");
+  }
+  if (!ACCEPTED_BUNDLE_SCHEMAS.has(bundle.schema)) {
+    throw new Error("Unsupported scenario bundle schema.");
+  }
+  if (!fs.existsSync(getScenarioMetaPath(scenarioId))) {
+    throw new Error(`Scenario not found: ${scenarioId}`);
+  }
+
+  const scenario = bundle.scenario && typeof bundle.scenario === "object" ? bundle.scenario : {};
+  const data = bundle.data && typeof bundle.data === "object" ? bundle.data : {};
+  const assets = bundle.assets && typeof bundle.assets === "object" ? bundle.assets : {};
+  const hubOrigin = normalizeHubOrigin(bundle.hubOrigin);
+
+  const metaPatch = {};
+  for (const key of ["accentColor", "name", "subtitle", "description", "eyebrow", "heroTitle", "heroSubtitle"]) {
+    if (scenario[key] != null) metaPatch[key] = scenario[key];
+  }
+  if (scenario.countryNameOverrides && typeof scenario.countryNameOverrides === "object") {
+    metaPatch.countryNameOverrides = scenario.countryNameOverrides;
+  }
+  writeScenarioMeta(scenarioId, metaPatch);
+
+  updateScenario(scenarioId, {
+    game: data.game ?? {},
+    prompts: data.prompts ?? {},
+    storage: {
+      actions: data.actions ?? [],
+      advisor: data.advisor ?? [],
+      chat: data.chat ?? [],
+      events: data.events ?? [],
+    },
+    world: data.world ?? {},
+  });
+
+  for (const assetKey of Object.keys(UPLOADABLE_SCENARIO_ASSET_FILES)) {
+    applyScenarioBundleAsset(scenarioId, assetKey, assets[assetKey]);
+  }
+
+  writeScenarioMeta(scenarioId, hubOrigin ? { hubOrigin } : {});
 
   return getScenarioDetails(scenarioId);
 };
@@ -2505,6 +2595,7 @@ export {
   getScenarioDetails,
   getSelectedScenarioSummary,
   importScenarioBundle,
+  updateScenarioFromBundle,
   readRuntimeJsonAsset,
   removeGameAsset,
   removeScenarioAsset,

--- a/server/server.js
+++ b/server/server.js
@@ -18,6 +18,7 @@ import {
   getScenarioCatalog,
   getScenarioDetails,
   importScenarioBundle,
+  updateScenarioFromBundle,
   readRuntimeJsonAsset,
   removeGameAsset,
   removeScenarioAsset,
@@ -308,6 +309,16 @@ app.get("/api/scenarios/:scenarioId/export", (req, res) => {
 app.post("/api/scenarios/import", largeJsonParser, (req, res) => {
   try {
     res.status(201).json(importScenarioBundle(req.body ?? {}, { setSelected: true }));
+  } catch (error) {
+    sendError(res, 400, error);
+  }
+});
+
+// Replace an existing scenario's content with a fresh bundle — the community
+// hub's "Update" button for scenarios imported unmodified from a post.
+app.put("/api/scenarios/:scenarioId/import", largeJsonParser, (req, res) => {
+  try {
+    res.json(updateScenarioFromBundle(req.params.scenarioId, req.body ?? {}));
   } catch (error) {
     sendError(res, 400, error);
   }

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -145,6 +145,42 @@ export const fetchHubPosts = async ({ force = false } = {}) => {
   return posts;
 };
 
+// Download + assemble a hub post's scenario bundle, ready for import: fetches
+// through the server's allowlisted /api/hub/file proxy, unpacks a .zip (re-
+// embedding the basemap that rides alongside scenario.json), and inlines a
+// referenced community basemap. Shared by the Community tab's Import button and
+// the Scenarios tab's Update button (which lazy-loads this module).
+export const downloadHubBundle = async (bundleUrl) => {
+  const response = await fetch(`/api/hub/file?url=${encodeURIComponent(bundleUrl)}`);
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(payload.error || `Download failed (HTTP ${response.status}).`);
+  }
+  // A scenario with a custom basemap ships as a .zip (scenario.json + the raw
+  // basemap file + preview); everything else is a plain JSON bundle. The basemap
+  // is an image (basemap.png/jpg…) or a generated vector (basemap.geojson).
+  let bundle;
+  if (/\.zip(\?|$)/i.test(bundleUrl)) {
+    const zip = await unzipBundle(await response.arrayBuffer());
+    const scenarioText = await zip.text("scenario.json");
+    if (!scenarioText) throw new Error("That .zip is missing scenario.json.");
+    bundle = JSON.parse(scenarioText);
+    const imageName = zip.names().find((n) => /(^|\/)basemap\.(png|jpe?g|webp|gif|svg)$/i.test(n));
+    if (imageName) {
+      embedScenarioBundleImage(bundle, await zip.bytes(imageName), imageName);
+    } else {
+      const vectorName = zip.names().find((n) => /(^|\/)basemap\.geojson$/i.test(n));
+      if (vectorName) embedScenarioBundleVector(bundle, await zip.bytes(vectorName));
+    }
+  } else {
+    bundle = await response.json();
+  }
+  // A shared scenario may reference a community basemap instead of embedding
+  // it — fetch and inline it before importing so the map isn't blank.
+  await resolveScenarioBundleBackground(bundle);
+  return bundle;
+};
+
 const saveBlobToDisk = (blob, fileName) => {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
@@ -471,33 +507,12 @@ const CommunityPanel = ({ onImported }) => {
     setBusyId(post.id);
     clearBanners();
     try {
-      const response = await fetch(`/api/hub/file?url=${encodeURIComponent(post.bundleUrl)}`);
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({}));
-        throw new Error(payload.error || `Download failed (HTTP ${response.status}).`);
-      }
-      // A scenario with a custom basemap ships as a .zip (scenario.json + the raw
-      // basemap file + preview); everything else is a plain JSON bundle. The basemap
-      // is an image (basemap.png/jpg…) or a generated vector (basemap.geojson).
-      let bundle;
-      if (/\.zip(\?|$)/i.test(post.bundleUrl)) {
-        const zip = await unzipBundle(await response.arrayBuffer());
-        const scenarioText = await zip.text("scenario.json");
-        if (!scenarioText) throw new Error("That .zip is missing scenario.json.");
-        bundle = JSON.parse(scenarioText);
-        const imageName = zip.names().find((n) => /(^|\/)basemap\.(png|jpe?g|webp|gif|svg)$/i.test(n));
-        if (imageName) {
-          embedScenarioBundleImage(bundle, await zip.bytes(imageName), imageName);
-        } else {
-          const vectorName = zip.names().find((n) => /(^|\/)basemap\.geojson$/i.test(n));
-          if (vectorName) embedScenarioBundleVector(bundle, await zip.bytes(vectorName));
-        }
-      } else {
-        bundle = await response.json();
-      }
-      // A shared scenario may reference a community basemap instead of embedding
-      // it — fetch and inline it before importing so the map isn't blank.
-      await resolveScenarioBundleBackground(bundle);
+      const bundle = await downloadHubBundle(post.bundleUrl);
+      // Provenance: which post and which exact bundle file this copy came from.
+      // The library's Scenarios tab compares this against the post's CURRENT
+      // bundle URL to offer an Update button — and drops it the moment the
+      // scenario is modified locally (see writeScenarioMeta).
+      bundle.hubOrigin = { postId: post.id, bundleUrl: post.bundleUrl };
       const details = await importScenarioBundle(bundle);
       // Best-effort: tell the server this import succeeded so it can count it
       // (once per install) on the hub's self-hosted import counter. Never blocks

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -15,6 +15,7 @@ import {
   ensureLibraryCatalog,
   exportScenarioBundle,
   importScenarioBundle,
+  updateScenarioFromBundle,
   loadGameDetails,
   loadScenarioDetails,
   refreshLibraryCatalog,
@@ -338,7 +339,7 @@ const PromptSectionEditor = ({
   );
 };
 
-const ScenarioCard = ({ onClone, onEdit, onPlay, onSelect, scenario, selected }) => {
+const ScenarioCard = ({ onClone, onEdit, onPlay, onSelect, onUpdate, scenario, selected, updateAvailable }) => {
   const isBuiltIn = scenario.id === "default";
   const assetBadges = Object.entries(scenarioBadgeLabels)
     .filter(([key]) => scenario.assetStatus?.[key])
@@ -466,18 +467,23 @@ const ScenarioCard = ({ onClone, onEdit, onPlay, onSelect, scenario, selected })
           </div>
           <AssetBadgeRow badges={assetBadges} />
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.55rem" }}>
+            {/* A hub-imported, unmodified scenario whose post has a newer bundle
+                swaps its primary action for Update; everyone else starts games. */}
             <button
-              onClick={() => onPlay(scenario)}
+              onClick={() => (updateAvailable ? onUpdate(scenario) : onPlay(scenario))}
               style={{
                 ...actionButtonStyle,
-                background: `${scenario.accentColor}cc`,
-                borderColor: `${scenario.accentColor}dd`,
+                background: updateAvailable ? "#1d7f4ccc" : `${scenario.accentColor}cc`,
+                borderColor: updateAvailable ? "#27a663dd" : `${scenario.accentColor}dd`,
                 color: "#fff",
                 flex: 1,
               }}
+              title={updateAvailable
+                ? "A newer version of this scenario is on the community hub. Updating replaces this copy (existing games keep working)."
+                : undefined}
               type="button"
             >
-              New Game
+              {updateAvailable ? "⬆ Update" : "New Game"}
             </button>
             <button onClick={() => onEdit(scenario.id)} style={{ ...actionButtonStyle, flex: 1 }} type="button">
               Edit
@@ -1174,6 +1180,57 @@ const LibraryTopBar = () => {
         }
       })
       .catch(() => setCountryOptions([]));
+  };
+
+  // Hub update detection: scenarios imported straight from the community tab
+  // (and not modified since) carry hubOrigin. When the Scenarios tab shows any,
+  // fetch the hub posts (lazily — same chunk as the Community tab, and the
+  // module's 5-minute cache dedupes) and compare each post's CURRENT bundle
+  // file against the one imported. A silent failure just means no Update
+  // buttons — offline behaves exactly as before.
+  const [hubPostById, setHubPostById] = useState(null);
+  useEffect(() => {
+    if (activeTab !== "scenarios" || !scenarios.some((entry) => entry.hubOrigin)) return undefined;
+    let cancelled = false;
+    import("./communityHub.jsx")
+      .then(({ fetchHubPosts }) => fetchHubPosts())
+      .then((posts) => {
+        if (cancelled) return;
+        const byId = {};
+        for (const post of posts) byId[post.id] = post;
+        setHubPostById(byId);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, scenarios]);
+
+  const scenarioUpdateAvailable = (scenario) => Boolean(
+    scenario.hubOrigin &&
+    hubPostById?.[scenario.hubOrigin.postId]?.bundleUrl &&
+    hubPostById[scenario.hubOrigin.postId].bundleUrl !== scenario.hubOrigin.bundleUrl,
+  );
+
+  // Pull the post's current bundle and replace this scenario in place. The
+  // scenario keeps its local id, so existing games keep pointing at it; the
+  // fresh hubOrigin stamp flips the card back to New Game on refresh.
+  const handleScenarioUpdate = async (scenario) => {
+    const post = scenario.hubOrigin ? hubPostById?.[scenario.hubOrigin.postId] : null;
+    if (!post?.bundleUrl) return;
+    setEditorError(null);
+    setIsBusy(true);
+
+    try {
+      const { downloadHubBundle } = await import("./communityHub.jsx");
+      const bundle = await downloadHubBundle(post.bundleUrl);
+      bundle.hubOrigin = { postId: post.id, bundleUrl: post.bundleUrl };
+      await updateScenarioFromBundle(scenario.id, bundle);
+    } catch (nextError) {
+      setEditorError(`Update failed: ${nextError.message}`);
+    } finally {
+      setIsBusy(false);
+    }
   };
 
   const handleScenarioClone = async (scenario) => {
@@ -2069,8 +2126,10 @@ const LibraryTopBar = () => {
                       onEdit={openScenarioEditor}
                       onPlay={handleScenarioPlay}
                       onSelect={selectScenario}
+                      onUpdate={handleScenarioUpdate}
                       scenario={scenario}
                       selected={scenario.id === selectedScenarioId}
+                      updateAvailable={scenarioUpdateAvailable(scenario)}
                     />
                   ))}
             </div>

--- a/src/runtime/library.js
+++ b/src/runtime/library.js
@@ -331,6 +331,18 @@ export const importScenarioBundle = async (bundle) => {
   return details;
 };
 
+// Replace an existing scenario's content with a fresh bundle — the hub's
+// "Update" button. Keeps the local scenario id, so games that reference it
+// keep working.
+export const updateScenarioFromBundle = async (scenarioId, bundle) => {
+  const details = await requestJson(`${SCENARIOS_API_ROOT}/${encodeURIComponent(scenarioId)}/import`, {
+    body: bundle,
+    method: "PUT",
+  });
+  await refreshLibraryCatalog({ force: true });
+  return details;
+};
+
 export const loadGameDetails = async (gameId) =>
   requestJson(`${GAMES_API_ROOT}/${encodeURIComponent(gameId)}`);
 

--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -19,7 +19,7 @@ import {
   DEFAULT_SCENARIO_META, DEFAULT_GAME_META, canonicalizeWorldCountryRefs, canonicalizeGameCountry, canonicalizeColorKeys,
   readScenarioMeta, readGameMeta, readStoredImageContentType, resolveOrderedIds, normalizeId,
   scenarioLooksLikeRuntimeSnapshot, buildFreshGameSeedFromScenario, buildFreshWorldSeedFromScenario,
-  normalizeRuntimeWorld, COUNTRY_NAME_REGISTRY,
+  normalizeRuntimeWorld, COUNTRY_NAME_REGISTRY, normalizeHubOrigin,
 } from "./models.js";
 // Imported, not mirrored: server/ownerMigration.js is pure ESM with no node
 // imports, so Vite bundles it into the web build. One implementation of the
@@ -89,6 +89,12 @@ const writeScenarioMeta = (record, updates = {}) => {
         : current.coverImageContentType,
     countryNameOverrides: updates.countryNameOverrides && typeof updates.countryNameOverrides === "object"
       ? updates.countryNameOverrides : current.countryNameOverrides,
+    // Hub provenance survives ONLY when a write explicitly carries it — any
+    // other meta write is a local modification, which turns the copy into a
+    // fork that must stop offering hub updates (server twin has the same rule).
+    hubOrigin: Object.prototype.hasOwnProperty.call(updates, "hubOrigin")
+      ? normalizeHubOrigin(updates.hubOrigin)
+      : null,
     id: record.id,
     updatedAt: nowIso(),
   };
@@ -857,6 +863,9 @@ const importScenarioBundle = async (bundle) => {
   // Accept every schema we can read, not just the one we write — a v1 bundle
   // imports fine, arriving unmarked and named by the migration on first read.
   if (!bundle || typeof bundle !== "object" || !ACCEPTED_BUNDLE_SCHEMAS.has(bundle.schema)) throw new Error("Unsupported scenario bundle.");
+  // Hub provenance the community tab attaches to a direct import — stamped
+  // LAST so the import's own meta writes don't clear it.
+  const hubOrigin = normalizeHubOrigin(bundle.hubOrigin);
   const created = await createScenario({ ...(bundle.scenario ?? {}), setActive: false });
   const newId = created.scenario.id;
   // Server coerces missing bundle data to empty ({} / []) which then OVERWRITES
@@ -892,8 +901,70 @@ const importScenarioBundle = async (bundle) => {
       await removeScenarioAsset(newId, key);
     }
   }
+  if (hubOrigin) {
+    const record = await getScenario(newId);
+    writeScenarioMeta(record, { hubOrigin });
+    await putScenario(record);
+  }
   await setSelectedScenario(newId);
   return getScenarioDetails(newId);
+};
+
+// The "Update" path for a hub-imported scenario: replace an EXISTING scenario's
+// content with a fresh bundle, keeping the local id (games reference scenarios
+// by id) and createdAt. Every uploadable asset the new bundle doesn't carry is
+// cleared so a dropped basemap or cover doesn't linger; the new hubOrigin is
+// stamped last (server twin: updateScenarioFromBundle).
+const updateScenarioFromBundle = async (scenarioId, bundle) => {
+  if (!bundle || typeof bundle !== "object" || !ACCEPTED_BUNDLE_SCHEMAS.has(bundle.schema)) throw new Error("Unsupported scenario bundle.");
+  const existing = await getScenario(scenarioId);
+  if (!existing) throw new Error(`Scenario not found: ${scenarioId}`);
+  const scenario = bundle.scenario && typeof bundle.scenario === "object" ? bundle.scenario : {};
+  const data = bundle.data ?? {};
+  const hubOrigin = normalizeHubOrigin(bundle.hubOrigin);
+
+  const metaPatch = {};
+  for (const key of ["accentColor", "name", "subtitle", "description", "eyebrow", "heroTitle", "heroSubtitle"]) {
+    if (scenario[key] != null) metaPatch[key] = scenario[key];
+  }
+  if (scenario.countryNameOverrides && typeof scenario.countryNameOverrides === "object") {
+    metaPatch.countryNameOverrides = scenario.countryNameOverrides;
+  }
+  writeScenarioMeta(existing, metaPatch);
+  await putScenario(existing);
+
+  await updateScenario(scenarioId, {
+    game: data.game ?? {}, prompts: data.prompts ?? {}, world: data.world ?? {},
+    storage: { actions: data.actions ?? [], advisor: data.advisor ?? [], chat: data.chat ?? [], events: data.events ?? [] },
+  });
+
+  for (const key of UPLOADABLE_SCENARIO_ASSET_KEYS) {
+    const descriptor = (bundle.assets ?? {})[key];
+    const embedded = descriptor?.mode === "embedded";
+    if (key === COVER_IMAGE_ASSET_KEY) {
+      if (embedded && descriptor.data) await uploadScenarioAsset(scenarioId, key, base64ToBytes(descriptor.data), descriptor.contentType);
+      else await removeScenarioAsset(scenarioId, key);
+    } else if (OPTIONAL_JSON_ASSET_KEYS.includes(key)) {
+      // JSON descriptor assets carry the object itself, not base64 (see the
+      // matching branch in importScenarioBundle above).
+      const r = await getScenario(scenarioId);
+      if (embedded && descriptor.data !== undefined) r[key] = descriptor.data;
+      else delete r[key];
+      writeScenarioMeta(r, {});
+      await putScenario(r);
+    } else if (embedded && typeof descriptor.data === "string") {
+      await uploadScenarioAsset(scenarioId, key, base64ToBytes(descriptor.data), descriptor.contentType);
+    } else {
+      await removeScenarioAsset(scenarioId, key);
+    }
+  }
+
+  if (hubOrigin) {
+    const record = await getScenario(scenarioId);
+    writeScenarioMeta(record, { hubOrigin });
+    await putScenario(record);
+  }
+  return getScenarioDetails(scenarioId);
 };
 
 // --- pmtiles override (runtime binary) ------------------------------------
@@ -957,6 +1028,7 @@ export const handleScenarios = async ({ method, segments, body, rawBody, content
       if (method === "DELETE") return jsonResponse(await deleteScenario(id));
       return null;
     }
+    if (sub === "import" && method === "PUT") return jsonResponse(await updateScenarioFromBundle(id, body ?? {}));
     if (sub === "export" && method === "GET") return jsonResponse(await exportScenarioBundle(id, query?.get("mode") || "light"));
     if (sub === "assets" && segments[2]) {
       const key = decodeURIComponent(segments[2]);

--- a/src/runtime/web/models.js
+++ b/src/runtime/web/models.js
@@ -174,6 +174,22 @@ export const readStoredImageContentType = (value) =>
     ? value.trim().toLowerCase()
     : null;
 
+// Hub-import provenance (server/libraryStore.js normalizeHubOrigin twin): the
+// post's issue number + the exact bundle URL imported. A post whose current
+// bundleUrl differs from this has an update (attachment URLs are immutable —
+// a new upload gets a new URL).
+export const normalizeHubOrigin = (raw) => {
+  if (!raw || typeof raw !== "object") return null;
+  const postId = Number(raw.postId);
+  const bundleUrl = String(raw.bundleUrl ?? "").trim();
+  if (!Number.isFinite(postId) || postId <= 0 || !bundleUrl) return null;
+  return {
+    bundleUrl,
+    postId,
+    syncedAt: String(raw.syncedAt ?? "").trim() || nowIso(),
+  };
+};
+
 export const readScenarioMeta = (scenarioId, raw = {}) => {
   const name = String(raw?.name ?? "").trim() || DEFAULT_SCENARIO_META.name;
   const subtitle = String(raw?.subtitle ?? "").trim() || DEFAULT_SCENARIO_META.subtitle;
@@ -187,6 +203,7 @@ export const readScenarioMeta = (scenarioId, raw = {}) => {
     eyebrow: String(raw?.eyebrow ?? "").trim() || DEFAULT_SCENARIO_META.eyebrow,
     heroSubtitle: String(raw?.heroSubtitle ?? "").trim() || description,
     heroTitle: String(raw?.heroTitle ?? "").trim() || name,
+    hubOrigin: normalizeHubOrigin(raw?.hubOrigin),
     id: scenarioId,
     name,
     subtitle,


### PR DESCRIPTION
Scenarios imported **directly from the community tab, with no local modifications**, now track their source post. When the author uploads a new bundle to that post, the scenario card's **New Game** button is replaced by a green **⬆ Update** button; with no update available (or after updating), it shows New Game exactly as before.

How it works:
- Import records `hubOrigin` — the post's issue number + the exact bundle attachment URL (both server and web/mobile stores). GitHub attachment URLs are immutable (a re-upload mints a new URL), so "post's current URL ≠ recorded URL" IS the update signal — no hashing, no extra metadata on posts.
- The Scenarios tab checks lazily: hub posts are fetched (through the community module's existing 5-minute cache) only when a hub-imported scenario is actually visible. Offline or rate-limited just means no Update buttons.
- **Update replaces the scenario in place**: local id preserved (existing games keep working), createdAt preserved, content/name/assets all from the new bundle, and assets the new version dropped are cleared. The fresh provenance stamp flips the button back to New Game.
- **"No modifications" is structural**: any scenario edit — rename, editor apply, cover change — clears the provenance, so a locally-forked copy never gets an update offer that would overwrite the player's work. Plain file imports carry no provenance and behave exactly as today.

New API: `PUT /api/scenarios/:id/import` (replace-from-bundle), on both the Express server and the web store router.

Verified end to end on the dev server: import stamps provenance → outdated URL shows the green Update on the card (screenshot-verified) → updating replaced the scenario in place with the post's real bundle (id preserved) → the card reverted to New Game → a local rename cleared provenance.