### PR TITLE
Country labels: scenario-chosen font, letter color, border color — default Impact (main)

### DIFF
--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -201,6 +201,9 @@ const buildScenarioEditorState = (details) => {
     language: game.language ?? world.language ?? "English",
     name: scenario.name ?? "",
     prompts,
+    labelFont: world.labelFont ?? "",
+    labelHaloColor: world.labelHaloColor ?? "",
+    labelTextColor: world.labelTextColor ?? "",
     simulationRules: world.simulationRules ?? "",
     startingTimelineText: world.startingTimelineText ?? "",
     subtitle: scenario.subtitle ?? "",
@@ -224,6 +227,9 @@ const buildGameEditorState = (details) => {
     language: game.language ?? world.language ?? "English",
     name: gameMeta.name ?? "",
     prompts,
+    labelFont: world.labelFont ?? "",
+    labelHaloColor: world.labelHaloColor ?? "",
+    labelTextColor: world.labelTextColor ?? "",
     simulationRules: world.simulationRules ?? "",
     startingTimelineText: world.startingTimelineText ?? "",
     subtitle: gameMeta.subtitle ?? "",
@@ -788,6 +794,42 @@ const EditorDrawer = ({
               <label style={fieldLabelStyle}>Simulation Rules</label>
               <textarea style={{ ...textareaStyle, minHeight: "8rem" }} value={formState.simulationRules} onChange={(event) => onChange("simulationRules", event.target.value)} />
             </div>
+            {/* Country-label styling. Labels rasterize from each player's LOCAL
+                fonts (the map has no glyph server), so any installed family
+                works — the list only suggests safe common ones. Empty = Impact. */}
+            <div>
+              <label style={fieldLabelStyle}>Country Label Font</label>
+              <input
+                list="oh-label-font-options"
+                placeholder="Impact (default)"
+                style={inputStyle}
+                value={formState.labelFont}
+                onChange={(event) => onChange("labelFont", event.target.value)}
+              />
+              <datalist id="oh-label-font-options">
+                {["Impact", "Arial Black", "Arial", "Georgia", "Times New Roman", "Trebuchet MS", "Verdana", "Courier New", "Garamond", "Comic Sans MS"].map((font) => (
+                  <option key={font} value={font} />
+                ))}
+              </datalist>
+            </div>
+            <div>
+              <label style={fieldLabelStyle}>Label Letter Color</label>
+              <input
+                type="color"
+                style={{ ...inputStyle, height: "2.4rem", padding: "0.2rem" }}
+                value={/^#[0-9a-fA-F]{6}$/.test(formState.labelTextColor) ? formState.labelTextColor : "#ffffff"}
+                onChange={(event) => onChange("labelTextColor", event.target.value)}
+              />
+            </div>
+            <div>
+              <label style={fieldLabelStyle}>Label Border Color</label>
+              <input
+                type="color"
+                style={{ ...inputStyle, height: "2.4rem", padding: "0.2rem" }}
+                value={/^#[0-9a-fA-F]{6}$/.test(formState.labelHaloColor) ? formState.labelHaloColor : "#000000"}
+                onChange={(event) => onChange("labelHaloColor", event.target.value)}
+              />
+            </div>
           </div>
         </div>
       )}
@@ -1344,6 +1386,9 @@ const LibraryTopBar = () => {
             allowedUnitTypes: Array.isArray(editorState.allowedUnitTypes)
               ? editorState.allowedUnitTypes
               : [...UNIT_TYPES],
+            labelFont: editorState.labelFont,
+            labelHaloColor: editorState.labelHaloColor,
+            labelTextColor: editorState.labelTextColor,
             language: editorState.language,
             simulationRules: editorState.simulationRules,
             startingTimelineText: editorState.startingTimelineText,
@@ -1371,6 +1416,9 @@ const LibraryTopBar = () => {
           subtitle: editorState.subtitle,
           world: {
             ...currentWorld,
+            labelFont: editorState.labelFont,
+            labelHaloColor: editorState.labelHaloColor,
+            labelTextColor: editorState.labelTextColor,
             language: editorState.language,
             simulationRules: editorState.simulationRules,
             startingTimelineText: editorState.startingTimelineText,

--- a/src/Game/GameUI/scenarios.jsx
+++ b/src/Game/GameUI/scenarios.jsx
@@ -126,6 +126,9 @@ const buildEditorState = (details) => {
     gameDate: game.gameDate ?? "",
     heroSubtitle: scenario.heroSubtitle ?? "",
     heroTitle: scenario.heroTitle ?? "",
+    labelFont: world.labelFont ?? "",
+    labelHaloColor: world.labelHaloColor ?? "",
+    labelTextColor: world.labelTextColor ?? "",
     language: game.language ?? world.language ?? "English",
     leaderPrompt: prompts.leader ?? "",
     name: scenario.name ?? "",
@@ -486,6 +489,42 @@ const ScenarioEditor = ({
     onChange={(event) => onChange("simulationRules", event.target.value)}
     />
     </div>
+    {/* Country-label styling. The font renders from each player's LOCAL fonts
+        (the map rasterizes glyphs client-side), so any installed family works —
+        the list only offers common ones. Empty font = the Impact default. */}
+    <div>
+    <label style={fieldLabelStyle}>Country Label Font</label>
+    <input
+    list="oh-label-font-options"
+    placeholder="Impact (default)"
+    style={inputStyle}
+    value={formState.labelFont}
+    onChange={(event) => onChange("labelFont", event.target.value)}
+    />
+    <datalist id="oh-label-font-options">
+    {["Impact", "Arial Black", "Arial", "Georgia", "Times New Roman", "Trebuchet MS", "Verdana", "Courier New", "Garamond", "Comic Sans MS"].map((font) => (
+      <option key={font} value={font} />
+    ))}
+    </datalist>
+    </div>
+    <div>
+    <label style={fieldLabelStyle}>Label Letter Color</label>
+    <input
+    type="color"
+    style={{ ...inputStyle, height: "2.4rem", padding: "0.2rem" }}
+    value={/^#[0-9a-fA-F]{6}$/.test(formState.labelTextColor) ? formState.labelTextColor : "#ffffff"}
+    onChange={(event) => onChange("labelTextColor", event.target.value)}
+    />
+    </div>
+    <div>
+    <label style={fieldLabelStyle}>Label Border Color</label>
+    <input
+    type="color"
+    style={{ ...inputStyle, height: "2.4rem", padding: "0.2rem" }}
+    value={/^#[0-9a-fA-F]{6}$/.test(formState.labelHaloColor) ? formState.labelHaloColor : "#000000"}
+    onChange={(event) => onChange("labelHaloColor", event.target.value)}
+    />
+    </div>
     </div>
     </div>
 
@@ -739,6 +778,9 @@ const ScenarioTopBar = () => {
                                          subtitle: editorState.subtitle,
                                          world: {
                                            ...currentWorld,
+                                           labelFont: editorState.labelFont,
+                                           labelHaloColor: editorState.labelHaloColor,
+                                           labelTextColor: editorState.labelTextColor,
                                            language: editorState.language,
                                            simulationRules: editorState.simulationRules,
                                            startingTimelineText: editorState.startingTimelineText,

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -395,6 +395,9 @@ const WorldMap = ({ isGlobe = false }) => {
     regionOwnershipOverrides,
     regionClaimants,
     polityOverrides,
+    labelFont,
+    labelHaloColor,
+    labelTextColor,
   } = useWorldState();
   const mapDisplaySettings = {
     hideCountryLabels: useMapSetting(MAP_SETTING_KEYS.hideCountryLabels),
@@ -857,9 +860,19 @@ const WorldMap = ({ isGlobe = false }) => {
       : 0,
   };
 
+  // Scenario-authored label styling (world.labelFont/labelTextColor/
+  // labelHaloColor). The style has no glyphs endpoint, so MapLibre v5 draws
+  // every glyph locally with this stack as a CSS font-family — any font on the
+  // PLAYER's machine works, with the trailing names as fallbacks where the
+  // first is not installed.
+  const labelFontStack = useMemo(
+    () => [labelFont || "Impact", "Arial Black", "sans-serif"],
+    [labelFont],
+  );
+
   const pointLabelLayerLayout = useMemo(() => ({
     "text-field": ["get", "name"],
-    "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font": labelFontStack,
     "text-size": buildCountryTextSize(1, isGlobe),
     "text-rotate": ["get", "rotation"],
     "text-anchor": "center",
@@ -868,11 +881,11 @@ const WorldMap = ({ isGlobe = false }) => {
     "text-rotation-alignment": "map",
     "text-keep-upright": false,
     visibility: mapDisplaySettings.hideCountryLabels ? "none" : "visible",
-  }), [isGlobe, mapDisplaySettings.hideCountryLabels]);
+  }), [isGlobe, labelFontStack, mapDisplaySettings.hideCountryLabels]);
 
   const curvedLabelLayerLayout = useMemo(() => ({
     "text-field": ["get", "glyph"],
-    "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
+    "text-font": labelFontStack,
     "text-size": buildCountryTextSize(1, isGlobe),
     "text-rotate": ["get", "rotation"],
     "text-anchor": "center",
@@ -881,18 +894,18 @@ const WorldMap = ({ isGlobe = false }) => {
     "text-rotation-alignment": "map",
     "text-keep-upright": false,
     visibility: mapDisplaySettings.hideCountryLabels ? "none" : "visible",
-  }), [isGlobe, mapDisplaySettings.hideCountryLabels]);
+  }), [isGlobe, labelFontStack, mapDisplaySettings.hideCountryLabels]);
 
   const labelLayerPaint = useMemo(() => ({
-    "text-color": "#FFFFFF",
-    "text-halo-color": "rgba(0, 0, 0, 0.5)",
+    "text-color": labelTextColor || "#FFFFFF",
+    "text-halo-color": labelHaloColor || "rgba(0, 0, 0, 0.5)",
     "text-halo-width": 1,
     "text-opacity": [
       "interpolate", ["linear"], ["zoom"],
       5, 0.75,
       8, 0,
     ],
-  }), []);
+  }), [labelHaloColor, labelTextColor]);
 
   return (
     <>

--- a/src/Game/Map/useWorldState.js
+++ b/src/Game/Map/useWorldState.js
@@ -91,6 +91,9 @@ export function useWorldState() {
     regionClaimants: state?.regionClaimants ?? {},
     polityOverrides: state?.polityOverrides ?? {},
     markers: Array.isArray(state?.markers) ? state.markers : EMPTY_MARKERS,
+    labelFont: state?.labelFont ?? "",
+    labelHaloColor: state?.labelHaloColor ?? "",
+    labelTextColor: state?.labelTextColor ?? "",
   };
 
   const prev = prevRef.current;
@@ -101,6 +104,9 @@ export function useWorldState() {
     prev.customCities === derived.customCities &&
     prev.basemap === derived.basemap &&
     prev.background === derived.background &&
+    prev.labelFont === derived.labelFont &&
+    prev.labelHaloColor === derived.labelHaloColor &&
+    prev.labelTextColor === derived.labelTextColor &&
     areEqualShallow(prev.regionOwnershipOverrides, derived.regionOwnershipOverrides) &&
     // Claimant values are ARRAYS (fresh objects every poll), so reference
     // equality would churn every 5s — compare content. The map is tiny.

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -24,6 +24,13 @@ export const WORLD_DEFAULTS = {
   // tags.json holds the map-maker's STARTING tags; this holds every change since,
   // and wins where present (see resolveCountryTags).
   countryTags: {},
+  // Country-label styling, set in the scenario settings. Empty = the defaults
+  // (Impact, white letters, half-black outline). The font renders from the
+  // PLAYER's local fonts — the style has no glyphs endpoint, so MapLibre v5
+  // rasterizes every glyph client-side using the stack as a CSS font-family.
+  labelFont: "",
+  labelHaloColor: "",
+  labelTextColor: "",
   language: "English",
   lastJumpMode: "",
   lastJumpSummary: "",
@@ -854,6 +861,9 @@ export const normalizeWorldState = (world) => {
     activeCatalyst: normalizeCatalyst(nextWorld.activeCatalyst),
     consolidatedHistory: normalizeConsolidatedHistory(nextWorld.consolidatedHistory),
     internationalReputation,
+    labelFont: normalizeOptionalString(nextWorld.labelFont),
+    labelHaloColor: normalizeOptionalString(nextWorld.labelHaloColor),
+    labelTextColor: normalizeOptionalString(nextWorld.labelTextColor),
     language: normalizeOptionalString(nextWorld.language) || WORLD_DEFAULTS.language,
     lastJumpMode: normalizeOptionalString(nextWorld.lastJumpMode),
     lastJumpSummary: normalizeOptionalString(nextWorld.lastJumpSummary),


### PR DESCRIPTION
Scenario settings gain country-label styling: a **Country Label Font** field (any font on the player's machine; the list suggests common safe ones), a **Letter Color** picker, and a **Border Color** picker — in the World tab of both the scenario editor and the per-game editor. Stored on world.json (`labelFont` / `labelTextColor` / `labelHaloColor`) and applied to both country-label layers. **The default font is now Impact** for every scenario (previously Open Sans Bold).

**How the font works with zero shipped assets:** the map style has no glyphs endpoint, so MapLibre v5 rasterizes every glyph client-side using the `text-font` stack as a CSS font-family. The chosen font renders from each player's LOCAL fonts (Impact ships with Windows/macOS), with Arial Black → sans-serif fallbacks where it is missing — no font files distributed, no licensing exposure, and weight is auto-derived from the family name.

**Verification (live, sandboxed copy — the real session untouched):**
- Default: every country label rendered in Impact (canvas capture attached workflow: condensed heavy letterforms vs the old rounded look).
- Custom: setting Georgia + gold letters (`#ffe066`) + dark-red border (`#8b0000`) restyled every label within one 5-second world poll — serifs, gold fill, red halo all visible.
- Settings: the three fields render in the World tab; a real UI save round-tripped all three values into the scenario's world.json.
- Zero console errors; production build clean.