### PR TITLE
Deleting a queued troop order reverts the unit (#368) (main)

### DIFF
--- a/src/Game/GameUI/actions.jsx
+++ b/src/Game/GameUI/actions.jsx
@@ -5,6 +5,7 @@ import advancedFormat from "dayjs/plugin/advancedFormat";
 import { JSON_URLS, readJson } from "../../runtime/assets.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { generateActionSuggestions, refinePlayerAction } from "../AI/gameplay.js";
+import { revertUnitOrder } from "../Map/unitsController.js";
 import {
     buildActionDisplayText,
     normalizeActionEntry,
@@ -339,6 +340,18 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
     };
 
     const handleDelete = async (index) => {
+        const removed = actions[index];
+        // Deleting a queued troop order also undoes what it did to the map —
+        // otherwise a manual move/deploy stays in place while the AI is never
+        // told about it (#368). Only planned orders carry a revert; anything
+        // already resolved by a jump keeps its outcome.
+        if (removed?.unitRevert && (removed.status ?? "planned") === "planned") {
+            try {
+                await revertUnitOrder(removed.unitRevert);
+            } catch (error) {
+                console.warn("[actions] could not revert the unit order:", error);
+            }
+        }
         await persistActions(actions.filter((_, actionIndex) => actionIndex !== index));
     };
 

--- a/src/Game/Map/unitsController.js
+++ b/src/Game/Map/unitsController.js
@@ -106,7 +106,10 @@ const commit = async (mutator) => {
   }
 };
 
-const queueOrder = async (text) => {
+// unitRevert records how to undo the order if the player deletes the queued
+// action before the next jump (#368): without it, a manual move stayed on the
+// map while the AI was never told about it.
+const queueOrder = async (text, unitRevert = null) => {
   try {
     const actions = await readActionsState({ force: true });
     actions.push({
@@ -115,6 +118,7 @@ const queueOrder = async (text) => {
       status: "planned",
       text,
       title: text.length > 60 ? `${text.slice(0, 57)}...` : text,
+      ...(unitRevert ? { unitRevert } : {}),
     });
     await writeActionsState(actions);
   } catch (error) {
@@ -122,27 +126,50 @@ const queueOrder = async (text) => {
   }
 };
 
+// Undo a queued manual order whose action the player deleted (#368): a pending
+// deploy is removed again, a moved unit snaps back to its recorded position,
+// and a long-range/approach order restores the unit's prior status.
+export const revertUnitOrder = async (revert) => {
+  const unitId = String(revert?.unitId ?? "").trim();
+  if (!unitId) return;
+  if (revert.remove) {
+    await commit((list) => list.filter((u) => u.id !== unitId));
+    return;
+  }
+  await commit((list) =>
+    list.map((u) => {
+      if (u.id !== unitId) return u;
+      return {
+        ...u,
+        ...(Number.isFinite(revert.lng) && Number.isFinite(revert.lat) ? { lng: revert.lng, lat: revert.lat } : {}),
+        ...(revert.status ? { status: revert.status } : {}),
+        updatedAt: new Date().toISOString(),
+      };
+    }));
+};
+
 export const deployUnit = async ({ type, strength, name, lng, lat }) => {
   if (!playerCode) await refresh();
   // Deploy as PENDING (rendered translucent): the player states an intent, and the
   // AI confirms, relocates or rejects it on the next time-jump.
-  const saved = await commit((list) => {
-    const unit = normalizeUnitEntry({
-      type,
-      strength,
-      name,
-      lng,
-      lat,
-      ownerCode: playerCode || "PLAYER",
-      source: "player",
-      status: "pending",
-    });
-    return unit ? [...list, unit] : list;
+  // Built outside the commit so the queued order can reference its id.
+  const unit = normalizeUnitEntry({
+    type,
+    strength,
+    name,
+    lng,
+    lat,
+    ownerCode: playerCode || "PLAYER",
+    source: "player",
+    status: "pending",
   });
+  if (!unit) return units;
+  const saved = await commit((list) => [...list, unit]);
   await queueOrder(
     `Deploy request: ${name || type} (${type}, strength ${strength}, owner ${playerCode || "PLAYER"}) at ` +
       `lat ${lat.toFixed(2)}, lng ${lng.toFixed(2)}. Currently pending — confirm it into the order of battle, ` +
       `reposition it, or reject it as the front and logistics allow.`,
+    { unitId: unit.id, remove: true },
   );
   return saved;
 };
@@ -167,6 +194,7 @@ export const moveUnitTo = async (unitId, lng, lat) => {
         `lat ${lat.toFixed(2)}, lng ${lng.toFixed(2)} — about ${Math.round(distance)} km away, beyond a single ` +
         `${unit.type} move in this era (~${leash} km). Advance it realistically across turns given the era, terrain ` +
         `and transport available, or reject the order with an event explaining why it is infeasible.`,
+      { unitId: unit.id, status: unit.status },
     );
     return { resolved: false, distance, leash };
   }
@@ -180,6 +208,7 @@ export const moveUnitTo = async (unitId, lng, lat) => {
   );
   await queueOrder(
     `Move ${unit.name} (${unit.type}, id ${unit.id}, owner ${unit.ownerCode}) to coordinates lat ${lat.toFixed(2)}, lng ${lng.toFixed(2)}.`,
+    { unitId: unit.id, lng: unit.lng, lat: unit.lat, status: unit.status },
   );
   return { resolved: true, distance, leash };
 };
@@ -205,6 +234,7 @@ export const attackWith = async (attackerId, targetId) => {
         `is ordered against ${defender.name} (id ${defender.id}, owner ${defender.ownerCode}) about ${Math.round(distance)} km away — ` +
         `beyond its ~${range} km engagement reach for this era. March/sail/fly it toward the target realistically across turns ` +
         `and resolve the clash when contact is actually possible, or reject the order with an event explaining why it is infeasible.`,
+      { unitId: attacker.id, status: attacker.status },
     );
     return { resolved: false, distance, range };
   }

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -114,6 +114,23 @@ const normalizeActionParticipants = (value) =>
     .map((entry) => normalizeString(entry))
     .filter(Boolean);
 
+// How to undo a queued manual troop order if its action is deleted before the
+// next jump (see unitsController): a deploy is removed again, a move snaps the
+// unit back, a long-range order restores the prior status (#368).
+const normalizeUnitRevert = (value) => {
+  if (!value || typeof value !== "object") return null;
+  const unitId = normalizeOptionalString(value.unitId);
+  if (!unitId) return null;
+  const lng = finiteOrNull(value.lng);
+  const lat = finiteOrNull(value.lat);
+  return {
+    unitId,
+    ...(lng !== null && lat !== null ? { lng, lat } : {}),
+    ...(value.remove === true ? { remove: true } : {}),
+    ...(normalizeOptionalString(value.status) ? { status: normalizeOptionalString(value.status) } : {}),
+  };
+};
+
 export const normalizeActionEntry = (entry, index = 0) => {
   if (typeof entry === "string") {
     const text = normalizeString(entry);
@@ -151,6 +168,8 @@ export const normalizeActionEntry = (entry, index = 0) => {
       ? "chat"
       : "action";
 
+  const unitRevert = normalizeUnitRevert(entry.unitRevert);
+
   return {
     chatStarter: normalizeOptionalString(entry.chatStarter || entry.openingMessage),
     createdAt: normalizeOptionalString(entry.createdAt) || new Date().toISOString(),
@@ -164,6 +183,7 @@ export const normalizeActionEntry = (entry, index = 0) => {
     suggestionTopic: normalizeOptionalString(entry.suggestionTopic || entry.topic),
     text: text || rawInput || title,
     title: title || rawInput || text,
+    ...(unitRevert ? { unitRevert } : {}),
   };
 };
 


### PR DESCRIPTION
Fixes bug 2 from #368: manually deploying or moving a unit queues a player action for the AI to resolve — but deleting that action left the unit in its new spot, a map change the AI was never told about.

Every manual order now records how to undo itself (`unitRevert` on the action entry, preserved through normalization):
- deleting a planned **deploy** removes the still-pending unit;
- deleting a **move** snaps the unit back to its recorded position and prior status;
- deleting a **long-range movement / attack-approach order** restores the unit's prior status.

Orders already resolved by a time jump keep their outcome (the revert only fires on still-planned actions). Resolved in-range clashes are deliberately not revertible — combat happened.

**Verification** (in a sandboxed copy of the game so the owner's live session stayed untouched): drove deploy + move through the real controller, confirmed both queued actions carry correct revert records, then deleted each through the actual Actions-panel delete button — the move deletion restored lat/lng/status exactly (-3.70/40.40/pending), the deploy deletion removed the unit entirely. Zero console errors; production build clean.