### PR TITLE
Heal saves whose game date froze the clock (beta)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -122,7 +122,7 @@ const addIsoDays = (value, days) => {
   return `${String(year).padStart(4, "0")}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
 };
 
-const validateTimelineDates = ({ candidate, mode, originDate, targetDate }) => {
+const validateTimelineDates = ({ candidate, mode, originDate, targetDate, requireAdvance = false }) => {
   const stopDate = normalizeString(candidate?.stopDate);
   if (!parseIsoDate(originDate)) {
     const eventDates = normalizeArray(candidate?.events).map((event) => normalizeString(event?.date));
@@ -131,6 +131,12 @@ const validateTimelineDates = ({ candidate, mode, originDate, targetDate }) => {
     if (malformedIsoIndex >= 0) {
       const path = malformedIsoIndex === 0 ? "$.stopDate" : `$.events[${malformedIsoIndex - 1}].date`;
       return `${path} must be a real Gregorian date when using YYYY-MM-DD format.`;
+    }
+    // A whole-day advance was requested but the model kept the clock where it
+    // was — the stuck-save signature (it then re-simulates the past instead of
+    // the future). Reject on the strict attempt so the retry moves time forward.
+    if (requireAdvance && stopDate && stopDate === normalizeString(originDate)) {
+      return `$.stopDate must move time forward - it must not equal the current date ${originDate}.`;
     }
     if (parseIsoDate(stopDate)) {
       let previousDate = "";
@@ -1740,7 +1746,7 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
       if (strict && mode !== "auto" && (eventCount < minEvents || eventCount > maxEvents)) {
         return `$.events must contain between ${minEvents} and ${maxEvents} events; received ${eventCount}.`;
       }
-      const dateError = validateTimelineDates({ candidate, mode, originDate, targetDate });
+      const dateError = validateTimelineDates({ candidate, mode, originDate, targetDate, requireAdvance: dateStep >= 1 });
       if (dateError) {
         if (strict) return dateError;
         clampTimelineDates(candidate, { mode, originDate, targetDate });

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -874,6 +874,30 @@ export const normalizeWorldState = (world) => {
   };
 };
 
+// Recover a Gregorian date stored in a loose format back to strict YYYY-MM-DD.
+// Older builds wrote the model's stopDate verbatim, so real saves hold values
+// like "2016-12-31T00:00:00.000Z" or "December 31, 2016" — the header displays
+// them fine, but date math (addIsoDays) rejects them, so every jump silently
+// computes target == origin and the game clock freezes forever while the model
+// re-simulates the past. Deliberately non-Gregorian scenario dates ("1200 BCE")
+// don't parse and pass through untouched.
+const canonicalizeDateString = (value) => {
+  const text = normalizeOptionalString(value);
+  if (!text || /^\d{4}-\d{2}-\d{2}$/.test(text)) return text;
+  // An ISO date prefix (datetime forms) is authoritative — slicing it avoids
+  // the timezone day-shift of parsing "...T00:00:00Z" into local time.
+  const prefix = /^(\d{4}-\d{2}-\d{2})[T ]/.exec(text);
+  if (prefix) return prefix[1];
+  const parsed = new Date(text);
+  if (!Number.isNaN(parsed.getTime())) {
+    const year = parsed.getFullYear();
+    if (year >= 1 && year <= 9999) {
+      return `${String(year).padStart(4, "0")}-${String(parsed.getMonth() + 1).padStart(2, "0")}-${String(parsed.getDate()).padStart(2, "0")}`;
+    }
+  }
+  return text;
+};
+
 export const normalizeGameData = (game) => {
   const nextGame = game && typeof game === "object" ? game : {};
 
@@ -882,13 +906,13 @@ export const normalizeGameData = (game) => {
     ...nextGame,
     country: normalizeOptionalString(nextGame.country),
     difficulty: normalizeOptionalString(nextGame.difficulty) || GAME_DEFAULTS.difficulty,
-    gameDate: normalizeOptionalString(nextGame.gameDate),
+    gameDate: canonicalizeDateString(nextGame.gameDate),
     language: normalizeOptionalString(nextGame.language) || GAME_DEFAULTS.language,
     round:
       Number.isFinite(Number(nextGame.round)) && Number(nextGame.round) > 0
         ? Math.trunc(Number(nextGame.round))
         : GAME_DEFAULTS.round,
-    startDate: normalizeOptionalString(nextGame.startDate),
+    startDate: canonicalizeDateString(nextGame.startDate),
   };
 };
 


### PR DESCRIPTION
Fixes the video report: a modern-day game showing December 31st, 2016 skips a year, **stays** on December 31st, 2016, and the new events re-run January 2016 onward.

**Root cause — a bricked save, not the current jump code.** Builds before the July 12 date validation stored the model's `stopDate` verbatim, so affected saves hold a date like `2016-12-31T00:00:00.000Z` (or `December 31, 2016`). The header *displays* these fine, but strict date math rejects them — so every jump silently computes target == origin, asks the model to simulate a zero-length window ending "today", and the model narrates the **past** year while the clock never moves. Reproduced exactly with a `.000Z` date: 365-day jump returned the identical date every time.

**Fixes:**
- `normalizeGameData` now canonicalizes Gregorian-parseable dates to `YYYY-MM-DD` on every read and write — datetime forms are sliced without timezone day-shift, loose forms (`December 31, 2016`, `12/31/2016`) are parsed. **Existing bricked saves self-heal on their next jump; no player action needed** beyond updating. Deliberately non-Gregorian scenario dates (`1200 BCE`, `Year 402 of the Empire`) pass through untouched (verified).
- `validateTimelineDates` rejects a `stopDate` equal to the origin when a whole-day advance was requested, so textual-date scenarios get a strict retry pushing time forward instead of a silently frozen clock. Sub-day skips (6 hours), which legitimately keep the same date, are unaffected.

**Verification (live in the running game):** trapped a save with the `.000Z` date → confirmed the year-skip returned the same date (the exact video behavior) → applied the fix → same save jumped 365 days to `2017-12-31`, now stored as clean ISO; canonicalizer unit-checked against 7 formats including fantasy dates; production build clean.