### PR TITLE
Launcher: ComSpec hardening + cannot-find troubleshooting docs (main)

### DIFF
--- a/Launch Open Historia.bat
+++ b/Launch Open Historia.bat
@@ -53,8 +53,29 @@ if errorlevel 1 (
     exit /b 1
 )
 
+REM A broken ComSpec system variable breaks double-clicking .bat files
+REM ("Windows cannot find ...") and any child-shell command. Field-diagnosed:
+REM it is maddening to find by hand, so name it loudly and keep going.
+if not exist "%ComSpec%" (
+    echo [WARN] The ComSpec system variable on this computer is broken:
+    echo        ComSpec = "%ComSpec%"
+    echo It must point to cmd.exe. Fix it in System Properties ^> Environment
+    echo Variables ^> System variables ^> ComSpec ^> set the value to:
+    echo        %%SystemRoot%%\system32\cmd.exe
+    echo This is also why double-clicking .bat files can say "Windows cannot
+    echo find..." on this computer. Trying to continue anyway...
+    echo.
+)
+REM Capture the version WITHOUT a child shell: for /f ^('command'^) needs
+REM ComSpec, which is broken on some machines. A plain redirect runs node
+REM directly in this window instead.
 set "NODEVER="
-for /f "delims=" %%V in ('node --version 2^>nul') do set "NODEVER=%%V"
+set "OH_VERFILE=%TEMP%\oh-node-version.txt"
+call node --version >"%OH_VERFILE%" 2>nul
+if exist "%OH_VERFILE%" (
+    set /p NODEVER=<"%OH_VERFILE%"
+    del "%OH_VERFILE%" >nul 2>&1
+)
 REM "where" finding node does NOT guarantee it runs here: launched "as
 REM administrator", the window gets the ADMIN account's environment, and a
 REM Node.js installed only for the normal user account isn't on that PATH.
@@ -106,6 +127,7 @@ if not defined NODEOK (
 )
 set "NODEPATH="
 for /f "delims=" %%P in ('where node 2^>nul') do if not defined NODEPATH set "NODEPATH=%%P"
+if not defined NODEPATH set "NODEPATH=on PATH"
 echo [OK] Node.js !NODEVER! detected ^(!NODEPATH!^).
 echo.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ and opens the game. To update an existing install later, run the matching
 **`Update Open Historia`** script for your platform — it fetches the latest version
 while preserving your saves, scenarios, and map data.
 
+> [!TIP]
+> Run the launcher **normally** — it does not need (and works better without)
+> administrator rights: an elevated window gets the admin account's environment,
+> which can hide a Node.js that was installed for your own account.
+
+<details>
+<summary><b>Windows says "Windows cannot find …Launch Open Historia.bat"?</b></summary>
+
+The file exists — this is Windows' misleading message for a **blocked or broken
+double-click action** on batch files, usually one of:
+
+1. **Antivirus / SmartScreen blocking a downloaded .bat.** Before extracting,
+   right-click the downloaded ZIP → *Properties* → check **Unblock** → *OK*, then
+   extract to a simple folder like `C:\Games\Open-Historia` (not Downloads). If
+   you already extracted, do the same on `Launch Open Historia.bat` itself, and
+   check your antivirus' protection log / quarantine.
+2. **A broken .bat file association.** Open a *normal* Command Prompt, `cd` into
+   the folder and run `"Launch Open Historia.bat"` — if that works while
+   double-clicking doesn't, restore the association from an **administrator**
+   Command Prompt: `assoc .bat=batfile` and ensure the registry value
+   `HKEY_CLASSES_ROOT\batfile\shell\open\command` is exactly `"%1" %*`.
+
+Running "as administrator" sidesteps the block, but don't make that the routine —
+see the tip above.
+</details>
+
 #### Android app (thin APK)
 
 Easiest: download **`pax-historia.apk`** from the

--- a/README.md
+++ b/README.md
@@ -91,12 +91,19 @@ while preserving your saves, scenarios, and map data.
 The file exists — this is Windows' misleading message for a **blocked or broken
 double-click action** on batch files, usually one of:
 
-1. **Antivirus / SmartScreen blocking a downloaded .bat.** Before extracting,
+1. **A broken `ComSpec` system variable** (the launcher also warns about this
+   when started from a terminal). In a Command Prompt run `echo %ComSpec%` —
+   it must print `C:\WINDOWS\system32\cmd.exe`. If it doesn't: System
+   Properties → *Environment Variables* → *System variables* → `ComSpec` → set
+   it to `%SystemRoot%\system32\cmd.exe`, then sign out and back in. Windows
+   needs `ComSpec` to launch any double-clicked batch file, so a broken value
+   produces exactly this error.
+2. **Antivirus / SmartScreen blocking a downloaded .bat.** Before extracting,
    right-click the downloaded ZIP → *Properties* → check **Unblock** → *OK*, then
    extract to a simple folder like `C:\Games\Open-Historia` (not Downloads). If
    you already extracted, do the same on `Launch Open Historia.bat` itself, and
    check your antivirus' protection log / quarantine.
-2. **A broken .bat file association.** Open a *normal* Command Prompt, `cd` into
+3. **A broken .bat file association.** Open a *normal* Command Prompt, `cd` into
    the folder and run `"Launch Open Historia.bat"` — if that works while
    double-clicking doesn't, restore the association from an **administrator**
    Command Prompt: `assoc .bat=batfile` and ensure the registry value


### PR DESCRIPTION
The two commits that missed the #356-#358 merge window:

1. **README troubleshooting** for the "Windows cannot find ...Launch Open Historia.bat" double-click error (blocked/broken .bat open action) and a tip that the launcher must not be run as administrator.
2. **ComSpec hardening** — field-diagnosed and reproduced on a player's machine: a broken `ComSpec` system variable makes `for /f` fail with the whole command echoed as one unrecognized token, and is also why double-clicking any .bat says "Windows cannot find...". The launcher now captures the Node version with a plain redirect (no child shell, call-safe for batch shims) so it works on such machines, and prints a loud warning naming ComSpec with the exact repair steps. README troubleshooting leads with the ComSpec check.

Verified by simulating the broken-ComSpec machine (warning prints, version captures, launcher proceeds) and re-running the full version-gate matrix.