### PR TITLE
Settings: toggle to remove the AI generation time limit entirely

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -41,6 +41,7 @@ import {
   writeWorldState,
 } from "../../runtime/gameState.js";
 import { difficultyDirective } from "../../runtime/difficulty.js";
+import { MAP_SETTING_KEYS, getMapSetting } from "../../runtime/mapSettings.js";
 
 const CHAT_HINT_PATTERNS = [
   /\bchat\b/i,
@@ -1599,7 +1600,9 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
     // of silently swapping in the canned fallback. Five minutes covers even a
     // large reasoning model writing 37 events; the bound only exists so a
     // genuinely hung request can't spin forever (Cancel works throughout).
-    timeoutMs: 300000,
+    // The settings toggle removes the bound entirely: 0 disables the deadline
+    // in runJsonTask, so only a real error (or Cancel) can end the wait.
+    timeoutMs: getMapSetting(MAP_SETTING_KEYS.noAiTimeLimit) ? 0 : 300000,
     userMessage:
       mode === "auto"
         ? "Simulate an auto-jump and stop at the next notable or player-relevant event. Return JSON only. " +

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -794,6 +794,7 @@ const SettingsMenu = ({
         hideCountryLabels: getMapSetting(MAP_SETTING_KEYS.hideCountryLabels),
         disableIdleRotation: getMapSetting(MAP_SETTING_KEYS.disableIdleRotation),
         disableEventCamera: getMapSetting(MAP_SETTING_KEYS.disableEventCamera),
+        noAiTimeLimit: getMapSetting(MAP_SETTING_KEYS.noAiTimeLimit),
     }));
 
     const updateMapSetting = (stateKey, settingKey, value) => {
@@ -895,6 +896,18 @@ const SettingsMenu = ({
         />
         </div>
         <ComingSoonToggle label="Country borders" note="Not available yet — coming soon." />
+
+        <div style={{ margin: "0.5rem 0 1rem", paddingTop: "0.75rem", borderTop: "1px solid rgba(255,255,255,0.1)" }}>
+        <div style={{ fontSize: "0.84rem", fontWeight: 700, marginBottom: "0.6rem" }}>AI</div>
+        <Toggle
+        label="No time limit on AI generation"
+        enabled={mapSettings.noAiTimeLimit}
+        onToggle={() => updateMapSetting("noAiTimeLimit", MAP_SETTING_KEYS.noAiTimeLimit, !mapSettings.noAiTimeLimit)}
+        />
+        <div style={{ marginTop: "-0.7rem", marginBottom: "0.4rem", fontSize: "0.72rem", color: "rgba(255,255,255,0.45)", lineHeight: 1.35 }}>
+        Time skips wait as long as the model needs — fallback events can never replace a slow generation. Off: 5-minute limit. Cancel works either way.
+        </div>
+        </div>
 
         {typeof onOpenCheats === "function" && (
             <button

--- a/src/runtime/mapSettings.js
+++ b/src/runtime/mapSettings.js
@@ -10,6 +10,10 @@ export const MAP_SETTING_KEYS = {
     hideCountryLabels: "map_hide_country_labels",
     disableIdleRotation: "map_disable_idle_rotation",
     disableEventCamera: "map_disable_event_camera",
+    // Not a map setting, but the same localStorage-toggle mechanism: when on,
+    // timeline-jump generation has NO deadline — the canned fallback can only
+    // be reached through a real error, never a slow model (Cancel still works).
+    noAiTimeLimit: "ai_no_time_limit",
 };
 
 export function getMapSetting(key) {


### PR DESCRIPTION
Follow-up to the just-merged 5-minute change (#325-#327): the promised settings toggle rode the same branches but landed AFTER the merge, so it never reached the channels. This delivers it.

A new **AI** section in Game Settings gains "**No time limit on AI generation**". On: a time skip waits as long as the model needs — the deadline is disabled outright (0 disables it in runJsonTask), so fallback events can only appear on a real error, never a slow generation; Cancel works throughout. Off: the 5-minute bound. Read at jump time (no reload needed), stored via the same localStorage toggle mechanism as the map settings.

Mechanism verified live in the dev app: toggling flips the jump's effective deadline between disabled and 300000ms, persisting across the settings round-trip.