### PR TITLE
Jumps: salvage stray dates instead of trashing the turn to the fallback

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -165,6 +165,38 @@ const validateTimelineDates = ({ candidate, mode, originDate, targetDate }) => {
   return "";
 };
 
+// Attempt-2 salvage for timeline dates: rather than discarding a finished
+// (possibly very long) generation to the canned fallback because the model
+// simulated a little past the window, pull the strays in. Events dated on or
+// before the origin land on the first simulated day, events past the stop land
+// on the stop date, unparseable dates become the stop date, and ordering is
+// restored monotonically. The CONTENT is untouched — a good story with sloppy
+// dates beats canned events every time (a 1-day skip whose model "kept going"
+// used to trash the whole turn exactly this way).
+export const clampTimelineDates = (candidate, { mode, originDate, targetDate }) => {
+  if (!parseIsoDate(originDate)) return; // textual/BCE scenarios use the lenient branch
+  const dayAfterOrigin = addIsoDays(originDate, 1) || targetDate;
+  let stopDate = normalizeString(candidate?.stopDate);
+  if (mode === "auto") {
+    if (!parseIsoDate(stopDate) || stopDate <= originDate || stopDate > targetDate) stopDate = targetDate;
+  } else {
+    stopDate = targetDate;
+  }
+  candidate.stopDate = stopDate;
+  const floor = dayAfterOrigin > stopDate ? stopDate : dayAfterOrigin;
+  let previous = floor;
+  for (const event of normalizeArray(candidate?.events)) {
+    if (!event || typeof event !== "object") continue;
+    let date = normalizeString(event.date);
+    if (!parseIsoDate(date)) date = stopDate;
+    if (date <= originDate) date = floor;
+    if (date > stopDate) date = stopDate;
+    if (date < previous) date = previous;
+    event.date = date;
+    previous = date;
+  }
+};
+
 const sentenceCase = (value) => {
   const text = normalizeString(value);
   if (!text) return "";
@@ -1613,12 +1645,22 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
            `spread across the skipped period.`,
     validatePayload: async (candidate) => {
       validationAttempts += 1;
+      // Shape-of-story problems (event count, stray dates) are STRICT on the
+      // first attempt — the model gets the exact error and usually fixes its
+      // own answer — and SALVAGED on the second: a finished generation must
+      // never lose to the canned fallback over its date stamps or an extra
+      // event. Only real errors reach the fallback now.
+      const strict = validationAttempts === 1;
       const eventCount = normalizeArray(candidate?.events).length;
-      if (mode !== "auto" && (eventCount < minEvents || eventCount > maxEvents)) {
+      if (strict && mode !== "auto" && (eventCount < minEvents || eventCount > maxEvents)) {
         return `$.events must contain between ${minEvents} and ${maxEvents} events; received ${eventCount}.`;
       }
-      return validateTimelineDates({ candidate, mode, originDate, targetDate }) ||
-        await validateGeneratedWorldChanges(candidate, bundle.world, { strictTransfers: validationAttempts === 1 });
+      const dateError = validateTimelineDates({ candidate, mode, originDate, targetDate });
+      if (dateError) {
+        if (strict) return dateError;
+        clampTimelineDates(candidate, { mode, originDate, targetDate });
+      }
+      return await validateGeneratedWorldChanges(candidate, bundle.world, { strictTransfers: strict });
     },
     variables,
   });


### PR DESCRIPTION
Fixes the Discord report: a 1-day skip whose model kept simulating past the window lost the ENTIRE generation — date validation rejected it twice (`$.events[0].date must be after 2016-01-01 and no later than 2016-01-02`) and the canned fallback replaced the turn, which is brutal with the no-time-limit setting where a generation can run a long while.

Shape-of-story validation is now **strict once, then salvage**:
- **Attempt 1**: the model gets the exact date/count error back and usually fixes its own answer (existing retry machinery).
- **Attempt 2**: the turn is salvaged instead of rejected — stray event dates are clamped into the window (on-or-before origin → first simulated day; past the stop → the stop date; unparseable → the stop date; ordering restored monotonically), and an off-count event list is accepted. Event CONTENT is never touched, only date stamps. Only genuine errors (malformed payloads, provider failures) can still reach the canned fallback.
- Auto-jumps keep the model's own stop date when valid; textual/BCE scenario dates keep their existing lenient path untouched.

Verified via the exported clamp against the reported case (all strays land on the 1-day target), the auto-jump regime, and BCE scenarios (untouched).