### PR TITLE
Attack orders can target cities and structures (beta)

### DIFF
--- a/src/Game/GameUI/forces.jsx
+++ b/src/Game/GameUI/forces.jsx
@@ -32,7 +32,7 @@ const TYPE_GLYPH = {
 const MODE_HINT = {
   deploy: "Click the map to place your unit",
   move: "Click a destination to move the unit",
-  attack: "Click an enemy unit to attack",
+  attack: "Click an enemy unit, a city, or a structure to attack",
 };
 
 const surface = {

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -10,6 +10,7 @@ import {
   deployUnit,
   moveUnitTo,
   attackWith,
+  attackFeature,
 } from "./unitsController.js";
 import {
   JSON_URLS,
@@ -506,6 +507,33 @@ const WorldMap = ({ isGlobe = false }) => {
         ? map.queryRenderedFeatures(event.point, { layers: ["units-fill"] })
         : [];
 
+    // A city or built structure under the cursor. Point features are tiny
+    // targets, so a hit is always deliberate; built structures (world.markers)
+    // outrank cities when the two overlap. Shared between normal selection and
+    // attack targeting, so anything clickable is also attackable.
+    const featureAt = () => {
+      const featureLayers = ["markers-shapes", "cities-shapes", "cities-labels"]
+        .filter((id) => map.getLayer(id));
+      const featureHits = featureLayers.length
+        ? map.queryRenderedFeatures(event.point, { layers: featureLayers })
+        : [];
+      if (!featureHits.length) return null;
+      const hit = featureHits.find((entry) => entry.layer.id === "markers-shapes") ?? featureHits[0];
+      const props = hit.properties ?? {};
+      const [lng, lat] = hit.geometry?.coordinates ?? [event.lngLat.lng, event.lngLat.lat];
+      return hit.layer.id === "markers-shapes"
+        ? { source: "marker", id: props.id, name: props.name, kind: props.kind, ownerCode: props.ownerCode, lng, lat }
+        : {
+          source: "city",
+          name: props.city || props.name || "",
+          population: props.population,
+          capital: props.capital,
+          tier: props.tier,
+          lng,
+          lat,
+        };
+    };
+
     const mode = getInteractionMode();
 
     // Active troop command modes intercept the click as a target, not a selection.
@@ -520,8 +548,16 @@ const WorldMap = ({ isGlobe = false }) => {
       return;
     }
     if (mode.kind === "attack") {
+      // An enemy unit under the cursor is the target; otherwise a city or
+      // structure is — troops can be directed against objectives, not just
+      // other troops.
       const target = unitsAt();
-      if (target.length) attackWith(mode.unitId, target[0].properties.id);
+      const feature = target.length ? null : featureAt();
+      if (target.length) {
+        attackWith(mode.unitId, target[0].properties.id);
+      } else if (feature) {
+        attackFeature(mode.unitId, feature);
+      }
       clearInteractionMode();
       return;
     }
@@ -537,30 +573,10 @@ const WorldMap = ({ isGlobe = false }) => {
 
     dismissUnitPopup();
 
-    // A city or built structure under the cursor wins over the region: point
-    // features are tiny targets, so a hit is always deliberate. Built structures
-    // (world.markers) outrank cities when the two overlap.
-    const featureLayers = ["markers-shapes", "cities-shapes", "cities-labels"]
-      .filter((id) => map.getLayer(id));
-    const featureHits = featureLayers.length
-      ? map.queryRenderedFeatures(event.point, { layers: featureLayers })
-      : [];
-    if (featureHits.length) {
+    const featureHit = featureAt();
+    if (featureHit) {
       dismissRegionPopup();
-      const hit = featureHits.find((entry) => entry.layer.id === "markers-shapes") ?? featureHits[0];
-      const props = hit.properties ?? {};
-      const [lng, lat] = hit.geometry?.coordinates ?? [event.lngLat.lng, event.lngLat.lat];
-      onFeatureSelected(hit.layer.id === "markers-shapes"
-        ? { source: "marker", id: props.id, name: props.name, kind: props.kind, ownerCode: props.ownerCode, lng, lat }
-        : {
-          source: "city",
-          name: props.city || props.name || "",
-          population: props.population,
-          capital: props.capital,
-          tier: props.tier,
-          lng,
-          lat,
-        });
+      onFeatureSelected(featureHit);
       return;
     }
 

--- a/src/Game/Map/unitsController.js
+++ b/src/Game/Map/unitsController.js
@@ -286,5 +286,63 @@ export const attackWith = async (attackerId, targetId) => {
   return { resolved: true, distance, range };
 };
 
+// Attack aimed at a map feature — a city or a built structure (world.markers) —
+// rather than another unit. There is no local clash to resolve against a
+// building, so the instant feedback is positional: in range the unit closes on
+// the objective and reads "engaged", and the queued order hands the assault to
+// the AI, which owns the outcome (a fallen city may mean a regionTransfer, a
+// stormed structure a markerOps remove/rebuild). Out of range it becomes an
+// approach order exactly like a long-range unit attack.
+export const attackFeature = async (attackerId, target) => {
+  const attacker = getUnitById(attackerId);
+  const point = { lng: Number(target?.lng), lat: Number(target?.lat) };
+  if (!attacker || !Number.isFinite(point.lng) || !Number.isFinite(point.lat)) return { resolved: false };
+  // Ordering troops against their own structure is a misclick, not an order.
+  if (target.source === "marker" && target.ownerCode && target.ownerCode === attacker.ownerCode) {
+    return { resolved: false, ownTarget: true };
+  }
+
+  const targetLabel = target.source === "marker"
+    ? `the ${target.kind ? `${target.kind} ` : ""}structure "${target.name || "unnamed"}"` +
+      `${target.ownerCode ? ` held by ${target.ownerCode}` : ""}${target.id ? ` (marker id ${target.id})` : ""}`
+    : `the city of ${target.name || "an unnamed city"}`;
+  const at = `lat ${point.lat.toFixed(2)}, lng ${point.lng.toFixed(2)}`;
+
+  const distance = distanceKm(attacker, point);
+  const range = engagementRangeKm(attacker.type, gameDate);
+  if (distance > range) {
+    await commit((list) =>
+      list.map((u) =>
+        u.id === attackerId ? { ...u, status: "moving", updatedAt: new Date().toISOString() } : u,
+      ),
+    );
+    await queueOrder(
+      `Attack order (approach required): ${attacker.name} (${attacker.type}, id ${attacker.id}, owner ${attacker.ownerCode}) ` +
+        `is ordered to assault ${targetLabel} at ${at}, about ${Math.round(distance)} km away — beyond its ~${range} km ` +
+        `engagement reach for this era. March/sail/fly it toward the objective realistically across turns and resolve the ` +
+        `assault when contact is actually possible, or reject the order with an event explaining why it is infeasible.`,
+      { unitId: attacker.id, status: attacker.status },
+    );
+    return { resolved: false, distance, range };
+  }
+
+  await commit((list) =>
+    list.map((u) =>
+      u.id === attackerId
+        ? { ...u, lng: point.lng, lat: point.lat, status: "engaged", updatedAt: new Date().toISOString() }
+        : u,
+    ),
+  );
+  await queueOrder(
+    `Assault order: ${attacker.name} (${attacker.type}, id ${attacker.id}, owner ${attacker.ownerCode}) attacks ` +
+      `${targetLabel} at ${at} and is now engaged at the objective. Resolve the assault on the next turn — decide the ` +
+      `defense it meets, the casualties, and the outcome. If the objective falls, reflect it: a captured city usually ` +
+      `implies a regionTransfer of its region, and a destroyed or seized structure should be reflected with markerOps ` +
+      `(remove it, or rebuild it under the new owner). If the assault is repelled, say so in an event and adjust the unit.`,
+    { unitId: attacker.id, lng: attacker.lng, lat: attacker.lat, status: attacker.status },
+  );
+  return { resolved: true, distance, range };
+};
+
 export const removeUnit = async (unitId) =>
   commit((list) => list.filter((u) => u.id !== unitId));


### PR DESCRIPTION
The unit **Attack** command can now be aimed at map objectives, not just enemy troops. After clicking Attack on one of your units, clicking a **city** or a **built structure** (world.markers — bases, plants, custom map features) directs the troop against it.

## Behavior
- **Priority**: an enemy unit under the cursor is still the target first; otherwise the structure (markers outrank cities when overlapping, same chain as normal selection — anything clickable is attackable).
- **In engagement range** (era/type reach, same rules as unit-vs-unit): the unit closes onto the objective and reads **engaged**, and a machine-readable *Assault order* is queued for the AI, which owns the outcome — a fallen city usually implies a `regionTransfer` of its region, a stormed structure `markerOps` (remove, or rebuild under the new owner), and a repelled assault gets an event.
- **Out of range**: the same *approach order* a long-range unit attack gets — the unit reads "moving" and the AI advances or rejects the campaign realistically across turns.
- Ordering troops against **their own structure** is ignored as a misclick.
- Both order kinds carry the `unitRevert` record, so deleting the queued action snaps the unit back (#368 mechanism).
- Mode banner now reads *"Click an enemy unit, a city, or a structure to attack"*.

## Verified live (Fallout 2281 sandbox)
- NCR 1st Recon → Nellis AFB (35 km, in range): unit engaged at the marker, `Assault order … attacks the military base structure "Nellis Air Force Base" (marker id fo-nellis-air-force-base)` queued.
- Same unit → Boulder City (city, in range): engaged at the city, city assault order queued.
- Far target (~330 km): approach order queued, unit stays put with status "moving".
- Click on a Legion unit standing on a city correctly attacked the **unit** (priority regression).
- Attacking own HELIOS One: no order queued, unit untouched, mode cleared.
