### PR TITLE
Combined: slim top bar + community flag packs

### DIFF
--- a/src/Editor/FlagPicker.jsx
+++ b/src/Editor/FlagPicker.jsx
@@ -17,6 +17,7 @@ import {
   communityFlagsHubUrl,
   fetchCommunityFlags,
   loadCommunityFlagDataUrl,
+  loadCommunityFlagPack,
   openFlagPublishForm,
 } from "../runtime/communityFlags.js";
 import { FLAG_ACCEPT, fileToFlagDataUrl } from "./flagImage.js";
@@ -175,6 +176,7 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
   const [community, setCommunity] = useState([]);
   const [communityLoading, setCommunityLoading] = useState(false);
   const [communityError, setCommunityError] = useState("");
+  const [communityNotice, setCommunityNotice] = useState("");
   const [communityLoaded, setCommunityLoaded] = useState(false);
   const [busyId, setBusyId] = useState(null);
   // "My flags": saved to the library, so an upload is reusable on every map —
@@ -256,6 +258,38 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
       pick(await loadCommunityFlagDataUrl(post));
     } catch (e) {
       setCommunityError(e?.message || "Could not download that flag.");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  // A scenario flag pack installs into "My flags" wholesale — the library
+  // dedupes by content hash, so re-installing the same pack is harmless. The
+  // picker stays open on the Community tab; the flags land under "In the game".
+  const handleInstallPack = async (post) => {
+    setBusyId(post.id);
+    setCommunityError("");
+    setCommunityNotice("");
+    try {
+      const flags = await loadCommunityFlagPack(post);
+      let saved = 0;
+      for (const flag of flags) {
+        try {
+          await saveFlag({
+            name: flag.code || post.title,
+            code: flag.code || "",
+            author: post.author || "",
+            dataUrl: flag.dataUrl,
+          });
+          saved += 1;
+        } catch { /* one bad flag must not sink the whole pack */ }
+      }
+      refreshMine();
+      setCommunityNotice(
+        `Added ${saved} flag${saved === 1 ? "" : "s"} from “${post.title}” to My flags — they're in the “In the game” tab now.`,
+      );
+    } catch (e) {
+      setCommunityError(e?.message || "Could not install that flag pack.");
     } finally {
       setBusyId(null);
     }
@@ -391,6 +425,7 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
               </div>
 
               {communityError && <div style={{ ...dim, color: "#fecaca" }}>{communityError}</div>}
+              {communityNotice && <div style={{ ...dim, color: "#86efac" }}>{communityNotice}</div>}
               {communityLoading ? (
                 <div style={dim}>Loading community flags…</div>
               ) : filteredCommunity.length === 0 ? (
@@ -403,8 +438,17 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
                 <div style={grid}>
                   {filteredCommunity.map((post) => (
                     <div key={post.id} style={{ ...cardSurface, cursor: "default" }}>
-                      <div style={{ aspectRatio: "3 / 2", background: "rgba(0,0,0,0.35)", display: "flex", alignItems: "center", justifyContent: "center" }}>
-                        <img src={post.imageUrl} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                      <div style={{ aspectRatio: "3 / 2", background: "rgba(0,0,0,0.35)", display: "flex", alignItems: "center", justifyContent: "center", position: "relative" }}>
+                        {post.imageUrl ? (
+                          <img src={post.imageUrl} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                        ) : (
+                          <span style={{ fontSize: "2rem", opacity: 0.6 }}>🚩</span>
+                        )}
+                        {post.fromScenario && (
+                          <span style={{ position: "absolute", left: 6, top: 6, background: "rgba(124,58,237,0.85)", borderRadius: 6, color: "#fff", fontSize: "0.62rem", fontWeight: 700, padding: "0.15rem 0.35rem" }}>
+                            {post.flagCount} flag{post.flagCount === 1 ? "" : "s"} · scenario
+                          </span>
+                        )}
                       </div>
                       <div style={{ padding: "0.4rem 0.5rem" }}>
                         <div style={{ fontSize: "0.78rem", fontWeight: 700, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
@@ -415,10 +459,15 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
                         <button
                           type="button"
                           disabled={busyId === post.id}
-                          onClick={() => handleInstall(post)}
+                          onClick={() => (post.fromScenario ? handleInstallPack(post) : handleInstall(post))}
                           style={{ ...tabBtn(false), marginTop: "0.35rem", width: "100%" }}
+                          title={post.fromScenario ? "Save this scenario's custom flags into My flags" : undefined}
                         >
-                          {busyId === post.id ? "Applying…" : "Use this flag"}
+                          {busyId === post.id
+                            ? (post.fromScenario ? "Adding…" : "Applying…")
+                            : post.fromScenario
+                              ? `⬇ Add ${post.flagCount} flag${post.flagCount === 1 ? "" : "s"}`
+                              : "Use this flag"}
                         </button>
                       </div>
                     </div>

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -79,6 +79,7 @@ const parsePost = (issue, importsById) => {
   const description = (descSection ? descSection[1] : body)
     .replace(/###\s*Basemap info[\s\S]*$/i, "")     // auto-filled technical section (fallback path)
     .replace(/^Basemap-(?:Hash|Kind):.*$/gim, "")   // stray hash/kind lines
+    .replace(/^Flags-Count:.*$/gim, "")             // flag-pack tag (see communityFlags.js)
     .replace(/!\[[^\]]*\]\([^)]*\)/g, "")            // images
     .replace(/<img[^>]*>/gi, "")
     .replace(/\[[^\]]*\]\([^)]*\)/g, "")             // markdown links (the dragged-in scenario file)
@@ -601,11 +602,19 @@ const CommunityPanel = ({ fullPage = false, onImported }) => {
       if (coverBlob && coverDownloadName) saveBlobToDisk(coverBlob, coverDownloadName);
       // When the scenario carries a basemap, tag the post with the basemap hash so
       // the community Basemaps browser (which surfaces scenario-carried basemaps) can
-      // dedupe it against dedicated posts. Harmless if the scenario form has no such
-      // field — GitHub just ignores the unknown prefill param.
+      // dedupe it against dedicated posts. When it carries custom flags, tag the
+      // count so the flag picker's Community tab surfaces the post as an
+      // installable flag pack without downloading every bundle first. Harmless if
+      // the scenario form has no such field — GitHub ignores unknown prefills.
+      const customFlagCount = Object.values(bundle.assets?.flags?.data ?? {})
+        .filter((value) => typeof value === "string" && value.startsWith("data:")).length;
+      const technicalLines = [
+        ...(split ? [`Basemap-Hash: ${split.hash}`, `Basemap-Kind: ${split.kind}`] : []),
+        ...(customFlagCount > 0 ? [`Flags-Count: ${customFlagCount}`] : []),
+      ];
       const scenarioUrl =
         `${HUB_NEW_POST_URL}&title=${encodeURIComponent(`[Scenario] ${scenario.name}`)}` +
-        (split ? `&technical=${encodeURIComponent(`Basemap-Hash: ${split.hash}\nBasemap-Kind: ${split.kind}`)}` : "");
+        (technicalLines.length ? `&technical=${encodeURIComponent(technicalLines.join("\n"))}` : "");
       window.open(scenarioUrl, "_blank", "noopener");
       setNotice(
         `${hasCover ? `"${fileName}" and its cover image were` : `"${fileName}" was`} downloaded. ` +

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -98,7 +98,9 @@ let menuOpenDefault = true;
 // For background work that should not run for a game the player hasn't
 // actually entered (e.g. pre-game history generation while browsing the menu).
 export const isMainMenuOpen = () => menuOpenDefault;
-const TOP_BAR_OFFSET = "4.75rem";
+// With the full-width in-game bar gone, top-anchored UI (settings ⋮, date
+// widget, forces panel, editor drawer) starts at the screen edge.
+const TOP_BAR_OFFSET = "0.5rem";
 
 const surfaceStyle = {
   background:
@@ -1973,79 +1975,123 @@ const LibraryTopBar = () => {
 
   return (
     <>
-      {/* In-game top bar. The library tabs moved to the main menu — in-game it
-          identifies the session and offers the way back (Exit Game). */}
-      {!menuOpen && (
+      {/* In-game the full-width top bar is gone — the map gets the space. What
+          remains is a compact floating cluster beside the ⋮ settings button: a
+          small sleek pill with the session summary, plus Exit Game and ⏻.
+          Below the settings menu and date widget (z 9998/9999) so opening
+          either covers it instead of the other way around. */}
+      {!menuOpen && !isMobile && (
         <div
           style={{
-            ...surfaceStyle,
             alignItems: "center",
-            borderLeft: "none",
-            borderRadius: 0,
-            borderRight: "none",
-            borderTop: "none",
-            display: "grid",
-            gap: isMobile ? "0.4rem" : "0.9rem",
-            gridTemplateColumns: "minmax(0, 1fr) auto",
-            height: `${BAR_HEIGHT}px`,
-            left: 0,
-            padding: isMobile ? "0 0.5rem" : "0 1rem",
+            display: "flex",
+            fontFamily: "sans-serif",
+            gap: "0.45rem",
+            left: "5rem",
             position: "fixed",
-            right: 0,
-            top: 0,
-            zIndex: 10030,
+            top: "0.5rem",
+            zIndex: 9997,
           }}
         >
-          <div style={{ alignItems: "center", display: "flex", gap: "0.8rem", minWidth: 0 }}>
-            <div style={{ alignItems: "center", background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.08)", borderRadius: "999px", display: "flex", flexShrink: 0, height: "2.65rem", justifyContent: "center", overflow: "hidden", width: "2.65rem" }}>
-              <img alt="Open Historia" src="/logo.png" style={{ height: "1.7rem", width: "1.7rem" }} />
-            </div>
-            {/* Phones keep the logo only — the title/summary would crowd the buttons. */}
-            {!isMobile && (
-              <div style={{ minWidth: 0 }}>
-                <div style={{ color: "#fff", fontSize: "1rem", fontWeight: 800, letterSpacing: "-0.03em" }}>
-                  Open Historia
-                </div>
-                <div style={{ color: "rgba(255,255,255,0.48)", fontSize: "0.72rem", marginTop: "0.08rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", width: "min(28rem, 46vw)" }}>
-                  {summaryText}
-                </div>
-              </div>
-            )}
+          <div
+            style={{
+              ...surfaceStyle,
+              borderRadius: "999px",
+              color: "rgba(255,255,255,0.72)",
+              fontSize: "0.74rem",
+              fontWeight: 600,
+              // Shrinks to nothing before it can reach under the date widget
+              // on narrow desktop windows (the widget owns the top right).
+              maxWidth: "min(34rem, max(0rem, calc(100vw - 44rem)))",
+              overflow: "hidden",
+              padding: "0.5rem 0.85rem",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {summaryText}
           </div>
-
-          <div style={{ alignItems: "center", display: "flex", gap: "0.55rem", justifyContent: "flex-end" }}>
+          <button
+            onClick={() => setMenuOpen(true)}
+            title="Leave this game and return to the main menu"
+            type="button"
+            style={{ ...actionButtonStyle, ...surfaceStyle, borderRadius: "999px", fontSize: "0.74rem", minHeight: "0", padding: "0.5rem 0.85rem" }}
+          >
+            ⌂ Exit Game
+          </button>
+          {/* Shut the server down (phones/Termux have no terminal handy). Hidden
+              on the hosted website (web build) — there's no local server to stop
+              there, and the compile-time flag strips this from that bundle. */}
+          {!import.meta.env.VITE_OH_WEB && (
             <button
-              onClick={() => setMenuOpen(true)}
-              title="Leave this game and return to the main menu"
+              onClick={handleShutdownServer}
+              title="Exit: shut down the Open Historia server"
               type="button"
               style={{
                 ...actionButtonStyle,
-                padding: isMobile ? "0.55rem 0.7rem" : undefined,
+                ...surfaceStyle,
+                background: "rgba(220,70,70,0.14)",
+                borderColor: "rgba(248,113,113,0.35)",
+                borderRadius: "999px",
+                color: "#fca5a5",
+                fontSize: "0.74rem",
+                minHeight: "0",
+                minWidth: "0",
+                padding: "0.5rem 0.7rem",
               }}
             >
-              {isMobile ? "⌂" : "⌂ Exit Game"}
+              ⏻
             </button>
-            {/* Shut the server down (phones/Termux have no terminal handy). Hidden
-                on the hosted website (web build) — there's no local server to stop
-                there, and the compile-time flag strips this from that bundle. */}
-            {!import.meta.env.VITE_OH_WEB && (
-              <button
-                onClick={handleShutdownServer}
-                title="Exit: shut down the Open Historia server"
-                type="button"
-                style={{
-                  ...actionButtonStyle,
-                  background: "rgba(220,70,70,0.14)",
-                  borderColor: "rgba(248,113,113,0.35)",
-                  color: "#fca5a5",
-                  minWidth: "2.35rem",
-                  padding: isMobile ? "0.55rem 0.7rem" : undefined,
-                }}
-              >
-                ⏻
-              </button>
-            )}
-          </div>
+          )}
+        </div>
+      )}
+
+      {/* Phones: the date widget spans the whole top row, so Exit Game and ⏻
+          stack in the left gutter under the ⋮ settings button instead. */}
+      {!menuOpen && isMobile && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            fontFamily: "sans-serif",
+            gap: "0.45rem",
+            left: "0.5rem",
+            position: "fixed",
+            top: "5rem",
+            zIndex: 9997,
+          }}
+        >
+          <button
+            onClick={() => setMenuOpen(true)}
+            title="Leave this game and return to the main menu"
+            type="button"
+            style={{ ...actionButtonStyle, ...surfaceStyle, borderRadius: "12px", fontSize: "1rem", height: "2.6rem", minHeight: "0", minWidth: "0", padding: 0, width: "2.6rem" }}
+          >
+            ⌂
+          </button>
+          {!import.meta.env.VITE_OH_WEB && (
+            <button
+              onClick={handleShutdownServer}
+              title="Exit: shut down the Open Historia server"
+              type="button"
+              style={{
+                ...actionButtonStyle,
+                ...surfaceStyle,
+                background: "rgba(220,70,70,0.14)",
+                borderColor: "rgba(248,113,113,0.35)",
+                borderRadius: "12px",
+                color: "#fca5a5",
+                fontSize: "1rem",
+                height: "2.6rem",
+                minHeight: "0",
+                minWidth: "0",
+                padding: 0,
+                width: "2.6rem",
+              }}
+            >
+              ⏻
+            </button>
+          )}
         </div>
       )}
 

--- a/src/runtime/communityFlags.js
+++ b/src/runtime/communityFlags.js
@@ -10,6 +10,8 @@
 //
 // Kept free of React/OpenLayers deps so the editor and the game can both use it.
 
+import { unzipBundle, looksLikeZip } from "./bundleZip.js";
+
 const HUB_OWNER = "Open-Historia";
 const HUB_REPO = "Open-historia-scenarios";
 const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
@@ -17,6 +19,10 @@ const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 // EXIST in the repo — GitHub silently drops a label an issue form tries to apply if
 // it hasn't been created, and the post then never appears here.
 const HUB_API_FLAGS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=flag&per_page=100`;
+// Scenario posts are scanned too: one whose publish stamped a Flags-Count tag
+// carries custom flags in its bundle, and surfaces here as an installable flag
+// pack — the same trick communityBasemaps.js uses for scenario-carried basemaps.
+const HUB_API_SCENARIOS = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache = { at: 0, posts: null };
@@ -31,6 +37,11 @@ const FILE_LINK_PATTERN =
   /https:\/\/(?:github\.com\/[^\s)<>"']+\/files\/[^\s)<>"']+|github\.com\/user-attachments\/files\/[^\s)<>"']+|raw\.githubusercontent\.com\/[^\s)<>"']+)/i;
 // Optional, and only a hint: which country the author drew this for.
 const CODE_PATTERN = /Flag-Code:\s*([A-Za-z0-9_-]{2,12})/i;
+// Stamped into a scenario post by the publish flow when its bundle carries
+// custom flags. The tag is the browse-time signal — without it, knowing whether
+// a scenario has flags would mean downloading every bundle.
+const FLAGS_COUNT_PATTERN = /Flags-Count:\s*(\d{1,4})/i;
+const ALL_FILE_LINKS_PATTERN = new RegExp(FILE_LINK_PATTERN.source, "gi");
 
 const firstMatch = (body, pattern) => {
   const m = pattern.exec(body || "");
@@ -59,13 +70,54 @@ const parseFlagPost = (issue) => {
   };
 };
 
-// A post is only usable if we can actually get an image out of it.
-export const flagPostInstallable = (post) => Boolean(post?.imageUrl);
+// A scenario post carrying custom flags (Flags-Count tag) becomes ONE pack
+// card: installing it saves every custom flag into "My flags" in a single
+// click. The bundle attachment is the payload; the scenario's cover image (if
+// the author dragged one in) doubles as the card art.
+const parseScenarioAsFlagPack = (issue) => {
+  const body = String(issue.body ?? "");
+  const flagCount = Number(body.match(FLAGS_COUNT_PATTERN)?.[1] ?? 0);
+  if (!Number.isFinite(flagCount) || flagCount <= 0) return null;
+  const links = body.match(ALL_FILE_LINKS_PATTERN) ?? [];
+  const packUrl =
+    links.find((link) => /\.zip(\?|#|$)/i.test(link)) ??
+    links.find((link) => /\.json(\?|#|$)/i.test(link)) ??
+    links[0] ??
+    null;
+  if (!packUrl) return null;
+  return {
+    id: `scenario-${issue.number}`,
+    title: String(issue.title ?? "").replace(/^\[Scenario\]\s*/i, "").trim() || `Scenario #${issue.number}`,
+    author: issue.user?.login || "",
+    avatarUrl: issue.user?.avatar_url || "",
+    url: issue.html_url,
+    createdAt: issue.created_at,
+    official: OFFICIAL_ASSOCIATIONS.has(issue.author_association),
+    upvotes: issue.reactions?.["+1"] ?? 0,
+    code: null,
+    imageUrl: firstMatch(body, COVER_IMAGE_PATTERN),
+    fromScenario: true,
+    flagCount,
+    packUrl,
+  };
+};
+
+// A post is only usable if we can actually get a payload out of it: an image
+// for a dedicated flag post, the bundle attachment for a scenario pack.
+export const flagPostInstallable = (post) =>
+  Boolean(post?.fromScenario ? post?.packUrl : post?.imageUrl);
 
 export const fetchCommunityFlags = async ({ force = false } = {}) => {
   if (!force && cache.posts && Date.now() - cache.at < CACHE_TTL_MS) return cache.posts;
 
-  const res = await fetch(HUB_API_FLAGS, { headers: { Accept: "application/vnd.github+json" } });
+  // Dedicated flag posts, plus scenario posts (scanned so flags shared inside
+  // scenarios show up here too). The scenarios call is best-effort — a failure
+  // just hides the packs, exactly like the basemap browser.
+  const headers = { Accept: "application/vnd.github+json" };
+  const [res, scRes] = await Promise.all([
+    fetch(HUB_API_FLAGS, { headers }),
+    fetch(HUB_API_SCENARIOS, { headers }).catch(() => null),
+  ]);
   if (!res.ok) {
     throw new Error(
       res.status === 403
@@ -74,10 +126,19 @@ export const fetchCommunityFlags = async ({ force = false } = {}) => {
     );
   }
   const issues = await res.json();
-  const posts = (Array.isArray(issues) ? issues : [])
+  const dedicated = (Array.isArray(issues) ? issues : [])
     .filter((i) => !i.pull_request) // the issues endpoint returns PRs too
     .map(parseFlagPost)
     .filter(flagPostInstallable);
+  let packs = [];
+  if (scRes && scRes.ok) {
+    const scIssues = await scRes.json().catch(() => []);
+    packs = (Array.isArray(scIssues) ? scIssues : [])
+      .filter((i) => !i.pull_request)
+      .map(parseScenarioAsFlagPack)
+      .filter(Boolean);
+  }
+  const posts = [...dedicated, ...packs];
 
   cache = { at: Date.now(), posts };
   return posts;
@@ -102,6 +163,43 @@ export const loadCommunityFlagDataUrl = async (post) => {
     binary += String.fromCharCode(...view.subarray(i, i + chunk));
   }
   return `data:${mime};base64,${btoa(binary)}`;
+};
+
+// Resolve a scenario flag pack to its flags: download the bundle through the
+// hub proxy, find scenario.json (bundles ship as a .zip; older posts may be
+// bare JSON), and return the CUSTOM flags from assets.flags. flagcdn URLs are
+// skipped — those are the built-ins every picker already lists.
+export const loadCommunityFlagPack = async (post) => {
+  if (!post?.packUrl) throw new Error("That post has no scenario bundle.");
+  const r = await fetch(`/api/hub/file?url=${encodeURIComponent(post.packUrl)}`);
+  if (!r.ok) {
+    const p = await r.json().catch(() => ({}));
+    throw new Error(p.error || `Download failed (HTTP ${r.status}).`);
+  }
+  const buffer = await r.arrayBuffer();
+  let bundle;
+  if (looksLikeZip(new Uint8Array(buffer))) {
+    const zip = await unzipBundle(buffer);
+    const text = await zip.text("scenario.json");
+    if (!text) throw new Error("That .zip is missing scenario.json.");
+    bundle = JSON.parse(text);
+  } else {
+    bundle = JSON.parse(new TextDecoder().decode(buffer));
+  }
+  // assets.flags is { data: {owner -> flag string}, mode: "embedded" } from the
+  // exporter; tolerate a bare owner->flag object from hand-built bundles.
+  const asset = bundle?.assets?.flags;
+  const flagsMap =
+    asset && typeof asset === "object" && asset.data && typeof asset.data === "object"
+      ? asset.data
+      : asset && typeof asset === "object" && !("mode" in asset)
+        ? asset
+        : {};
+  const flags = Object.entries(flagsMap)
+    .filter(([, value]) => typeof value === "string" && value.startsWith("data:"))
+    .map(([code, dataUrl]) => ({ code, dataUrl }));
+  if (!flags.length) throw new Error("No custom flags found in that scenario.");
+  return flags;
 };
 
 export const communityFlagsHubUrl = () =>


### PR DESCRIPTION
One combined PR per channel, superseding the per-feature PRs that conflicted with each other as siblings merged (#403-#408, #410, #411 — each closed with a pointer here). File contents are identical to the sandbox-verified state of each feature.

## What's inside
- **Slim top bar** (was #403/#404/#405): the in-game full-width bar is gone — a compact sleek summary pill sits next to the ⋮ settings button with Exit Game and ⏻ as matching pills (stacked in the left gutter on phones), and `TOP_BAR_OFFSET` drops to 0.5rem so the map gets the whole band back.
- **Community flag packs** (was #406/#407/#408): scenario posts tagged `Flags-Count: N` at publish surface in the flag picker's Community tab as installable packs; install pulls `assets.flags` from the bundle through the hub proxy and saves each custom flag into My flags, hash-deduped. Editor twin: Open-Historia/open-historia-map-editor#6.
- **Pre-game history** (was #409, already merged on main; included for alpha/beta): a fresh game whose scenario filled in "World Before Round One" generates its backstory events on first entry — dated strictly before the start (strict retry, then salvage), no impacts, clock frozen at round 1, menu-gated, never runs twice.
- **Reference image** (same origin): map editor overlay for tracing borders — movable/resizable, 50% opacity, session-only, never exported. Editor twin: Open-Historia/open-historia-map-editor#7.

The main PR carries only what main still lacks (slim top bar + flag packs); the alpha/beta PRs carry all four features and are content-identical to each other.


---
**Update:** now also carries the Windows-safe soft delete - deleting a game/scenario no longer EPERMs when another process holds a file inside it open (poll in flight, indexer, OneDrive). The trash rename retries briefly, then falls back to copy-into-.trash + per-file delete. Reproduced with a pinned-open world.json: bare rename fails, DELETE on this build succeeds in <1s with the .trash copy intact.