### PR TITLE
Main menu, salvage validation for generated turns, compact economy stats

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -572,6 +572,11 @@ const normalizeHubOrigin = (raw) => {
   };
 };
 
+const normalizePlayCount = (raw) => {
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+};
+
 const readScenarioMeta = (scenarioId) => {
   const raw = readJsonFile(getScenarioMetaPath(scenarioId), {});
   const name = String(raw?.name ?? "").trim() || DEFAULT_SCENARIO_META.name;
@@ -593,6 +598,7 @@ const readScenarioMeta = (scenarioId) => {
     hubOrigin: normalizeHubOrigin(raw?.hubOrigin),
     id: scenarioId,
     name,
+    playCount: normalizePlayCount(raw?.playCount),
     subtitle,
     updatedAt: raw?.updatedAt ?? new Date().toISOString(),
   };
@@ -644,7 +650,9 @@ const readGameMeta = (gameId) => {
     heroSubtitle: String(raw?.heroSubtitle ?? "").trim() || description,
     heroTitle: String(raw?.heroTitle ?? "").trim() || name,
     id: gameId,
+    lastPlayedAt: String(raw?.lastPlayedAt ?? "").trim() || null,
     name,
+    playCount: normalizePlayCount(raw?.playCount),
     scenarioId: String(raw?.scenarioId ?? "").trim() || DEFAULT_SCENARIO_ID,
     subtitle,
     updatedAt: raw?.updatedAt ?? new Date().toISOString(),
@@ -1358,6 +1366,35 @@ const setSelectedScenario = (scenarioId) => {
   return getLibraryCatalog();
 };
 
+// Play stamps power the main menu's "Last Played"/"Most Played" rows. They
+// bypass writeGameMeta/writeScenarioMeta on purpose: those stamp updatedAt
+// (which would turn "Last Updated" into "Last Played") and writeScenarioMeta
+// drops hubOrigin on any write it isn't explicitly handed (which would fork a
+// hub scenario off update tracking just for playing it).
+const recordGamePlayed = (gameId) => {
+  try {
+    const metaPath = getGameMetaPath(gameId);
+    const current = readJsonFile(metaPath, {});
+    writeJsonFile(metaPath, {
+      ...current,
+      lastPlayedAt: new Date().toISOString(),
+      playCount: normalizePlayCount(current?.playCount) + 1,
+    });
+
+    const scenarioId = String(current?.scenarioId ?? "").trim();
+    if (scenarioId && fs.existsSync(getScenarioDirectory(scenarioId))) {
+      const scenarioMetaPath = getScenarioMetaPath(scenarioId);
+      const scenarioMeta = readJsonFile(scenarioMetaPath, {});
+      writeJsonFile(scenarioMetaPath, {
+        ...scenarioMeta,
+        playCount: normalizePlayCount(scenarioMeta?.playCount) + 1,
+      });
+    }
+  } catch {
+    // Stamping is best-effort — never block activating a game over it.
+  }
+};
+
 const setActiveGame = (gameId) => {
   ensureGameStore();
 
@@ -1372,6 +1409,7 @@ const setActiveGame = (gameId) => {
   );
   manifest.order.unshift(gameId);
   saveGameManifest(manifest);
+  recordGamePlayed(gameId);
   return getLibraryCatalog();
 };
 
@@ -1554,6 +1592,9 @@ const createGame = ({
     manifest.activeGameId = resolvedGameId;
   }
   saveGameManifest(manifest);
+  if (setActive) {
+    recordGamePlayed(resolvedGameId);
+  }
 
   return getGameDetails(resolvedGameId);
 };

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -944,88 +944,125 @@ const validateChatOpener = (chatLike, path) => {
   return "";
 };
 
+// Strict/salvage discipline, the same contract clampTimelineDates follows:
+// the FIRST attempt returns corrective errors so the model can fix its own
+// answer; the SECOND attempt never rejects a finished generation — invalid
+// ops are DROPPED in place instead ("$.events[4].impacts.unitOps[0].unitId
+// does not identify an existing unit" used to trash whole good turns to the
+// canned fallback over one stale id).
 export const validateGeneratedWorldChanges = async (candidate, world, { strictTransfers = false } = {}) => {
+  const strict = strictTransfers;
   const containers = Array.isArray(candidate?.events)
     ? candidate.events.map((event, index) => ({ impacts: event?.impacts, path: `$.events[${index}].impacts` }))
     : [{ impacts: candidate?.impacts, path: "$.impacts" }];
   const unresolvedTransfers = await resolveRegionTransfers(containers, world);
-  if (strictTransfers && unresolvedTransfers.length > 0) {
+  if (strict && unresolvedTransfers.length > 0) {
     return buildTransferFeedback(unresolvedTransfers);
   }
   const unitIds = new Set(normalizeWorldState(world).units.map((unit) => normalizeString(unit.id)).filter(Boolean));
   const generatedPolities = [];
+  for (const { impacts } of containers) generatedPolities.push(...normalizeArray(impacts?.polityChanges));
 
   for (const { impacts, path } of containers) {
-    generatedPolities.push(...normalizeArray(impacts?.polityChanges));
+    const keptChats = [];
     for (let index = 0; index < normalizeArray(impacts?.createdChats).length; index += 1) {
       const createdChat = impacts.createdChats[index];
       const countries = await resolveInvitees(createdChat?.countries, world, generatedPolities);
       if (countries.length === 0) {
-        return `${path}.createdChats[${index}].countries must contain at least one known polity.`;
+        if (strict) return `${path}.createdChats[${index}].countries must contain at least one known polity.`;
+        continue; // salvage: drop the unresolvable chat, keep the turn
       }
-      // Strict attempt only (same contract as transfers): a blank, untitled
-      // chat tells the player nothing about why they were contacted — the
-      // retry demands the opener rather than dropping the turn to fallback.
-      if (strictTransfers) {
+      if (strict) {
         const chatError = validateChatOpener(createdChat, `${path}.createdChats[${index}]`);
         if (chatError) return chatError;
       }
+      keptChats.push(createdChat);
     }
+    if (impacts && Array.isArray(impacts.createdChats)) impacts.createdChats = keptChats;
 
+    const keptUnitOps = [];
     for (let index = 0; index < normalizeArray(impacts?.unitOps).length; index += 1) {
       const operation = impacts.unitOps[index];
       const operationPath = `${path}.unitOps[${index}]`;
       if (operation.op === "spawn") {
         if (!normalizeString(operation.unit?.name) || !normalizeString(operation.unit?.ownerCode)) {
-          return `${operationPath}.unit must have nonblank name and ownerCode values.`;
+          if (strict) return `${operationPath}.unit must have nonblank name and ownerCode values.`;
+          continue;
         }
         const spawnedId = normalizeString(operation.unit?.id);
-        if (spawnedId && unitIds.has(spawnedId)) return `${operationPath}.unit.id duplicates an existing unit.`;
-        if (spawnedId) unitIds.add(spawnedId);
+        if (spawnedId && unitIds.has(spawnedId)) {
+          if (strict) return `${operationPath}.unit.id duplicates an existing unit.`;
+          delete operation.unit.id; // salvage: let normalization mint a fresh id
+        } else if (spawnedId) {
+          unitIds.add(spawnedId);
+        }
+        keptUnitOps.push(operation);
         continue;
       }
 
       const unitId = normalizeString(operation.unitId);
-      if (!unitId) return `${operationPath}.unitId must not be blank.`;
-      if (!unitIds.has(unitId)) return `${operationPath}.unitId does not identify an existing unit.`;
+      if (!unitId) {
+        if (strict) return `${operationPath}.unitId must not be blank.`;
+        continue;
+      }
+      if (!unitIds.has(unitId)) {
+        if (strict) return `${operationPath}.unitId does not identify an existing unit.`;
+        continue; // salvage: drop the op aimed at a unit that no longer exists
+      }
       if (operation.op === "remove" || (operation.op === "strength" && operation.strength === 0)) unitIds.delete(unitId);
+      keptUnitOps.push(operation);
     }
+    if (impacts && Array.isArray(impacts.unitOps)) impacts.unitOps = keptUnitOps;
 
     // Marker ops that would be silently dropped by normalization instead fail
-    // here, so the retry tells the model what was missing.
+    // the strict attempt, so the retry tells the model what was missing.
+    const keptMarkerOps = [];
     for (let index = 0; index < normalizeArray(impacts?.markerOps).length; index += 1) {
       const operation = impacts.markerOps[index];
       const operationPath = `${path}.markerOps[${index}]`;
       const op = normalizeString(operation?.op).toLowerCase();
       if (op === "build" || op === "found") {
         const marker = operation.marker ?? operation;
-        if (!normalizeString(marker?.name)) return `${operationPath}.marker.name must not be blank.`;
+        if (!normalizeString(marker?.name)) {
+          if (strict) return `${operationPath}.marker.name must not be blank.`;
+          continue;
+        }
         if (!Number.isFinite(Number(marker?.lng)) || !Number.isFinite(Number(marker?.lat))) {
-          return `${operationPath}.marker must carry numeric lng and lat coordinates.`;
+          if (strict) return `${operationPath}.marker must carry numeric lng and lat coordinates.`;
+          continue;
         }
       } else if (op === "remove" || op === "destroy") {
         if (!normalizeString(operation?.name) && !normalizeString(operation?.markerId)) {
-          return `${operationPath} must carry the name (or markerId) of the structure to remove.`;
+          if (strict) return `${operationPath} must carry the name (or markerId) of the structure to remove.`;
+          continue;
         }
       }
+      keptMarkerOps.push(operation);
     }
+    if (impacts && Array.isArray(impacts.markerOps)) impacts.markerOps = keptMarkerOps;
   }
 
   // Unprompted outreach chats (top-level, not tied to an event) need real
   // participants exactly like createdChats do.
-  for (let index = 0; index < normalizeArray(candidate?.diplomaticOutreach).length; index += 1) {
-    const countries = await resolveInvitees(
-      candidate.diplomaticOutreach[index]?.countries,
-      world,
-      generatedPolities,
-    );
-    if (countries.length === 0) {
-      return `$.diplomaticOutreach[${index}].countries must contain at least one known polity.`;
+  if (Array.isArray(candidate?.diplomaticOutreach)) {
+    const keptOutreach = [];
+    for (let index = 0; index < candidate.diplomaticOutreach.length; index += 1) {
+      const countries = await resolveInvitees(
+        candidate.diplomaticOutreach[index]?.countries,
+        world,
+        generatedPolities,
+      );
+      if (countries.length === 0) {
+        if (strict) return `$.diplomaticOutreach[${index}].countries must contain at least one known polity.`;
+        continue;
+      }
+      if (strict) {
+        const chatError = validateChatOpener(candidate.diplomaticOutreach[index], `$.diplomaticOutreach[${index}]`);
+        if (chatError) return chatError;
+      }
+      keptOutreach.push(candidate.diplomaticOutreach[index]);
     }
-    if (strictTransfers) {
-      const chatError = validateChatOpener(candidate.diplomaticOutreach[index], `$.diplomaticOutreach[${index}]`);
-      if (chatError) return chatError;
-    }
+    candidate.diplomaticOutreach = keptOutreach;
   }
 
   return "";

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -433,7 +433,7 @@ const ScenarioDetail = ({ post, busy, onImport, onBack, notice, error }) => (
   </div>
 );
 
-const CommunityPanel = ({ onImported }) => {
+const CommunityPanel = ({ fullPage = false, onImported }) => {
   const { scenarios } = useLibraryState();
   const [posts, setPosts] = useState(null);
   const [error, setError] = useState(null);
@@ -618,7 +618,9 @@ const CommunityPanel = ({ onImported }) => {
   };
 
   return (
-    <div style={{ color: "#fff", maxHeight: "calc(100vh - 11rem)", overflowY: "auto", paddingRight: "0.2rem" }}>
+    // As the main menu's Community tab (fullPage) the surrounding page owns
+    // scrolling; as a floating panel it caps its own height and scrolls itself.
+    <div style={{ color: "#fff", ...(fullPage ? {} : { maxHeight: "calc(100vh - 11rem)", overflowY: "auto", paddingRight: "0.2rem" }) }}>
       {selectedPost ? (
         <ScenarioDetail
           post={selectedPost}

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -83,11 +83,18 @@ const TECHNICAL_OWNER_CODES = new Set([
   "Z09",
 ]);
 
-// Set by the mounted LibraryTopBar; lets the no-game gate open a tab.
+// Set by the mounted LibraryTopBar; lets outside callers open the main menu
+// on a specific tab.
 let _openLibraryTab = null;
 export const openLibraryTab = (tab) => {
   _openLibraryTab?.(tab);
 };
+
+// Whether the main menu is showing. Lives at module scope because the whole UI
+// tree (this component included) remounts whenever the active game changes —
+// per-component state would reset to "open" mid game-start and the menu would
+// pop back over the freshly activated game. The app boots into the menu.
+let menuOpenDefault = true;
 const TOP_BAR_OFFSET = "4.75rem";
 
 const surfaceStyle = {
@@ -608,6 +615,52 @@ const GameCard = ({ active, game, onActivate, onClone, onEdit }) => {
   );
 };
 
+// A netflix-style shelf on the main menu: a titled row of horizontally
+// scrolling cards. Rows that can be legitimately empty pass emptyText.
+const MenuRow = ({ children, emptyText, title }) => (
+  <div style={{ marginBottom: "1.7rem" }}>
+    <div style={{ color: "rgba(255,255,255,0.88)", fontSize: "1.02rem", fontWeight: 800, letterSpacing: "-0.01em", marginBottom: "0.7rem" }}>
+      {title}
+    </div>
+    {React.Children.count(children) > 0 ? (
+      <div style={{ display: "flex", gap: "0.9rem", overflowX: "auto", paddingBottom: "0.35rem", scrollbarWidth: "thin" }}>
+        {children}
+      </div>
+    ) : (
+      <div style={{ color: "rgba(255,255,255,0.45)", fontSize: "0.85rem", padding: "0.4rem 0 0.6rem" }}>
+        {emptyText || "Nothing here yet."}
+      </div>
+    )}
+  </div>
+);
+
+// First slot of "Your Scenarios": the big + that creates a blank scenario.
+const CreateScenarioTile = ({ busy, onCreate }) => (
+  <button
+    disabled={busy}
+    onClick={onCreate}
+    type="button"
+    style={{
+      alignItems: "center",
+      background: "rgba(255,255,255,0.03)",
+      border: "2px dashed rgba(255,255,255,0.24)",
+      borderRadius: "24px",
+      color: "rgba(255,255,255,0.78)",
+      cursor: busy ? "wait" : "pointer",
+      display: "flex",
+      flex: "0 0 21rem",
+      flexDirection: "column",
+      gap: "0.55rem",
+      justifyContent: "center",
+      minHeight: "15rem",
+      opacity: busy ? 0.6 : 1,
+    }}
+  >
+    <span aria-hidden="true" style={{ fontSize: "4.6rem", fontWeight: 300, lineHeight: 1 }}>+</span>
+    <span style={{ fontSize: "0.95rem", fontWeight: 700 }}>Create Scenario</span>
+  </button>
+);
+
 const SectionTabs = ({ currentSection, sections, setSection }) => (
   <div style={{ display: "flex", flexWrap: "wrap", gap: "0.45rem", marginBottom: "0.95rem" }}>
     {sections.map((sectionKey) => (
@@ -678,7 +731,9 @@ const EditorDrawer = ({
         right: "0.85rem",
         top: `calc(${TOP_BAR_OFFSET} + 3.5rem)`,
         width: "min(34rem, calc(100vw - 1.2rem))",
-        zIndex: 10031,
+        // Above the main menu (10046) — the menu's + tile and Edit buttons open
+        // this drawer, and it must land on top of the menu it came from.
+        zIndex: 10048,
       }}
     >
       <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", marginBottom: "1rem" }}>
@@ -992,11 +1047,19 @@ const LibraryTopBar = () => {
     selectedScenarioId,
   } = useLibraryState();
   const [activeTab, setActiveTab] = useState("games");
-  const [isPanelOpen, setIsPanelOpen] = useState(false);
-  // Bridge for outside callers (the no-game gate): open a library tab.
+  const [menuOpen, setMenuOpenState] = useState(menuOpenDefault);
+  // The module-level default is the ONLY value that survives the keyed UI
+  // remount a game activation triggers, so every open/close writes it first.
+  // Flows that activate a game flip it BEFORE awaiting the request — the
+  // remount happens mid-await, and the new instance must mount closed.
+  const setMenuOpen = (open) => {
+    menuOpenDefault = open;
+    setMenuOpenState(open);
+  };
+  // Bridge for outside callers: open the main menu on a library tab.
   _openLibraryTab = (tab) => {
     setActiveTab(tab);
-    setIsPanelOpen(true);
+    setMenuOpen(true);
   };
   const [editorKind, setEditorKind] = useState(null);
   const [editorDetails, setEditorDetails] = useState(null);
@@ -1066,6 +1129,9 @@ const LibraryTopBar = () => {
     setCustomRegionData(null);
     setEditorError(null);
     setIsBusy(true);
+    // Before the await: createGame({setActive}) remounts the UI mid-flight and
+    // the remounted menu must come up closed, over the new game.
+    setMenuOpen(false);
     try {
       const details = await createGame({
         name: `${scenario.name} Session`,
@@ -1080,6 +1146,7 @@ const LibraryTopBar = () => {
       }
       await openGameEditor(details.game.id);
     } catch (nextError) {
+      setMenuOpen(true);
       setEditorError(nextError.message);
     } finally {
       setIsBusy(false);
@@ -1094,6 +1161,7 @@ const LibraryTopBar = () => {
     setCustomRegionData(null);
     setEditorError(null);
     setIsBusy(true);
+    setMenuOpen(false);
     try {
       const details = await createGame({
         name: `${faction.name} — ${scenario.name}`,
@@ -1148,6 +1216,7 @@ const LibraryTopBar = () => {
 
       await openGameEditor(gameId);
     } catch (nextError) {
+      setMenuOpen(true);
       setEditorError(nextError.message);
     } finally {
       setIsBusy(false);
@@ -1232,7 +1301,7 @@ const LibraryTopBar = () => {
   // buttons — offline behaves exactly as before.
   const [hubPostById, setHubPostById] = useState(null);
   useEffect(() => {
-    if (activeTab !== "scenarios" || !scenarios.some((entry) => entry.hubOrigin)) return undefined;
+    if (!menuOpen || activeTab !== "scenarios" || !scenarios.some((entry) => entry.hubOrigin)) return undefined;
     let cancelled = false;
     import("./communityHub.jsx")
       .then(({ fetchHubPosts }) => fetchHubPosts())
@@ -1246,7 +1315,7 @@ const LibraryTopBar = () => {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, scenarios]);
+  }, [menuOpen, activeTab, scenarios]);
 
   const scenarioUpdateAvailable = (scenario) => Boolean(
     scenario.hubOrigin &&
@@ -1298,6 +1367,7 @@ const LibraryTopBar = () => {
   const handleGameClone = async (game) => {
     setEditorError(null);
     setIsBusy(true);
+    setMenuOpen(false);
 
     try {
       const details = await createGame({
@@ -1306,6 +1376,34 @@ const LibraryTopBar = () => {
         setActive: true,
       });
       await openGameEditor(details.game.id);
+    } catch (nextError) {
+      setMenuOpen(true);
+      setEditorError(nextError.message);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  // Play an existing game from the menu: close the menu (module flag first —
+  // the activation remounts the UI) and activate. Reopen only on failure.
+  const handleGameActivate = async (gameId) => {
+    setMenuOpen(false);
+    try {
+      await activateGame(gameId);
+    } catch (nextError) {
+      setMenuOpen(true);
+      setEditorError(nextError.message);
+    }
+  };
+
+  // Blank scenario from the menu's + tile: create (seeded server-side from the
+  // default scenario) and drop straight into its editor, above the menu.
+  const handleCreateScenario = async () => {
+    setEditorError(null);
+    setIsBusy(true);
+    try {
+      const details = await createScenario({ name: "New Scenario", setActive: true });
+      await openScenarioEditor(details.scenario.id);
     } catch (nextError) {
       setEditorError(nextError.message);
     } finally {
@@ -1591,7 +1689,7 @@ const LibraryTopBar = () => {
       }
       const details = await importScenarioBundle(bundle);
       setActiveTab("scenarios");
-      setIsPanelOpen(true);
+      setMenuOpen(true);
       await openScenarioEditor(details.scenario.id);
     } catch (nextError) {
       setEditorError(nextError.message);
@@ -1609,16 +1707,6 @@ const LibraryTopBar = () => {
 
     return "No active game";
   }, [activeGame, activeCountryName]);
-
-  const handleTabToggle = (tab) => {
-    if (activeTab === tab) {
-      setIsPanelOpen((open) => !open);
-      return;
-    }
-
-    setActiveTab(tab);
-    setIsPanelOpen(true);
-  };
 
   const isMobile = useIsMobile();
   // True once the user shut the server down from the ⏻ button — swaps the whole
@@ -1756,7 +1844,9 @@ const LibraryTopBar = () => {
 
     // Create + activate a fresh game so the running map reflects the edit. Relying
     // on the player finishing a follow-up picker left the old active game (and old
-    // map) in place — this guarantees the new map is live.
+    // map) in place — this guarantees the new map is live. Menu flag first: the
+    // activation remounts the UI and the remount must come up menu-closed.
+    setMenuOpen(false);
     const gameDetails = await createGame({
       name: `${scenario.name} Session`,
       scenarioId,
@@ -1772,7 +1862,7 @@ const LibraryTopBar = () => {
     setMapEditorScenario(null);
     setMapEditorSeed(null);
     resetEditor();
-    setIsPanelOpen(false);
+    setMenuOpen(false);
 
     // Optional: let the player pick who they control on the new game — limited to
     // the factions this map actually contains.
@@ -1809,6 +1899,7 @@ const LibraryTopBar = () => {
     setCustomRegionData(null);
     setPlayGameId(null);
     if (!gid) return;
+    setMenuOpen(false);
     try {
       const gamePatch = { ...(countryCode ? { country: countryCode } : null), ...(difficulty ? { difficulty } : null) };
       if (Object.keys(gamePatch).length) {
@@ -1846,87 +1937,114 @@ const LibraryTopBar = () => {
     ? countryOptions.find((country) => country.code === difficultyPick.countryCode)
     : null;
 
+  // ---- Main-menu shelves ----------------------------------------------------
+  // The catalog's game order is already activation recency (activating unshifts),
+  // so games without a lastPlayedAt stamp (pre-feature saves) keep a sensible
+  // relative order behind the stamped ones.
+  const lastPlayedGames = useMemo(
+    () => [...games].sort((a, b) => String(b.lastPlayedAt ?? "").localeCompare(String(a.lastPlayedAt ?? ""))),
+    [games],
+  );
+  const mostPlayedGames = useMemo(
+    () => [...games].sort((a, b) => (b.playCount ?? 0) - (a.playCount ?? 0) || (b.round ?? 0) - (a.round ?? 0)),
+    [games],
+  );
+  const mostPlayedScenarios = useMemo(
+    () => [...scenarios].sort((a, b) => (b.playCount ?? 0) - (a.playCount ?? 0) || (b.gameCount ?? 0) - (a.gameCount ?? 0)),
+    [scenarios],
+  );
+  const lastUpdatedScenarios = useMemo(
+    () => [...scenarios].sort((a, b) => String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? ""))),
+    [scenarios],
+  );
+  // "Your Scenarios": ones the player made or edited themselves. hubOrigin is
+  // null for locally created scenarios AND for hub imports edited locally (any
+  // local meta write clears it — see writeScenarioMeta). The stock built-in
+  // only counts once it has actually been touched.
+  const yourScenarios = useMemo(
+    () => scenarios.filter(
+      (scenario) => !scenario.hubOrigin && (scenario.id !== "default" || scenario.updatedAt !== scenario.createdAt),
+    ),
+    [scenarios],
+  );
+
   return (
     <>
-      <div
-        style={{
-          ...surfaceStyle,
-          alignItems: "center",
-          borderLeft: "none",
-          borderRadius: 0,
-          borderRight: "none",
-          borderTop: "none",
-          display: "grid",
-          gap: isMobile ? "0.4rem" : "0.9rem",
-          gridTemplateColumns: "minmax(0, 1fr) auto minmax(0, 1fr)",
-          height: `${BAR_HEIGHT}px`,
-          left: 0,
-          padding: isMobile ? "0 0.5rem" : "0 1rem",
-          position: "fixed",
-          right: 0,
-          top: 0,
-          zIndex: 10030,
-        }}
-      >
-        <div style={{ alignItems: "center", display: "flex", gap: "0.8rem", minWidth: 0 }}>
-          <div style={{ alignItems: "center", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "999px", display: "flex", flexShrink: 0, height: "2.65rem", justifyContent: "center", overflow: "hidden", width: "2.65rem" }}>
-            <img alt="Open Historia" src="/logo.png" style={{ height: "1.7rem", width: "1.7rem" }} />
-          </div>
-          {/* Phones keep the logo only — the title/summary would crowd out the tabs. */}
-          {!isMobile && (
-            <div style={{ minWidth: 0 }}>
-              <div style={{ color: "#fff", fontSize: "1rem", fontWeight: 800, letterSpacing: "-0.03em" }}>
-                Open Historia
-              </div>
-              <div style={{ color: "rgba(255,255,255,0.48)", fontSize: "0.72rem", marginTop: "0.08rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", width: "min(28rem, 46vw)" }}>
-                {summaryText}
-              </div>
+      {/* In-game top bar. The library tabs moved to the main menu — in-game it
+          identifies the session and offers the way back (Exit Game). */}
+      {!menuOpen && (
+        <div
+          style={{
+            ...surfaceStyle,
+            alignItems: "center",
+            borderLeft: "none",
+            borderRadius: 0,
+            borderRight: "none",
+            borderTop: "none",
+            display: "grid",
+            gap: isMobile ? "0.4rem" : "0.9rem",
+            gridTemplateColumns: "minmax(0, 1fr) auto",
+            height: `${BAR_HEIGHT}px`,
+            left: 0,
+            padding: isMobile ? "0 0.5rem" : "0 1rem",
+            position: "fixed",
+            right: 0,
+            top: 0,
+            zIndex: 10030,
+          }}
+        >
+          <div style={{ alignItems: "center", display: "flex", gap: "0.8rem", minWidth: 0 }}>
+            <div style={{ alignItems: "center", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "999px", display: "flex", flexShrink: 0, height: "2.65rem", justifyContent: "center", overflow: "hidden", width: "2.65rem" }}>
+              <img alt="Open Historia" src="/logo.png" style={{ height: "1.7rem", width: "1.7rem" }} />
             </div>
-          )}
-        </div>
-
-        <div style={{ alignItems: "center", display: "flex", gap: "0.55rem", justifyContent: "center", justifySelf: "center" }}>
-          {["games", "scenarios", "community"].map((tab) => (
-            <button
-              key={tab}
-              onClick={() => handleTabToggle(tab)}
-              style={{
-                ...actionButtonStyle,
-                background: activeTab === tab ? "rgba(124,58,237,0.24)" : "rgba(255,255,255,0.05)",
-                borderColor: activeTab === tab ? "rgba(124,58,237,0.38)" : "rgba(255,255,255,0.08)",
-                minWidth: isMobile ? "0" : "6.6rem",
-                padding: isMobile ? "0.55rem 0.7rem" : undefined,
-              }}
-              type="button"
-            >
-              {tab === "games" ? "Games" : tab === "scenarios" ? "Scenarios" : "Community"}
-            </button>
-          ))}
-        </div>
-
-        {/* Top-right: shut the server down (phones/Termux have no terminal handy).
-            Hidden on the hosted website (web build) — there's no local server to
-            stop there, and the compile-time flag strips this from that bundle. */}
-        {!import.meta.env.VITE_OH_WEB && (
-          <div style={{ alignItems: "center", display: "flex", justifyContent: "flex-end" }}>
-            <button
-              onClick={handleShutdownServer}
-              title="Exit: shut down the Open Historia server"
-              type="button"
-              style={{
-                ...actionButtonStyle,
-                background: "rgba(220,70,70,0.14)",
-                borderColor: "rgba(248,113,113,0.35)",
-                color: "#fca5a5",
-                minWidth: "2.35rem",
-                padding: isMobile ? "0.55rem 0.7rem" : undefined,
-              }}
-            >
-              ⏻
-            </button>
+            {/* Phones keep the logo only — the title/summary would crowd the buttons. */}
+            {!isMobile && (
+              <div style={{ minWidth: 0 }}>
+                <div style={{ color: "#fff", fontSize: "1rem", fontWeight: 800, letterSpacing: "-0.03em" }}>
+                  Open Historia
+                </div>
+                <div style={{ color: "rgba(255,255,255,0.48)", fontSize: "0.72rem", marginTop: "0.08rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", width: "min(28rem, 46vw)" }}>
+                  {summaryText}
+                </div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+
+          <div style={{ alignItems: "center", display: "flex", gap: "0.55rem", justifyContent: "flex-end" }}>
+            <button
+              onClick={() => setMenuOpen(true)}
+              title="Leave this game and return to the main menu"
+              type="button"
+              style={{
+                ...actionButtonStyle,
+                padding: isMobile ? "0.55rem 0.7rem" : undefined,
+              }}
+            >
+              {isMobile ? "⌂" : "⌂ Exit Game"}
+            </button>
+            {/* Shut the server down (phones/Termux have no terminal handy). Hidden
+                on the hosted website (web build) — there's no local server to stop
+                there, and the compile-time flag strips this from that bundle. */}
+            {!import.meta.env.VITE_OH_WEB && (
+              <button
+                onClick={handleShutdownServer}
+                title="Exit: shut down the Open Historia server"
+                type="button"
+                style={{
+                  ...actionButtonStyle,
+                  background: "rgba(220,70,70,0.14)",
+                  borderColor: "rgba(248,113,113,0.35)",
+                  color: "#fca5a5",
+                  minWidth: "2.35rem",
+                  padding: isMobile ? "0.55rem 0.7rem" : undefined,
+                }}
+              >
+                ⏻
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {serverDown && (
         <div
@@ -2117,57 +2235,165 @@ const LibraryTopBar = () => {
         type="file"
       />
 
-      {isPanelOpen && (
+      {/* The Main Menu: a full page over everything in-game. Opens on app start
+          (module default) and via Exit Game; closes only by entering a game. */}
+      {menuOpen && (
         <div
           style={{
-            ...surfaceStyle,
-            borderRadius: "0 0 28px 28px",
-            left: "0.85rem",
-            maxWidth: "calc(100vw - 1.7rem)",
-            padding: "1rem",
+            background:
+              "radial-gradient(circle at 12% -4%, rgba(124,58,237,0.16), transparent 42%), " +
+              "radial-gradient(circle at 88% 110%, rgba(56,120,255,0.10), transparent 46%), " +
+              "linear-gradient(180deg, #0b1020 0%, #090d18 100%)",
+            color: "#fff",
+            display: "flex",
+            flexDirection: "column",
+            fontFamily: "sans-serif",
+            inset: 0,
             position: "fixed",
-            right: "0.85rem",
-            top: `${BAR_HEIGHT}px`,
-            zIndex: 10029,
+            zIndex: 10046,
           }}
         >
-          {activeTab !== "community" && (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "0.55rem", justifyContent: "flex-end", marginBottom: "0.9rem" }}>
-              <button onClick={() => refreshLibraryCatalog({ force: true }).catch(() => {})} style={actionButtonStyle} type="button">
-                Refresh
-              </button>
+          <div
+            style={{
+              alignItems: "center",
+              borderBottom: "1px solid rgba(255,255,255,0.08)",
+              display: "grid",
+              flexShrink: 0,
+              gap: isMobile ? "0.4rem" : "0.9rem",
+              gridTemplateColumns: "minmax(0, 1fr) auto minmax(0, 1fr)",
+              height: `${BAR_HEIGHT}px`,
+              padding: isMobile ? "0 0.5rem" : "0 1rem",
+            }}
+          >
+            <div style={{ alignItems: "center", display: "flex", gap: "0.8rem", minWidth: 0 }}>
+              <div style={{ alignItems: "center", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "999px", display: "flex", flexShrink: 0, height: "2.65rem", justifyContent: "center", overflow: "hidden", width: "2.65rem" }}>
+                <img alt="Open Historia" src="/logo.png" style={{ height: "1.7rem", width: "1.7rem" }} />
+              </div>
+              {!isMobile && (
+                <div style={{ color: "#fff", fontSize: "1.05rem", fontWeight: 800, letterSpacing: "-0.03em" }}>
+                  Open Historia
+                </div>
+              )}
+            </div>
+
+            <div style={{ alignItems: "center", display: "flex", gap: "0.55rem", justifyContent: "center", justifySelf: "center" }}>
+              {["games", "scenarios", "community"].map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
+                  style={{
+                    ...actionButtonStyle,
+                    background: activeTab === tab ? "rgba(124,58,237,0.24)" : "rgba(255,255,255,0.05)",
+                    borderColor: activeTab === tab ? "rgba(124,58,237,0.38)" : "rgba(255,255,255,0.08)",
+                    minWidth: isMobile ? "0" : "6.6rem",
+                    padding: isMobile ? "0.55rem 0.7rem" : undefined,
+                  }}
+                  type="button"
+                >
+                  {tab === "games" ? "Games" : tab === "scenarios" ? "Scenarios" : "Community"}
+                </button>
+              ))}
+            </div>
+
+            <div style={{ alignItems: "center", display: "flex", gap: "0.55rem", justifyContent: "flex-end" }}>
+              {activeTab !== "community" && (
+                <button onClick={() => refreshLibraryCatalog({ force: true }).catch(() => {})} style={actionButtonStyle} type="button">
+                  {isMobile ? "⟳" : "Refresh"}
+                </button>
+              )}
               {activeTab === "scenarios" && (
                 <button onClick={() => importScenarioInputRef.current?.click()} style={actionButtonStyle} type="button">
-                  Import JSON
+                  {isMobile ? "⬆" : "Import JSON"}
+                </button>
+              )}
+              {!import.meta.env.VITE_OH_WEB && (
+                <button
+                  onClick={handleShutdownServer}
+                  title="Exit: shut down the Open Historia server"
+                  type="button"
+                  style={{
+                    ...actionButtonStyle,
+                    background: "rgba(220,70,70,0.14)",
+                    borderColor: "rgba(248,113,113,0.35)",
+                    color: "#fca5a5",
+                    minWidth: "2.35rem",
+                    padding: isMobile ? "0.55rem 0.7rem" : undefined,
+                  }}
+                >
+                  ⏻
                 </button>
               )}
             </div>
-          )}
+          </div>
 
-          {activeTab === "community" ? (
-            <Suspense
-              fallback={
-                <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.85rem", padding: "1rem 0" }}>
-                  Loading Community…
+          <div style={{ flex: 1, overflowY: "auto", padding: isMobile ? "1.1rem 0.8rem 2.5rem" : "1.5rem 1.6rem 3rem" }}>
+            {activeTab === "community" ? (
+              <Suspense
+                fallback={
+                  <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.85rem", padding: "1rem 0" }}>
+                    Loading Community…
+                  </div>
+                }
+              >
+                <CommunityPanel fullPage onImported={() => setActiveTab("scenarios")} />
+              </Suspense>
+            ) : activeTab === "games" ? (
+              loaded && games.length === 0 ? (
+                <div style={{ alignItems: "center", display: "flex", flexDirection: "column", justifyContent: "center", minHeight: "60vh", textAlign: "center" }}>
+                  <img alt="" src="/logo.png" style={{ height: "5rem", marginBottom: "1.2rem", opacity: 0.9, width: "5rem" }} />
+                  <div style={{ fontSize: "1.5rem", fontWeight: 800, letterSpacing: "-0.02em" }}>No games yet</div>
+                  <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.95rem", lineHeight: 1.6, margin: "0.6rem 0 1.6rem", maxWidth: "26rem" }}>
+                    Start a new game from one of your scenarios, or grab new scenarios from the community first.
+                  </div>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "0.7rem", justifyContent: "center" }}>
+                    <button
+                      type="button"
+                      style={{ ...actionButtonStyle, background: "rgba(124,58,237,0.3)", borderColor: "rgba(139,92,246,0.55)", minHeight: "2.8rem", padding: "0 1.4rem" }}
+                      onClick={() => setActiveTab("scenarios")}
+                    >
+                      Start from a scenario
+                    </button>
+                    <button
+                      type="button"
+                      style={{ ...actionButtonStyle, minHeight: "2.8rem", padding: "0 1.4rem" }}
+                      onClick={() => setActiveTab("community")}
+                    >
+                      Browse community scenarios
+                    </button>
+                  </div>
                 </div>
-              }
-            >
-              <CommunityPanel onImported={() => setActiveTab("scenarios")} />
-            </Suspense>
-          ) : (
-            <div style={{ display: "flex", gap: "0.9rem", overflowX: "auto", paddingBottom: "0.15rem", scrollbarWidth: "thin" }}>
-              {activeTab === "games"
-                ? games.map((game) => (
-                    <GameCard
-                      key={game.id}
-                      active={game.id === activeGameId}
-                      game={game}
-                      onActivate={activateGame}
-                      onClone={handleGameClone}
-                      onEdit={openGameEditor}
-                    />
-                  ))
-                : scenarios.map((scenario) => (
+              ) : (
+                <>
+                  <MenuRow title="🕐 Last Played">
+                    {lastPlayedGames.map((game) => (
+                      <GameCard
+                        key={game.id}
+                        active={game.id === activeGameId}
+                        game={game}
+                        onActivate={handleGameActivate}
+                        onClone={handleGameClone}
+                        onEdit={openGameEditor}
+                      />
+                    ))}
+                  </MenuRow>
+                  <MenuRow title="🔥 Most Played">
+                    {mostPlayedGames.map((game) => (
+                      <GameCard
+                        key={game.id}
+                        active={game.id === activeGameId}
+                        game={game}
+                        onActivate={handleGameActivate}
+                        onClone={handleGameClone}
+                        onEdit={openGameEditor}
+                      />
+                    ))}
+                  </MenuRow>
+                </>
+              )
+            ) : (
+              <>
+                <MenuRow title="🔥 Most Played" emptyText="No scenarios yet.">
+                  {mostPlayedScenarios.map((scenario) => (
                     <ScenarioCard
                       key={scenario.id}
                       onClone={handleScenarioClone}
@@ -2180,8 +2406,41 @@ const LibraryTopBar = () => {
                       updateAvailable={scenarioUpdateAvailable(scenario)}
                     />
                   ))}
-            </div>
-          )}
+                </MenuRow>
+                <MenuRow title="🕐 Last Updated" emptyText="No scenarios yet.">
+                  {lastUpdatedScenarios.map((scenario) => (
+                    <ScenarioCard
+                      key={scenario.id}
+                      onClone={handleScenarioClone}
+                      onEdit={openScenarioEditor}
+                      onPlay={handleScenarioPlay}
+                      onSelect={selectScenario}
+                      onUpdate={handleScenarioUpdate}
+                      scenario={scenario}
+                      selected={scenario.id === selectedScenarioId}
+                      updateAvailable={scenarioUpdateAvailable(scenario)}
+                    />
+                  ))}
+                </MenuRow>
+                <MenuRow title="✦ Your Scenarios">
+                  <CreateScenarioTile busy={isBusy} onCreate={handleCreateScenario} />
+                  {yourScenarios.map((scenario) => (
+                    <ScenarioCard
+                      key={scenario.id}
+                      onClone={handleScenarioClone}
+                      onEdit={openScenarioEditor}
+                      onPlay={handleScenarioPlay}
+                      onSelect={selectScenario}
+                      onUpdate={handleScenarioUpdate}
+                      scenario={scenario}
+                      selected={scenario.id === selectedScenarioId}
+                      updateAvailable={scenarioUpdateAvailable(scenario)}
+                    />
+                  ))}
+                </MenuRow>
+              </>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -1,7 +1,7 @@
 /*! Open Historia — portions (mobile HUD wiring + advisor/forces launchers) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import { SettingsButton, SettingsMenu } from "./settings";
-import { LibraryTopBar, TOP_BAR_OFFSET, openLibraryTab } from "./libraryBar";
+import { LibraryTopBar, TOP_BAR_OFFSET } from "./libraryBar";
 import { useLibraryState } from "../../runtime/library.js";
 import { DateWidget } from "./time";
 import { Other } from "./other";
@@ -100,70 +100,6 @@ const WebGLWarningPopup = () => (
   </div>
 );
 
-// Fullscreen gate shown when the library has NO games: the map and HUD stay
-// hidden behind it, and the player is walked into starting a game from a
-// scenario (or grabbing new scenarios from the Community tab) instead of
-// staring at a spectator world they aren't playing in. The top bar and its
-// panels render above the gate, so the normal New Game flow works on top.
-const NoGameGate = () => {
-  useEffect(() => {
-    // Land the player straight in the scenario list.
-    openLibraryTab("scenarios");
-  }, []);
-
-  const gateButtonStyle = {
-    alignItems: "center",
-    background: "rgba(124,58,237,0.3)",
-    border: "1px solid rgba(139,92,246,0.55)",
-    borderRadius: "12px",
-    color: "white",
-    cursor: "pointer",
-    display: "flex",
-    fontSize: "0.95rem",
-    fontWeight: 700,
-    gap: "0.5rem",
-    justifyContent: "center",
-    padding: "0.85rem 1.4rem",
-  };
-
-  return (
-    <div
-      style={{
-        alignItems: "center",
-        background: "#0b1020",
-        color: "white",
-        display: "flex",
-        flexDirection: "column",
-        fontFamily: "sans-serif",
-        inset: 0,
-        justifyContent: "center",
-        position: "fixed",
-        textAlign: "center",
-        zIndex: 10010,
-      }}
-    >
-      <img alt="" src="/logo.png" style={{ height: "5rem", marginBottom: "1.2rem", opacity: 0.9, width: "5rem" }} />
-      <div style={{ fontSize: "1.5rem", fontWeight: 800, letterSpacing: "-0.02em" }}>No game yet</div>
-      <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.95rem", lineHeight: 1.6, margin: "0.6rem 0 1.6rem", maxWidth: "26rem", padding: "0 1rem" }}>
-        Start a new game from one of your scenarios, or grab new scenarios
-        from the community first.
-      </div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.7rem", justifyContent: "center", padding: "0 1rem" }}>
-        <button type="button" style={gateButtonStyle} onClick={() => openLibraryTab("scenarios")}>
-          Start from a scenario
-        </button>
-        <button
-          type="button"
-          style={{ ...gateButtonStyle, background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.16)" }}
-          onClick={() => openLibraryTab("community")}
-        >
-          Browse community scenarios
-        </button>
-      </div>
-    </div>
-  );
-};
-
 const AdvisorButton = ({ isAdvisorOpen, rightShift, onToggle }) => (
   <button onClick={onToggle} style={{
     ...baseStyle,
@@ -194,8 +130,8 @@ const Main = ({
   const [apiProvider, setApiProvider] = useState(() => getStoredProvider());
   const [providerSettings, setProviderSettings] = useState(() => loadProviderSettingsFormState());
   const { games, loaded } = useLibraryState();
-  // No games -> the map is hidden behind a start gate (see NoGameGate).
-  const showNoGameGate = loaded && (games?.length ?? 0) === 0;
+  // No games -> nothing to simulate (the main menu covers the empty world).
+  const hasNoGames = loaded && (games?.length ?? 0) === 0;
 
   useEffect(() => {
     if (!checkWebGL()) setShowWebGLWarning(true);
@@ -208,7 +144,7 @@ const Main = ({
   // command, or catalyst stage is in flight, never overlaps itself, and stays
   // silent on any failure. Hidden tabs don't roll the dice.
   useEffect(() => {
-    if (showNoGameGate) return undefined;
+    if (hasNoGames) return undefined;
     const iv = setInterval(() => {
       if (document.visibilityState !== "visible") return;
       import("../AI/gameplay.js")
@@ -216,7 +152,7 @@ const Main = ({
         .catch(() => {});
     }, 60000);
     return () => clearInterval(iv);
-  }, [showNoGameGate]);
+  }, [hasNoGames]);
 
   useEffect(() => {
     if (isAdvisorOpen) setShouldLoadAdvisor(true);
@@ -292,7 +228,6 @@ const Main = ({
   return (
     <>
       {showWebGLWarning && <WebGLWarningPopup />}
-      {showNoGameGate && <NoGameGate />}
       <LibraryTopBar />
       <DateWidget
         activePanel={activeBottomPanel}

--- a/src/Game/GameUI/stats.jsx
+++ b/src/Game/GameUI/stats.jsx
@@ -72,12 +72,31 @@ const Bar = ({ value, color }) => (
     </div>
 );
 
+// The AI writes economic figures however it likes — "30000000000",
+// "$30,000,000,000", "2.1%", "1.2 trillion caps". Raw long numbers overflow
+// the card, so purely numeric values from a million up render compactly
+// (30000000000 → 30.0B) with any currency prefix preserved; everything else
+// (percentages, prose) passes through untouched.
+const compactEconomyValue = (value) => {
+    if (value === null || value === undefined) return value;
+    const text = String(value).trim();
+    const match = /^([^0-9-]{0,4})(-?\d[\d,]*)(?:\.(\d+))?$/.exec(text);
+    if (!match) return value;
+    const number = Number(`${match[2].replace(/,/g, "")}${match[3] ? `.${match[3]}` : ""}`);
+    if (!Number.isFinite(number) || Math.abs(number) < 1e6) return value;
+    const prefix = match[1] ?? "";
+    const abs = Math.abs(number);
+    const [divisor, suffix] = abs >= 1e12 ? [1e12, "T"] : abs >= 1e9 ? [1e9, "B"] : [1e6, "M"];
+    const compact = (number / divisor).toFixed(abs / divisor >= 100 ? 0 : 1);
+    return `${prefix}${compact}${suffix}`;
+};
+
 const EconomyCard = ({ label, value, sub, tone }) => (
     <div style={cardStyle}>
     <div style={{ color: "rgba(255,255,255,0.45)", fontSize: "0.62rem", fontWeight: 700, letterSpacing: "0.06em", marginBottom: "0.3rem", textTransform: "uppercase" }}>
     {label}
     </div>
-    <div data-no-translate style={{ color: tone, fontSize: "1.05rem", fontWeight: 800 }}>{value || "—"}</div>
+    <div data-no-translate style={{ color: tone, fontSize: "1.05rem", fontWeight: 800 }}>{compactEconomyValue(value) || "—"}</div>
     {sub && <div style={{ color: "rgba(255,255,255,0.4)", fontSize: "0.68rem", marginTop: "0.15rem" }}>{sub}</div>}
     </div>
 );

--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -17,7 +17,7 @@ import {
   PMTILES_ASSET_KEYS, SCENARIO_GEOJSON_ASSET_KEYS, UPLOADABLE_SCENARIO_ASSET_KEYS, UPLOADABLE_GAME_ASSET_KEYS,
   JSON_ASSET_DEFAULTS, SCENARIO_BUNDLE_SCHEMA, ACCEPTED_BUNDLE_SCHEMAS, SCENARIO_BUNDLE_VERSION, SUPPORTED_IMAGE_CONTENT_TYPES,
   DEFAULT_SCENARIO_META, DEFAULT_GAME_META, canonicalizeWorldCountryRefs, canonicalizeGameCountry, canonicalizeColorKeys,
-  readScenarioMeta, readGameMeta, readStoredImageContentType, resolveOrderedIds, normalizeId,
+  readScenarioMeta, readGameMeta, readStoredImageContentType, resolveOrderedIds, normalizeId, normalizePlayCount,
   scenarioLooksLikeRuntimeSnapshot, buildFreshGameSeedFromScenario, buildFreshWorldSeedFromScenario,
   normalizeRuntimeWorld, COUNTRY_NAME_REGISTRY, normalizeHubOrigin,
 } from "./models.js";
@@ -713,6 +713,7 @@ const createGame = async (body = {}) => {
   const order = resolveOrderedIds(manifest.order, await listGameIds(), DEFAULT_GAME_ID).filter((e) => e !== id);
   order.unshift(id);
   await saveGameManifest({ activeGameId: body.setActive ? id : manifest.activeGameId, order });
+  if (body.setActive) await recordGamePlayed(id);
   return getGameDetails(id);
 };
 
@@ -726,11 +727,40 @@ const updateGame = async (id, body = {}) => {
   return getGameDetails(id);
 };
 
+// Play stamps for the main menu's "Last Played"/"Most Played" rows — patches
+// record.meta directly (NOT writeGameMeta/writeScenarioMeta, which stamp
+// updatedAt and drop hubOrigin; server twin has the same rule).
+const recordGamePlayed = async (gameId) => {
+  try {
+    const record = await getGame(gameId);
+    if (!record) return;
+    record.meta = {
+      ...(record.meta ?? {}),
+      lastPlayedAt: nowIso(),
+      playCount: normalizePlayCount(record.meta?.playCount) + 1,
+    };
+    await putGame(record);
+
+    const scenarioId = String(record.meta?.scenarioId ?? "").trim();
+    const scenario = scenarioId ? await getScenario(scenarioId) : null;
+    if (scenario) {
+      scenario.meta = {
+        ...(scenario.meta ?? {}),
+        playCount: normalizePlayCount(scenario.meta?.playCount) + 1,
+      };
+      await putScenario(scenario);
+    }
+  } catch {
+    // Stamping is best-effort — never block activating a game over it.
+  }
+};
+
 const setActiveGame = async (gameId) => {
   const id = String(gameId ?? "").trim();
   if (!id || !(await getGame(id))) throw new Error(`Game not found: ${id}`);
   const manifest = await getGameManifest();
   await saveGameManifest({ activeGameId: id, order: [id, ...manifest.order.filter((e) => e !== id)] });
+  await recordGamePlayed(id);
   return getLibraryCatalog();
 };
 

--- a/src/runtime/web/models.js
+++ b/src/runtime/web/models.js
@@ -190,6 +190,11 @@ export const normalizeHubOrigin = (raw) => {
   };
 };
 
+export const normalizePlayCount = (raw) => {
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+};
+
 export const readScenarioMeta = (scenarioId, raw = {}) => {
   const name = String(raw?.name ?? "").trim() || DEFAULT_SCENARIO_META.name;
   const subtitle = String(raw?.subtitle ?? "").trim() || DEFAULT_SCENARIO_META.subtitle;
@@ -206,6 +211,7 @@ export const readScenarioMeta = (scenarioId, raw = {}) => {
     hubOrigin: normalizeHubOrigin(raw?.hubOrigin),
     id: scenarioId,
     name,
+    playCount: normalizePlayCount(raw?.playCount),
     subtitle,
     updatedAt: raw?.updatedAt ?? nowIso(),
   };
@@ -224,7 +230,9 @@ export const readGameMeta = (gameId, raw = {}) => {
     heroSubtitle: String(raw?.heroSubtitle ?? "").trim() || description,
     heroTitle: String(raw?.heroTitle ?? "").trim() || name,
     id: gameId,
+    lastPlayedAt: String(raw?.lastPlayedAt ?? "").trim() || null,
     name,
+    playCount: normalizePlayCount(raw?.playCount),
     scenarioId: String(raw?.scenarioId ?? "").trim() || DEFAULT_SCENARIO_ID,
     subtitle,
     updatedAt: raw?.updatedAt ?? nowIso(),


### PR DESCRIPTION
## Main Menu
- The no-games prompt and the top-bar Games/Scenarios/Community tabs are replaced by a full-page **Main Menu** that opens when the app starts.
- **Games** tab (default): netflix-style rows — `Last Played` and `Most Played`.
- **Scenarios** tab: rows `Most Played`, `Last Updated`, and `Your Scenarios` (only scenarios you created or edited yourself — hub-tracked imports stay out until modified). The first slot is a large **+** tile that creates a blank scenario and opens its editor.
- **Community** tab: the existing hub as a full page.
- In-game, the top bar keeps the session summary and gains **Exit Game**, which returns to the menu. The editor drawer, country picker, and map editor all stack above the menu.

## Play tracking (server + web store)
- `setActiveGame` / `createGame(setActive)` stamp `lastPlayedAt` + `playCount` on the game and `playCount` on its scenario.
- Stamps bypass `writeGameMeta`/`writeScenarioMeta` on purpose: playing must not bump `updatedAt` (the Last Updated row would become Last Played) and must not drop `hubOrigin` (playing a hub scenario must not fork it off update tracking). Verified: playing leaves `updatedAt` byte-identical.

## Fallback fix (bug report)
`Turn generated by fallback: $.events[4].impacts.unitOps[0].unitId does not identify an existing unit.` and `no map region matches "Northern Greenland"` were rejecting finished turns on *both* attempts. Validation now follows strict/salvage discipline: attempt 1 returns corrective errors for the model to retry with; attempt 2 **drops the invalid ops in place** (stale unit ids, unresolvable transfers/chats/markers) and keeps the rest of the turn. Verified: a turn with a ghost `unitId` + unknown region survives salvage with valid spawn/build ops kept.

## Stats
Economy cards format raw large numbers compactly — `30000000000` renders as `30.0B` (K/M/B/T, currency prefix preserved, percentages and prose untouched) so values no longer run off the card.
