### PR TITLE
Settings: 'Limit AI generation' toggle, off by default (alpha)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1772,13 +1772,13 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
   const { generation, payload } = await runJsonTask(mode === "auto" ? "autoJumpForward" : "jumpForward", {
     fallback: () => fallbackJumpSimulation({ bundle, days: dateStep || 1, mode, targetDate }),
     signal,
-    // The jump IS the game — let slow (local/reasoning) models finish instead
-    // of silently swapping in the canned fallback. Five minutes covers even a
-    // large reasoning model writing 37 events; the bound only exists so a
-    // genuinely hung request can't spin forever (Cancel works throughout).
-    // The settings toggle removes the bound entirely: 0 disables the deadline
-    // in runJsonTask, so only a real error (or Cancel) can end the wait.
-    timeoutMs: getMapSetting(MAP_SETTING_KEYS.noAiTimeLimit) ? 0 : 300000,
+    // The jump IS the game — by default generation waits as long as the model
+    // needs (0 disables the deadline in runJsonTask), so the canned fallback is
+    // only reachable through a real error, never a slow local/reasoning model.
+    // The "Limit AI generation" toggle opts back into a 5-minute bound for
+    // players who prefer a guaranteed turn over a guaranteed answer (Cancel
+    // works either way).
+    timeoutMs: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 300000 : 0,
     userMessage:
       mode === "auto"
         ? "Simulate an auto-jump and stop at the next notable or player-relevant event. Return JSON only. " +

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -747,7 +747,7 @@ const SettingsMenu = ({
         hideCountryLabels: getMapSetting(MAP_SETTING_KEYS.hideCountryLabels),
         disableIdleRotation: getMapSetting(MAP_SETTING_KEYS.disableIdleRotation),
         disableEventCamera: getMapSetting(MAP_SETTING_KEYS.disableEventCamera),
-        noAiTimeLimit: getMapSetting(MAP_SETTING_KEYS.noAiTimeLimit),
+        limitAiGeneration: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration),
     }));
 
     const updateMapSetting = (stateKey, settingKey, value) => {
@@ -852,12 +852,12 @@ const SettingsMenu = ({
         <div style={{ margin: "0.5rem 0 1rem", paddingTop: "0.75rem", borderTop: "1px solid rgba(255,255,255,0.1)" }}>
         <div style={{ fontSize: "0.84rem", fontWeight: 700, marginBottom: "0.6rem" }}>AI</div>
         <Toggle
-        label="No time limit on AI generation"
-        enabled={mapSettings.noAiTimeLimit}
-        onToggle={() => updateMapSetting("noAiTimeLimit", MAP_SETTING_KEYS.noAiTimeLimit, !mapSettings.noAiTimeLimit)}
+        label="Limit AI generation"
+        enabled={mapSettings.limitAiGeneration}
+        onToggle={() => updateMapSetting("limitAiGeneration", MAP_SETTING_KEYS.limitAiGeneration, !mapSettings.limitAiGeneration)}
         />
         <div style={{ marginTop: "-0.7rem", marginBottom: "0.4rem", fontSize: "0.72rem", color: "rgba(255,255,255,0.45)", lineHeight: 1.35 }}>
-        Time skips wait as long as the model needs — fallback events can never replace a slow generation. Off: 5-minute limit. Cancel works either way.
+        On: time skips give the model 5 minutes, then fall back to canned events. Off (default): generation waits as long as the model needs. Cancel works either way.
         </div>
         </div>
 

--- a/src/runtime/mapSettings.js
+++ b/src/runtime/mapSettings.js
@@ -10,10 +10,12 @@ export const MAP_SETTING_KEYS = {
     hideCountryLabels: "map_hide_country_labels",
     disableIdleRotation: "map_disable_idle_rotation",
     disableEventCamera: "map_disable_event_camera",
-    // Not a map setting, but the same localStorage-toggle mechanism: when on,
-    // timeline-jump generation has NO deadline — the canned fallback can only
-    // be reached through a real error, never a slow model (Cancel still works).
-    noAiTimeLimit: "ai_no_time_limit",
+    // Not a map setting, but the same localStorage-toggle mechanism: when ON,
+    // timeline-jump generation gets a 5-minute deadline and falls back to
+    // canned events past it. OFF (the default) waits as long as the model
+    // needs — the fallback is only reachable through a real error, never a
+    // slow model (Cancel still works either way).
+    limitAiGeneration: "ai_limit_generation",
 };
 
 export function getMapSetting(key) {


### PR DESCRIPTION
Inverts the "No time limit on AI generation" toggle per request: it is now **"Limit AI generation"**, and it is **off by default** — generation waits as long as the model needs unless the player opts into the 5-minute deadline. The fallback stays reachable through real errors and Cancel works either way. New storage key (`ai_limit_generation`), so every player starts at the new default regardless of the old setting.

Verified live in a sandboxed instance: the AI section shows the new label with the toggle off, clicking it stores `ai_limit_generation=1` and back, the old label is gone, zero console errors, production build clean.