### PR TITLE
Send enable_thinking to local endpoints when reasoning is on (#367) (beta)

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -592,6 +592,13 @@ async function callOpenAIStyleChatCompletions({
                 // reject the tools+reasoning combination surface the documented
                 // error below and the call retries without it.
                 ...(getReasoningEnabled() && !disableToolReasoning ? { reasoning_effort: "medium" } : {}),
+                // Thinking-class local models (Qwen3, Seed-OSS) key on
+                // enable_thinking, not reasoning_effort — textgen/oobabooga
+                // honors it per-request, llama.cpp/LM Studio ignore unknown
+                // fields. Local endpoints only: strict cloud APIs reject
+                // unknown parameters. Sent only when the toggle is ON so a
+                // server-side --enable-thinking default is never overridden.
+                ...(streamLocalEndpoint && getReasoningEnabled() && !disableToolReasoning ? { enable_thinking: true } : {}),
                 [tokenLimitField]: Math.max(8192, Number(maxTokens) || 0),
                 ...requestCustomParams,
                 ...(structuredMode === "tool" && disableToolReasoning ? { reasoning_effort: "none" } : {}),


### PR DESCRIPTION
Follow-up to #367 after the report that reasoning still is not engaging: `reasoning_effort` (shipped in #378) only drives **GPT-OSS-class** models. Thinking-class local models (**Qwen3, Seed-OSS**) key on **`enable_thinking`**, which textgen/oobabooga honors per-request (modules/api/typing.py: `enable_thinking: bool = shared.args.enable_thinking`) and llama.cpp/LM Studio ignore as an unknown field.

- Sent to **local endpoints only** — strict cloud APIs reject unknown parameters.
- Sent only when the reasoning toggle is **ON**, so a server-side `--enable-thinking` default is never overridden by omission.
- Skipped on the tools+reasoning conflict retry, like reasoning_effort.

Verified against a body-logging mock through the real relay: toggle on → text and tool requests both carry `reasoning_effort:"medium"` **and** `enable_thinking:true` (tool requests alongside `tool_choice:"required"`); toggle off → neither is sent. Production build clean.

Note for the reporter: they must be on a build containing #378 AND this; also worth confirming which model family they run — if it is GPT-OSS, #378 alone should already restore reasoning, so a still-broken report on #378 suggests the Qwen3/Seed-OSS case this PR covers.