### PR TITLE
AI: string tool_choice — fixes local-model (llama.cpp/LM Studio) tool forcing

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -535,7 +535,14 @@ async function callOpenAIStyleChatCompletions({
                         description: tool.description,
                         parameters: tool.schema,
                     } }],
-                    tool_choice: { type: "function", function: { name: tool.name } },
+                    // The string form, NOT OpenAI's {type:"function",function:{name}}
+                    // object: llama.cpp-based servers (LM Studio, Jan, local Qwen et
+                    // al.) only parse a string here — the object form logged
+                    // "Wrong type supplied for parameter 'tool_choice'" every jump
+                    // and silently fell back to "auto", losing the forcing. Exactly
+                    // one tool is ever sent, so "required" (accepted by OpenAI and
+                    // the compatible gateways alike) forces that same tool.
+                    tool_choice: "required",
                 } : {}),
                 ...(structuredMode === "json_schema" ? {
                     response_format: { type: "json_schema", json_schema: {


### PR DESCRIPTION
Fixes the warning a Discord user reported with a local Qwen 3.6 35B-A3B:

```
Wrong type supplied for parameter 'tool_choice'. Expected 'string', using default value: [json.exception.type_error.302] type must be string, but is object
```

That error signature is llama.cpp's JSON parser — LM Studio/Jan/local servers only accept `tool_choice` as a **string**, while the game sent OpenAI's object form `{"type":"function","function":{"name":…}}`. The server ignored it and fell back to `auto`, so the report is right that nothing visibly broke (the prompt still describes the format and freeform JSON is parsed as a fallback) — but the structured-output **forcing was silently lost on every jump** for every local model, making malformed responses more likely than they need to be.

The game only ever sends **one** tool per request on this path, so the string `"required"` — accepted by OpenAI and the compatible gateways alike — forces that same single tool. Local servers regain real tool-forcing, the per-jump warning disappears, and cloud providers behave identically. The Anthropic-native path (`{type:"tool"}`) is untouched — that object form is correct for Anthropic's own API.