### PR TITLE
Launcher: enforce Vite 7's real Node floor with a clear message (main)

### DIFF
--- a/Launch Open Historia.bat
+++ b/Launch Open Historia.bat
@@ -54,20 +54,39 @@ if errorlevel 1 (
 )
 
 for /f "delims=" %%V in ('node --version 2^>nul') do set "NODEVER=%%V"
-REM Require Node 18+. The map-fetch/build scripts are ES modules that ancient Node
-REM (e.g. v6) can't parse, so an old version would otherwise fail later with a
-REM cryptic "Unexpected token import". Parse the major number out of "vXX.Y.Z".
-for /f "tokens=1 delims=." %%M in ("!NODEVER!") do set "NODEMAJOR=%%M"
+REM The client build runs on Vite 7, which hard-refuses anything below Node
+REM 20.19 / 22.12 partway through setup with its own cryptic message. Enforce
+REM Vite's real floor HERE with a clear message instead: pass on 20.19+, 22.12+,
+REM or any 23+. Parse major.minor out of "vXX.YY.Z".
+for /f "tokens=1,2 delims=." %%M in ("!NODEVER!") do (
+    set "NODEMAJOR=%%M"
+    set "NODEMINOR=%%N"
+)
 set "NODEMAJOR=!NODEMAJOR:v=!"
 set /a NODEMAJORNUM=NODEMAJOR 2>nul
-if !NODEMAJORNUM! LSS 18 (
-    echo [ERROR] Node.js !NODEVER! is too old - Open Historia needs Node 18 or newer.
-    echo Update Node.js ^(LTS^) from https://nodejs.org/ then run this launcher again.
+set /a NODEMINORNUM=NODEMINOR 2>nul
+set "NODEOK="
+if !NODEMAJORNUM! GEQ 23 set "NODEOK=1"
+if !NODEMAJORNUM! EQU 22 if !NODEMINORNUM! GEQ 12 set "NODEOK=1"
+if !NODEMAJORNUM! EQU 20 if !NODEMINORNUM! GEQ 19 set "NODEOK=1"
+if not defined NODEOK (
+    echo [ERROR] Node.js !NODEVER! is too old - Open Historia needs Node 22.12 or
+    echo newer ^(20.19+ also works^). Install the current LTS from: https://nodejs.org/
+    echo.
+    echo Node.js installations found on this computer:
+    where node
+    echo.
+    echo If you just installed a newer Node.js and an OLD version is listed first
+    echo above, close this window and run the launcher again - windows that were
+    echo already open keep the old PATH. If that doesn't help, uninstall the old
+    echo Node.js ^(or move the new one higher in PATH^) and retry.
     echo.
     pause
     exit /b 1
 )
-echo [OK] Node.js !NODEVER! detected.
+set "NODEPATH="
+for /f "delims=" %%P in ('where node 2^>nul') do if not defined NODEPATH set "NODEPATH=%%P"
+echo [OK] Node.js !NODEVER! detected ^(!NODEPATH!^).
 echo.
 
 REM ---- 2. Ensure world map data ----------------------------

--- a/Launch Open Historia.bat
+++ b/Launch Open Historia.bat
@@ -53,7 +53,27 @@ if errorlevel 1 (
     exit /b 1
 )
 
+set "NODEVER="
 for /f "delims=" %%V in ('node --version 2^>nul') do set "NODEVER=%%V"
+REM "where" finding node does NOT guarantee it runs here: launched "as
+REM administrator", the window gets the ADMIN account's environment, and a
+REM Node.js installed only for the normal user account isn't on that PATH.
+REM The old script parsed the resulting EMPTY output as version 0 and told
+REM players their brand-new Node was "too old". Say what actually happened.
+if not defined NODEVER (
+    echo [ERROR] Node.js was found but could not be started from this window.
+    echo Node.js installations found on this computer:
+    where node
+    echo.
+    echo This usually means the launcher was run AS ADMINISTRATOR while Node.js
+    echo is installed only for your user account. Run the launcher normally by
+    echo double-clicking it - it does NOT need administrator rights. If it still
+    echo fails, reinstall Node.js LTS from https://nodejs.org/ with the default
+    echo settings and run the launcher again in a NEW window.
+    echo.
+    pause
+    exit /b 1
+)
 REM The client build runs on Vite 7, which hard-refuses anything below Node
 REM 20.19 / 22.12 partway through setup with its own cryptic message. Enforce
 REM Vite's real floor HERE with a clear message instead: pass on 20.19+, 22.12+,

--- a/Launch Open Historia.sh
+++ b/Launch Open Historia.sh
@@ -68,6 +68,16 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 NODEVER="$(node --version 2>/dev/null)"
+# A node that resolves but produces no version output never ran (broken
+# install, wrong binary for this system). Parsing the empty string as
+# version 0 used to mislabel this "too old" — say what actually happened.
+if [ -z "$NODEVER" ]; then
+    echo "[ERROR] Node.js was found at $(command -v node) but could not be run."
+    echo "Reinstall Node.js LTS from https://nodejs.org/ then run this launcher"
+    echo "again in a NEW terminal."
+    echo ""
+    exit 1
+fi
 # The client build runs on Vite 7, which hard-refuses anything below Node
 # 20.19 / 22.12 partway through setup with its own cryptic message. Enforce
 # Vite's real floor HERE with a clear message instead: pass on 20.19+, 22.12+,

--- a/Launch Open Historia.sh
+++ b/Launch Open Historia.sh
@@ -68,18 +68,31 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 NODEVER="$(node --version 2>/dev/null)"
-# Require Node 18+. The map-fetch/build scripts are ES modules that ancient Node
-# (e.g. v6) can't parse, so an old version would otherwise fail later with a cryptic
-# "Unexpected token import". Parse the major number out of "vXX.Y.Z".
+# The client build runs on Vite 7, which hard-refuses anything below Node
+# 20.19 / 22.12 partway through setup with its own cryptic message. Enforce
+# Vite's real floor HERE with a clear message instead: pass on 20.19+, 22.12+,
+# or any 23+. Parse major.minor out of "vXX.YY.Z".
 NODEMAJOR="$(printf '%s' "$NODEVER" | sed -E 's/^v?([0-9]+).*/\1/')"
+NODEMINOR="$(printf '%s' "$NODEVER" | sed -E 's/^v?[0-9]+\.([0-9]+).*/\1/')"
 case "$NODEMAJOR" in ''|*[!0-9]*) NODEMAJOR=0 ;; esac
-if [ "$NODEMAJOR" -lt 18 ]; then
-    echo "[ERROR] Node.js $NODEVER is too old - Open Historia needs Node 18 or newer."
-    echo "Update Node.js (LTS) from https://nodejs.org/ then run this launcher again."
+case "$NODEMINOR" in ''|*[!0-9]*) NODEMINOR=0 ;; esac
+NODEOK=""
+if [ "$NODEMAJOR" -ge 23 ]; then NODEOK=1
+elif [ "$NODEMAJOR" -eq 22 ] && [ "$NODEMINOR" -ge 12 ]; then NODEOK=1
+elif [ "$NODEMAJOR" -eq 20 ] && [ "$NODEMINOR" -ge 19 ]; then NODEOK=1
+fi
+if [ -z "$NODEOK" ]; then
+    echo "[ERROR] Node.js $NODEVER (at $(command -v node)) is too old - Open Historia"
+    echo "needs Node 22.12 or newer (20.19+ also works). Install the current LTS from:"
+    echo "  https://nodejs.org/"
+    echo ""
+    echo "If you just installed a newer Node.js, open a NEW terminal (already-open ones"
+    echo "keep the old PATH), and check 'which -a node' for an older install shadowing"
+    echo "the new one."
     echo ""
     exit 1
 fi
-echo "[OK] Node.js $NODEVER detected."
+echo "[OK] Node.js $NODEVER detected ($(command -v node))."
 echo ""
 
 # ---- 2. Ensure world map data ----------------------------

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ release APK — run it after changing `mobile/`.
 
 ### Manual
 
-Prerequisites: [Git](https://git-scm.com/) and [Node.js](https://nodejs.org/en).
+Prerequisites: [Git](https://git-scm.com/) and [Node.js](https://nodejs.org/en) 22 LTS or newer (minimum 20.19 / 22.12 — the client build runs on Vite 7, which requires it).
 
 ```bash
 git clone https://github.com/Open-Historia/open-historia.git

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "dev": "vite",
     "dev:web": "node scripts/seed-web-defaults.mjs && vite --mode web",


### PR DESCRIPTION
Fixes the Discord report of a player on Node 24.18 being told their Node version is a problem.

**Root causes (two, compounding):**
1. The launchers gated on **Node 18+**, but the client build runs **Vite 7**, which hard-refuses anything below **20.19 / 22.12** partway through setup with its own cryptic message. Old-Node players passed our gate and died mid-build.
2. Players with **multiple Node installs** (an old one shadowing a new one in PATH — e.g. a terminal opened before the upgrade never sees the new PATH) got a version complaint while `node -v` in their own shell showed a new version. Nothing told them which node the launcher actually resolved.

**Changes:**
- Both launchers now enforce Vite's real floor directly (20.19+ / 22.12+ / any 23+) with a clear message naming the required versions.
- The `[OK]` line prints **which** node binary was resolved; a failure lists **every** Node install found (`where node` / `command -v node`) and explains the stale-PATH / shadowed-install fix.
- `engines` added to package.json (`^20.19.0 || >=22.12.0`) and the README prerequisite updated.

**Verification:** both gate scripts were executed (not just read) against nine versions covering every boundary — 16/18/20.18 fail, 20.19 passes, 21.x fails, 22.11 fails, 22.12/23/24.18 pass — using fake `node` binaries, on both cmd and bash.

Note: the Open-Historia.zip app bundles ship these launchers, so they pick this up on the next bundle build.