### PR TITLE
Surface scenario-carried flags as community flag packs

### DIFF
--- a/src/Editor/FlagPicker.jsx
+++ b/src/Editor/FlagPicker.jsx
@@ -17,6 +17,7 @@ import {
   communityFlagsHubUrl,
   fetchCommunityFlags,
   loadCommunityFlagDataUrl,
+  loadCommunityFlagPack,
   openFlagPublishForm,
 } from "../runtime/communityFlags.js";
 import { FLAG_ACCEPT, fileToFlagDataUrl } from "./flagImage.js";
@@ -175,6 +176,7 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
   const [community, setCommunity] = useState([]);
   const [communityLoading, setCommunityLoading] = useState(false);
   const [communityError, setCommunityError] = useState("");
+  const [communityNotice, setCommunityNotice] = useState("");
   const [communityLoaded, setCommunityLoaded] = useState(false);
   const [busyId, setBusyId] = useState(null);
   // "My flags": saved to the library, so an upload is reusable on every map —
@@ -256,6 +258,38 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
       pick(await loadCommunityFlagDataUrl(post));
     } catch (e) {
       setCommunityError(e?.message || "Could not download that flag.");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  // A scenario flag pack installs into "My flags" wholesale — the library
+  // dedupes by content hash, so re-installing the same pack is harmless. The
+  // picker stays open on the Community tab; the flags land under "In the game".
+  const handleInstallPack = async (post) => {
+    setBusyId(post.id);
+    setCommunityError("");
+    setCommunityNotice("");
+    try {
+      const flags = await loadCommunityFlagPack(post);
+      let saved = 0;
+      for (const flag of flags) {
+        try {
+          await saveFlag({
+            name: flag.code || post.title,
+            code: flag.code || "",
+            author: post.author || "",
+            dataUrl: flag.dataUrl,
+          });
+          saved += 1;
+        } catch { /* one bad flag must not sink the whole pack */ }
+      }
+      refreshMine();
+      setCommunityNotice(
+        `Added ${saved} flag${saved === 1 ? "" : "s"} from “${post.title}” to My flags — they're in the “In the game” tab now.`,
+      );
+    } catch (e) {
+      setCommunityError(e?.message || "Could not install that flag pack.");
     } finally {
       setBusyId(null);
     }
@@ -391,6 +425,7 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
               </div>
 
               {communityError && <div style={{ ...dim, color: "#fecaca" }}>{communityError}</div>}
+              {communityNotice && <div style={{ ...dim, color: "#86efac" }}>{communityNotice}</div>}
               {communityLoading ? (
                 <div style={dim}>Loading community flags…</div>
               ) : filteredCommunity.length === 0 ? (
@@ -403,8 +438,17 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
                 <div style={grid}>
                   {filteredCommunity.map((post) => (
                     <div key={post.id} style={{ ...cardSurface, cursor: "default" }}>
-                      <div style={{ aspectRatio: "3 / 2", background: "rgba(0,0,0,0.35)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                        <img src={post.imageUrl} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                      <div style={{ aspectRatio: "3 / 2", background: "rgba(0,0,0,0.35)", display: "flex", alignItems: "center", justifyContent: "center", position: "relative" }}>
+                        {post.imageUrl ? (
+                          <img src={post.imageUrl} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                        ) : (
+                          <span style={{ fontSize: "2rem", opacity: 0.6 }}>🚩</span>
+                        )}
+                        {post.fromScenario && (
+                          <span style={{ position: "absolute", left: 6, top: 6, background: "rgba(124,58,237,0.85)", borderRadius: 6, color: "#fff", fontSize: "0.62rem", fontWeight: 700, padding: "0.15rem 0.35rem" }}>
+                            {post.flagCount} flag{post.flagCount === 1 ? "" : "s"} · scenario
+                          </span>
+                        )}
                       </div>
                       <div style={{ padding: "0.4rem 0.5rem" }}>
                         <div style={{ fontSize: "0.78rem", fontWeight: 700, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
@@ -415,10 +459,15 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
                         <button
                           type="button"
                           disabled={busyId === post.id}
-                          onClick={() => handleInstall(post)}
+                          onClick={() => (post.fromScenario ? handleInstallPack(post) : handleInstall(post))}
                           style={{ ...tabBtn(false), marginTop: "0.35rem", width: "100%" }}
+                          title={post.fromScenario ? "Save this scenario's custom flags into My flags" : undefined}
                         >
-                          {busyId === post.id ? "Applying…" : "Use this flag"}
+                          {busyId === post.id
+                            ? (post.fromScenario ? "Adding…" : "Applying…")
+                            : post.fromScenario
+                              ? `⬇ Add ${post.flagCount} flag${post.flagCount === 1 ? "" : "s"}`
+                              : "Use this flag"}
                         </button>
                       </div>
                     </div>

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -79,6 +79,7 @@ const parsePost = (issue, importsById) => {
   const description = (descSection ? descSection[1] : body)
     .replace(/###\s*Basemap info[\s\S]*$/i, "")     // auto-filled technical section (fallback path)
     .replace(/^Basemap-(?:Hash|Kind):.*$/gim, "")   // stray hash/kind lines
+    .replace(/^Flags-Count:.*$/gim, "")             // flag-pack tag (see communityFlags.js)
     .replace(/!\[[^\]]*\]\([^)]*\)/g, "")            // images
     .replace(/<img[^>]*>/gi, "")
     .replace(/\[[^\]]*\]\([^)]*\)/g, "")             // markdown links (the dragged-in scenario file)
@@ -601,11 +602,19 @@ const CommunityPanel = ({ fullPage = false, onImported }) => {
       if (coverBlob && coverDownloadName) saveBlobToDisk(coverBlob, coverDownloadName);
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
-      // dedupe it against dedicated posts. Harmless if the scenario form has no such
-      // field — GitHub just ignores the unknown prefill param.
+      // dedupe it against dedicated posts. When it carries custom flags, tag the
+      // count so the flag picker's Community tab surfaces the post as an
+      // installable flag pack without downloading every bundle first. Harmless if
+      // the scenario form has no such field — GitHub ignores unknown prefills.
+      const customFlagCount = Object.values(bundle.assets?.flags?.data ?? {})
+        .filter((value) => typeof value === "string" && value.startsWith("data:")).length;
+      const technicalLines = [
+        ...(split ? [`Basemap-Hash: ${split.hash}`, `Basemap-Kind: ${split.kind}`] : []),
+        ...(customFlagCount > 0 ? [`Flags-Count: ${customFlagCount}`] : []),
+      ];
       const scenarioUrl =
         `${HUB_NEW_POST_URL}&title=${encodeURIComponent(`[Scenario] ${scenario.name}`)}` +
-        (split ? `&technical=${encodeURIComponent(`Basemap-Hash: ${split.hash}\nBasemap-Kind: ${split.kind}`)}` : "");
+        (technicalLines.length ? `&technical=${encodeURIComponent(technicalLines.join("\n"))}` : "");
       window.open(scenarioUrl, "_blank", "noopener");
       setNotice(
         `${hasCover ? `"${fileName}" and its cover image were` : `"${fileName}" was`} downloaded. ` +

--- a/src/runtime/communityFlags.js
+++ b/src/runtime/communityFlags.js
@@ -10,6 +10,8 @@
 //
 // Kept free of React/OpenLayers deps so the editor and the game can both use it.
 
+import { unzipBundle, looksLikeZip } from "./bundleZip.js";
+
 const HUB_OWNER = "Open-Historia";
 const HUB_REPO = "Open-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
@@ -17,6 +19,10 @@ const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 // EXIST in the repo — GitHub silently drops a label an issue form tries to apply if
 // it hasn't been created, and the post then never appears here.
 const HUB_API_FLAGS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=flag&per_page=100`;
+// Scenario posts are scanned too: one whose publish stamped a Flags-Count tag
+// carries custom flags in its bundle, and surfaces here as an installable flag
+// pack — the same trick communityBasemaps.js uses for scenario-carried basemaps.
+const HUB_API_SCENARIOS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache = { at: 0, posts: null };
@@ -31,6 +37,11 @@ const FILE_LINK_PATTERN =
   /https:\/\/(?:github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+)/i;
 // Optional, and only a hint: which country the author drew this for.
 const CODE_PATTERN = /Flag-Code:\s*([A-Za-z0-9_-]{2,12})/i;
+// Stamped into a scenario post by the publish flow when its bundle carries
+// custom flags. The tag is the browse-time signal — without it, knowing whether
+// a scenario has flags would mean downloading every bundle.
+const FLAGS_COUNT_PATTERN = /Flags-Count:\s*(\d{1,4})/i;
+const ALL_FILE_LINKS_PATTERN = new RegExp(FILE_LINK_PATTERN.source, "gi");
 
 const firstMatch = (body, pattern) => {
   const m = pattern.exec(body || "");
@@ -59,13 +70,54 @@ const parseFlagPost = (issue) => {
   };
 };
 
-// A post is only usable if we can actually get an image out of it.
-export const flagPostInstallable = (post) => Boolean(post?.imageUrl);
+// A scenario post carrying custom flags (Flags-Count tag) becomes ONE pack
+// card: installing it saves every custom flag into "My flags" in a single
+// click. The bundle attachment is the payload; the scenario's cover image (if
+// the author dragged one in) doubles as the card art.
+const parseScenarioAsFlagPack = (issue) => {
+  const body = String(issue.body ?? "");
+  const flagCount = Number(body.match(FLAGS_COUNT_PATTERN)?.[1] ?? 0);
+  if (!Number.isFinite(flagCount) || flagCount <= 0) return null;
+  const links = body.match(ALL_FILE_LINKS_PATTERN) ?? [];
+  const packUrl =
+    links.find((link) => /\.zip(\?|#|$)/i.test(link)) ??
+    links.find((link) => /\.json(\?|#|$)/i.test(link)) ??
+    links[0] ??
+    null;
+  if (!packUrl) return null;
+  return {
+    id: `scenario-${issue.number}`,
+    title: String(issue.title ?? "").replace(/^\[Scenario\]\s*/i, "").trim() || `Scenario #${issue.number}`,
+    author: issue.user?.login || "",
+    avatarUrl: issue.user?.avatar_url || "",
+    url: issue.html_url,
+    createdAt: issue.created_at,
+    official: OFFICIAL_ASSOCIATIONS.has(issue.author_association),
+    upvotes: issue.reactions?.["+1"] ?? 0,
+    code: null,
+    imageUrl: firstMatch(body, COVER_IMAGE_PATTERN),
+    fromScenario: true,
+    flagCount,
+    packUrl,
+  };
+};
+
+// A post is only usable if we can actually get a payload out of it: an image
+// for a dedicated flag post, the bundle attachment for a scenario pack.
+export const flagPostInstallable = (post) =>
+  Boolean(post?.fromScenario ? post?.packUrl : post?.imageUrl);
 
 export const fetchCommunityFlags = async ({ force = false } = {}) => {
   if (!force && cache.posts && Date.now() - cache.at < CACHE_TTL_MS) return cache.posts;
 
-  const res = await fetch(HUB_API_FLAGS, { headers: { Accept: "application/vnd.github+json" } });
+  // Dedicated flag posts, plus scenario posts (scanned so flags shared inside
+  // scenarios show up here too). The scenarios call is best-effort — a failure
+  // just hides the packs, exactly like the basemap browser.
+  const headers = { Accept: "application/vnd.github+json" };
+  const [res, scRes] = await Promise.all([
+    fetch(HUB_API_FLAGS, { headers }),
+    fetch(HUB_API_SCENARIOS, { headers }).catch(() => null),
+  ]);
   if (!res.ok) {
     throw new Error(
       res.status === 403
@@ -74,10 +126,19 @@ export const fetchCommunityFlags = async ({ force = false } = {}) => {
     );
   }
   const issues = await res.json();
-  const posts = (Array.isArray(issues) ? issues : [])
+  const dedicated = (Array.isArray(issues) ? issues : [])
     .filter((i) => !i.pull_request) // the issues endpoint returns PRs too
     .map(parseFlagPost)
     .filter(flagPostInstallable);
+  let packs = [];
+  if (scRes && scRes.ok) {
+    const scIssues = await scRes.json().catch(() => []);
+    packs = (Array.isArray(scIssues) ? scIssues : [])
+      .filter((i) => !i.pull_request)
+      .map(parseScenarioAsFlagPack)
+      .filter(Boolean);
+  }
+  const posts = [...dedicated, ...packs];
 
   cache = { at: Date.now(), posts };
   return posts;
@@ -102,6 +163,43 @@ export const loadCommunityFlagDataUrl = async (post) => {
     binary += String.fromCharCode(...view.subarray(i, i + chunk));
   }
   return `data:${mime};base64,${btoa(binary)}`;
+};
+
+// Resolve a scenario flag pack to its flags: download the bundle through the
+// hub proxy, find scenario.json (bundles ship as a .zip; older posts may be
+// bare JSON), and return the CUSTOM flags from assets.flags. flagcdn URLs are
+// skipped — those are the built-ins every picker already lists.
+export const loadCommunityFlagPack = async (post) => {
+  if (!post?.packUrl) throw new Error("That post has no scenario bundle.");
+  const r = await fetch(`/api/hub/file?url=${encodeURIComponent(post.packUrl)}`);
+  if (!r.ok) {
+    const p = await r.json().catch(() => ({}));
+    throw new Error(p.error || `Download failed (HTTP ${r.status}).`);
+  }
+  const buffer = await r.arrayBuffer();
+  let bundle;
+  if (looksLikeZip(new Uint8Array(buffer))) {
+    const zip = await unzipBundle(buffer);
+    const text = await zip.text("scenario.json");
+    if (!text) throw new Error("That .zip is missing scenario.json.");
+    bundle = JSON.parse(text);
+  } else {
+    bundle = JSON.parse(new TextDecoder().decode(buffer));
+  }
+  // assets.flags is { data: {owner -> flag string}, mode: "embedded" } from the
+  // exporter; tolerate a bare owner->flag object from hand-built bundles.
+  const asset = bundle?.assets?.flags;
+  const flagsMap =
+    asset && typeof asset === "object" && asset.data && typeof asset.data === "object"
+      ? asset.data
+      : asset && typeof asset === "object" && !("mode" in asset)
+        ? asset
+        : {};
+  const flags = Object.entries(flagsMap)
+    .filter(([, value]) => typeof value === "string" && value.startsWith("data:"))
+    .map(([code, dataUrl]) => ({ code, dataUrl }));
+  if (!flags.length) throw new Error("No custom flags found in that scenario.");
+  return flags;
 };
 
 export const communityFlagsHubUrl = () =>


### PR DESCRIPTION
Flags shared inside scenarios now surface automatically in the flag picker's **Community** tab — the same mechanism that already surfaces scenario-carried basemaps in the basemap browser.

## How it works
- **Publish side** (`communityHub.jsx`): when a published scenario's bundle carries custom flags, the prefilled hub post gets a `Flags-Count: N` technical tag (riding alongside `Basemap-Hash`/`Basemap-Kind`; only data-URL flags count — flagcdn URLs are the built-ins everyone already has). The tag is also stripped from card descriptions like the basemap tags.
- **Browse side** (`communityFlags.js`): `fetchCommunityFlags` now also scans `scenario`-labeled hub posts. One tagged post becomes one **flag pack card** (scenario cover as art, `N flags · scenario` badge). Untagged scenario posts don't appear — no bundle downloads at browse time.
- **Install** (`FlagPicker.jsx`): "⬇ Add N flags" downloads the bundle through the hub proxy, reads `assets.flags` out of `scenario.json` (works for both `.zip` and bare-JSON attachments), and saves every custom flag into **My flags** — the library dedupes by content hash, so re-installing is harmless. The flags then show under "In the game" for any map or faction.

Mirrored in the standalone editor repo: Open-Historia/open-historia-map-editor#6.

## Verified live
- Scanner unit-tested against synthetic hub responses: dedicated flag posts unchanged, tagged scenario → pack card with count + zip URL + cover, untagged scenario filtered out.
- Loader tested against **real hub bundles**: the Red Era post's `.zip` yielded its 16 custom flags (German Democratic Republic, Spanish Republic, …); a bare-JSON bundle parses via the same path.
- Publish counting tested on a real export: the WWII-copy scenario produced `Flags-Count: 16` (31 total flags, 15 flagcdn built-ins correctly excluded); a flagless scenario produced no tag.
- Full UI flow in the sandbox: faction creator → flag picker → Community tab → pack card rendered → install → "Added 2 flags…" notice → both flags in My flags and persisted to `flags-library.json` with name/code/author/hash.

**Note:** existing hub posts predate the tag, so they won't show as packs until their post body gains a `Flags-Count: N` line (or they're republished — new publishes tag automatically).
