### PR TITLE
Remove the country-borders experiment; move manual deployment into Cheats

### DIFF
--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -959,18 +959,13 @@ const Chat = ({ hovered, setHovered, isOpen, onToggle }) => {
 
 // ── Toolbar ───────────────────────────────────────────────────────────────────
 
-const Toolbar = memo(({ onOpenAdvisor, activePanel, onTogglePanel, forcesOpen = false, onToggleForces }) => {
+const Toolbar = memo(({ onOpenAdvisor, activePanel, onTogglePanel }) => {
     const [hoveredChat, setHoveredChat]       = useState(false);
     const [hoveredActions, setHoveredActions] = useState(false);
-    const [hoveredForces, setHoveredForces]   = useState(false);
     return (
-        <div style={{ position: "fixed", bottom: "0.5rem", left: "0.5rem", height: "4rem", width: "12.5rem", gap: "0.75rem", padding: "0 0.1rem", backgroundColor: "rgba(17,24,39,0.9)", backdropFilter: "blur(4px)", zIndex: 9999, display: "flex", alignItems: "center", justifyContent: "center", color: "white", fontFamily: "sans-serif", borderRadius: "14px", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 8px 24px rgba(0,0,0,0.5),inset 0 1px 0 rgba(255,255,255,0.05)" }}>
+        <div style={{ position: "fixed", bottom: "0.5rem", left: "0.5rem", height: "4rem", width: "8.75rem", gap: "0.75rem", padding: "0 0.1rem", backgroundColor: "rgba(17,24,39,0.9)", backdropFilter: "blur(4px)", zIndex: 9999, display: "flex", alignItems: "center", justifyContent: "center", color: "white", fontFamily: "sans-serif", borderRadius: "14px", border: "1px solid rgba(255,255,255,0.08)", boxShadow: "0 8px 24px rgba(0,0,0,0.5),inset 0 1px 0 rgba(255,255,255,0.05)" }}>
         <Chat hovered={hoveredChat} setHovered={setHoveredChat} isOpen={activePanel === "chat"} onToggle={() => onTogglePanel("chat")} />
         <Actions onOpenAdvisor={onOpenAdvisor} hovered={hoveredActions} setHovered={setHoveredActions} isOpen={activePanel === "actions"} onToggle={() => onTogglePanel("actions")} />
-        {/* Forces — same launcher style as its toolbar siblings; panel lives in forces.jsx */}
-        <button title="Forces" style={{ width: "3.3rem", height: "3.3rem", borderRadius: "10px", border: hoveredForces ? "1px solid rgba(255,255,255,0.2)" : forcesOpen ? "1px solid rgba(139,92,246,0.5)" : "1px solid rgba(255,255,255,0.1)", background: forcesOpen ? "linear-gradient(145deg,rgba(109,40,217,0.4),rgba(76,29,149,0.4))" : hoveredForces ? "linear-gradient(145deg,rgba(40,55,80,0.95),rgba(20,30,50,0.95))" : "linear-gradient(145deg,rgba(30,42,65,0.95),rgba(15,22,40,0.95))", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", transition: "all 0.12s ease", boxShadow: hoveredForces ? "inset 0 1px 0 rgba(255,255,255,0.1),0 2px 8px rgba(0,0,0,0.4)" : "inset 0 1px 0 rgba(255,255,255,0.06),inset 0 -1px 0 rgba(0,0,0,0.3),0 2px 6px rgba(0,0,0,0.35)", fontSize: "1.2rem", outline: "none", transform: hoveredForces ? "translateY(-1px)" : "translateY(0)", color: "white", fontFamily: "sans-serif", flexShrink: 0 }}
-        onMouseEnter={() => setHoveredForces(true)} onMouseLeave={() => setHoveredForces(false)}
-        onClick={() => onToggleForces?.()}>⚔️</button>
         </div>
     );
 });

--- a/src/Game/GameUI/cheats.jsx
+++ b/src/Game/GameUI/cheats.jsx
@@ -161,7 +161,7 @@ const PolitySelect = ({ polities, value, onChange, placeholder = "Pick a country
     </select>
 );
 
-const CheatsPanel = ({ open, onClose }) => {
+const CheatsPanel = ({ open, onClose, onOpenForces }) => {
     const [tool, setTool] = useState(null);
     const [busy, setBusy] = useState(false);
     const [status, setStatus] = useState("");
@@ -284,6 +284,18 @@ const CheatsPanel = ({ open, onClose }) => {
             <>
             {header("Cheats")}
             <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", overflowY: "auto" }}>
+            {/* Manual force deployment moved here from the toolbar: hand-
+                placing troops is a cheat, not a normal play surface. */}
+            {typeof onOpenForces === "function" && (
+                <button
+                type="button"
+                onClick={onOpenForces}
+                style={{ ...buttonStyle, alignItems: "flex-start", flexDirection: "column", gap: "0.1rem", textAlign: "left" }}
+                >
+                <span style={{ fontWeight: 700 }}>⚔️ Manual force deployment</span>
+                <span style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.72rem", fontWeight: 500 }}>Open the Forces panel to spawn, move, and command units by hand.</span>
+                </button>
+            )}
             {TOOLS.map((entry) => (
                 <button
                 key={entry.id}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -306,8 +306,6 @@ const Main = ({
         onOpenAdvisor={openAdvisor}
         activePanel={activeBottomPanel}
         onTogglePanel={toggleBottomPanel}
-        forcesOpen={isForcesOpen}
-        onToggleForces={() => setIsForcesOpen((v) => !v)}
       />
       <Other rightShift={rightShift} />
       <Search mapRef={mapRef} />
@@ -329,7 +327,7 @@ const Main = ({
       </Suspense>
       <Suspense fallback={null}>
         {shouldLoadCheats && (
-          <LazyCheatsPanel open={isCheatsOpen} onClose={() => setIsCheatsOpen(false)} />
+          <LazyCheatsPanel open={isCheatsOpen} onClose={() => setIsCheatsOpen(false)} onOpenForces={() => { setIsCheatsOpen(false); setIsForcesOpen(true); }} />
         )}
       </Suspense>
       <SettingsButton

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -153,53 +153,6 @@ const LanguageSelector = () => {
     );
 };
 
-// Placeholder for the union country-border pass; stays greyed out until it is
-// production-ready (it will read the country-borders-enabled localStorage key
-// that Nations.jsx already checks). Default is off.
-const ComingSoonToggle = ({ label, note }) => (
-    <div style={{ marginBottom: "1rem" }}>
-    <div
-    style={{
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        opacity: 0.45,
-    }}
-    >
-    <span style={{ fontSize: "0.9rem" }}>{label}</span>
-    <button
-    type="button"
-    disabled
-    title={note}
-    style={{
-        width: "3.5rem",
-        height: "1.75rem",
-        borderRadius: "1rem",
-        border: "none",
-        cursor: "not-allowed",
-        position: "relative",
-        backgroundColor: "#4b5563",
-    }}
-    >
-    <div
-    style={{
-        position: "absolute",
-        top: "2px",
-        left: "2px",
-        width: "1.5rem",
-        height: "1.5rem",
-        backgroundColor: "white",
-        borderRadius: "50%",
-        boxShadow: "0 1px 2px rgba(0,0,0,0.2)",
-        pointerEvents: "none",
-    }}
-    />
-    </button>
-    </div>
-    <div style={{ ...helperStyle, marginTop: "0.2rem" }}>{note}</div>
-    </div>
-);
-
 const Toggle = ({ label, enabled, onToggle }) => (
     <div
     style={{
@@ -895,7 +848,6 @@ const SettingsMenu = ({
         onToggle={() => updateMapSetting("disableEventCamera", MAP_SETTING_KEYS.disableEventCamera, !mapSettings.disableEventCamera)}
         />
         </div>
-        <ComingSoonToggle label="Country borders" note="Not available yet — coming soon." />
 
         <div style={{ margin: "0.5rem 0 1rem", paddingTop: "0.75rem", borderTop: "1px solid rgba(255,255,255,0.1)" }}>
         <div style={{ fontSize: "0.84rem", fontWeight: 700, marginBottom: "0.6rem" }}>AI</div>

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -23,7 +23,6 @@ import { loadCountryLabelCollections } from "../../runtime/countryLabels.js";
 import { translateLabel } from "../../runtime/translator.js";
 import { MAP_SETTING_KEYS, useMapSetting } from "../../runtime/mapSettings.js";
 import { useWorldState } from "./useWorldState.js";
-import polygonClipping from "polygon-clipping";
 
 ensurePmtilesProtocol();
 const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
@@ -384,104 +383,6 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
   return { type: "FeatureCollection", features };
 };
 
-// Union country borders ship disabled — the Settings toggle is greyed out
-// ("coming soon") until the pass is production-ready. Flip the key below in
-// localStorage to preview; keep it in sync with settings.jsx.
-const COUNTRY_BORDERS_KEY = "country-borders-enabled";
-const countryBordersEnabled = () => {
-  try {
-    return localStorage.getItem(COUNTRY_BORDERS_KEY) === "1";
-  } catch {
-    return false;
-  }
-};
-
-// Era country borders (experiment, round 2): every owner's regions are
-// geometrically UNIONED and the union outline is the border — continuous by
-// construction even where neighbouring regions don't share vertices. Drawn
-// at full strength at EVERY zoom level this time.
-const computeOwnerBorderCollection = async (regionsFC, ownerById, isCancelled) => {
-  const byOwner = new Map();
-  for (const feature of regionsFC?.features ?? []) {
-    const props = feature.properties || {};
-    const id = props.id != null ? String(props.id) : "";
-    // Unclaimed land is its own "owner" so its frontier is drawn too.
-    const owner = (ownerById.get(id) ?? props.owner ?? "") || "~unclaimed";
-    const geometry = feature.geometry;
-    const polygons = geometry?.type === "Polygon"
-      ? [geometry.coordinates]
-      : geometry?.type === "MultiPolygon"
-        ? geometry.coordinates
-        : [];
-    if (!polygons.length) continue;
-    if (!byOwner.has(owner)) byOwner.set(owner, []);
-    byOwner.get(owner).push(...polygons);
-  }
-
-  // Chunked incremental union. One degenerate polygon must never poison a
-  // whole owner group — that used to make the huge "unclaimed" group fall
-  // back to raw per-region shapes, which drew a country-style border around
-  // every single region. Broken shapes are quarantined individually.
-  const unionPolygonsSafely = async (polygons, isCancelled) => {
-    const CHUNK = 40;
-    let merged = null;
-    for (let start = 0; start < polygons.length; start += CHUNK) {
-      // Yield every chunk: the incremental merge calls grow with the shape,
-      // and long synchronous stretches were felt as lag.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      if (isCancelled()) return null;
-      const chunk = polygons.slice(start, start + CHUNK);
-      let chunkResult = null;
-      try {
-        chunkResult = polygonClipping.union(...chunk);
-      } catch {
-        chunkResult = null;
-        for (const polygon of chunk) {
-          try {
-            chunkResult = chunkResult
-              ? polygonClipping.union(chunkResult, polygon)
-              : polygonClipping.union(polygon);
-          } catch {
-            // Skip just this shape; a hairline hole beats broken borders.
-          }
-        }
-      }
-      if (!chunkResult?.length) continue;
-      try {
-        merged = merged ? polygonClipping.union(merged, chunkResult) : chunkResult;
-      } catch {
-        // Keep what we have rather than losing the whole owner.
-      }
-    }
-    return merged;
-  };
-
-  const features = [];
-  for (const [owner, polygons] of byOwner) {
-    // Yield between owners so big maps don't freeze the UI while merging.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    if (isCancelled()) return null;
-    const merged = await unionPolygonsSafely(polygons, isCancelled);
-    if (isCancelled()) return null;
-    if (merged?.length) {
-      features.push({
-        type: "Feature",
-        geometry: { type: "MultiPolygon", coordinates: merged },
-        properties: { owner },
-      });
-    } else if (polygons.length) {
-      // Total failure for this owner: keep the raw shapes for the FILL but
-      // never outline them — regions must not carry country-style borders.
-      features.push({
-        type: "Feature",
-        geometry: { type: "MultiPolygon", coordinates: polygons },
-        properties: { owner, noOutline: true },
-      });
-    }
-  }
-
-  return { type: "FeatureCollection", features };
-};
 
 const WorldMap = ({ isGlobe = false }) => {
   const { current: map } = useMap();
@@ -864,34 +765,6 @@ const WorldMap = ({ isGlobe = false }) => {
     ownerLookupRef.current = ownerByRegionId;
   }, [ownerByRegionId]);
 
-  // Stable fingerprint of the ownership map: the world poll rebuilds
-  // ownerByRegionId every 5s, but border geometry only needs recomputing
-  // when an owner actually changes.
-  const computedOwnershipKey = useMemo(() => {
-    if (!customActive || !countryBordersEnabled()) return "";
-    let key = "";
-    for (const [regionId, owner] of ownerByRegionId) key += `${regionId}:${owner};`;
-    return key;
-  }, [customActive, ownerByRegionId]);
-
-  const [ownerBorderData, setOwnerBorderData] = useState(EMPTY_FEATURE_COLLECTION);
-  useEffect(() => {
-    if (!customActive || !countryBordersEnabled()) {
-      setOwnerBorderData(EMPTY_FEATURE_COLLECTION);
-      return undefined;
-    }
-    let cancelled = false;
-    computeOwnerBorderCollection(customRegionData, ownerLookupRef.current, () => cancelled)
-      .then((collection) => {
-        if (!cancelled && collection) setOwnerBorderData(collection);
-      })
-      .catch((error) => console.error("Failed to compute era borders:", error));
-    return () => {
-      cancelled = true;
-    };
-    // computedOwnershipKey stands in for ownerByRegionId's contents.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [customActive, customRegionData, computedOwnershipKey]);
 
 
   // GADM regions on custom maps paint the STOCK vector tiles (sharp geometry at
@@ -1118,24 +991,6 @@ const WorldMap = ({ isGlobe = false }) => {
             "line-opacity": customActive
               ? ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.35, 8, 0.6]
               : 0,
-          }}
-        />
-      </Source>
-
-      {/* Era country borders: OUTLINES ONLY of the colored areas. Fills stay
-          on the fast tile-painted pipeline (the union fills were the lag);
-          the union geometry draws just the lines, with dynamic zoom styling —
-          strong at world/mid zoom, fading out up close where the crisp
-          tile-rendered region borders take over. */}
-      <Source id="owner-zones-source" type="geojson" data={ownerBorderData}>
-        <Layer
-          id="owner-borders"
-          type="line"
-          filter={["!=", ["coalesce", ["get", "noOutline"], false], true]}
-          paint={{
-            "line-color": "#000",
-            "line-width": ["interpolate", ["linear"], ["zoom"], 2, 0.9, 6, 1.6],
-            "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0.85, 7, 0.85, 8.5, 0],
           }}
         />
       </Source>


### PR DESCRIPTION
Two removals, one commit each:

**The country-borders experiment is cut whole.** The greyed-out "Country borders (coming soon)" settings row is gone, along with everything backing it: the localStorage gate, the polygon-clipping union pass over every owner's regions, the ownership-fingerprint memo, the owner-zones source + border-outline layer, and the now-unused ComingSoonToggle component. Nations.jsx no longer imports polygon-clipping at all (the map editor keeps its own separate use). Zero residual references repo-wide; full `vite build` and all 24 server tests pass.

**Manual force deployment moves into Cheats.** The ⚔️ toolbar launcher is removed and the toolbar shrinks to its two real play surfaces (Chat, Actions). The Forces panel now opens from the Cheats panel via a "Manual force deployment" entry styled like the other cheat tools — same ForcesPanel, same unit interactions, just reached through Cheats where hand-placing troops belongs.