### PR TITLE
Import counter: dedup by account + IP for the website, IP for the app (beta)

### DIFF
--- a/tools/import-counter/README.md
+++ b/tools/import-counter/README.md
@@ -6,6 +6,16 @@ scenario. The game server pings it once per install on a successful import (see
 for scenarios GitHub can't count (issue attachments), deduped so one person
 re-importing doesn't inflate the total.
 
+Dedup is server-side, per scenario:
+- **Website** (import forwarded by the registry Worker): once per **account _and_
+  IP** — a signed-in import marks both, and a later hit is skipped if either the
+  account or the IP was already seen for that scenario.
+- **App / anonymous web**: once per **IP** (there is no account).
+
+Raw IPs are never stored — they're hashed with `HASH_SALT`. The real browser IP
+and account token are trusted only when the caller proves it's the registry
+Worker via `FORWARD_SECRET`; direct callers can only spend their own IP.
+
 It runs on Cloudflare's free tier (Workers + KV) — no card required for the free
 plan, no server to keep alive.
 

--- a/tools/import-counter/worker.js
+++ b/tools/import-counter/worker.js
@@ -1,15 +1,22 @@
 /**
  * Open Historia — scenario import counter (Cloudflare Worker + KV).
  *
- * Counts how many people imported each community scenario. Deduped SERVER-SIDE by
- * (scenario id, client IP): a person can't inflate a scenario's count by
- * re-importing / button-mashing / clearing localStorage. Genuine, distinct
- * installs still add up.
+ * Counts how many people imported each community scenario, deduped SERVER-SIDE so
+ * a person can't inflate a scenario's count by re-importing / button-mashing /
+ * clearing localStorage. Genuine, distinct installs still add up.
+ *
+ * Dedup axes per scenario id:
+ *   - Website (import forwarded by the registry Worker): per ACCOUNT *and* per IP.
+ *     A signed-in import marks both; a later hit is ignored if EITHER the account
+ *     OR the IP was already seen — so the same person counts once whether they
+ *     toggle sign-in or move networks, and a shared IP counts once.
+ *   - App / anonymous web: per IP only (there is no account).
  *
  * Web imports are forwarded by the registry Worker, so the real browser IP is
- * passed in X-OH-Client-IP and trusted ONLY when X-OH-Forward-Secret matches
- * FORWARD_SECRET — otherwise a Worker->Worker hop would collapse every web user
- * to the registry's single egress IP. Direct callers can only spend their own IP.
+ * passed in X-OH-Client-IP and the account token in X-OH-Account — both trusted
+ * ONLY when X-OH-Forward-Secret matches FORWARD_SECRET (otherwise a Worker->
+ * Worker hop would collapse every web user to the registry's single egress IP,
+ * and anyone could spoof an account). Direct callers can only spend their own IP.
  *
  * Routes:
  *   POST /hit          body {id, title?}  -> increment for `id` (once per IP)
@@ -48,15 +55,19 @@ function clientIp(request, env) {
   return request.headers.get("cf-connecting-ip") || "unknown";
 }
 
-// What a hit dedups on. A signed-in web account (an opaque token the trusted
-// registry Worker forwards with the shared secret) dedups per-ACCOUNT — so the
-// same person counts once for a scenario across devices/IPs. Everyone else dedups
-// per IP, exactly as before. Spoofing an account needs the FORWARD_SECRET.
-async function dedupKeyFor(request, env, id) {
+// The dedup markers a hit consumes for scenario `id`. Everyone gets an IP marker;
+// a signed-in web account (an opaque token the trusted registry Worker forwards
+// with the shared secret) adds an account marker too. The hit is counted only
+// when NONE of its markers already exist, so a website user is deduped by account
+// AND IP, and the app / anonymous web by IP alone. The key formats are unchanged
+// from the account-only / IP-only versions, so existing markers still dedup (an
+// account marker always carries ":a:", an IP hash never does — they can't collide).
+async function dedupMarkersFor(request, env, id) {
+  const markers = [`h:${id}:${await ipHash(clientIp(request, env), env)}`];
   const secretOk = env.FORWARD_SECRET && request.headers.get("x-oh-forward-secret") === env.FORWARD_SECRET;
   const acct = secretOk ? (request.headers.get("x-oh-account") || "").trim() : "";
-  if (acct) return `h:${id}:a:${acct.slice(0, 48)}`;
-  return `h:${id}:${await ipHash(clientIp(request, env), env)}`;
+  if (acct) markers.push(`h:${id}:a:${acct.slice(0, 48)}`);
+  return markers;
 }
 
 export default {
@@ -75,11 +86,15 @@ export default {
         const meta = existing.metadata || {};
         let count = Number(meta.count) || 0;
         const title = String(body.title ?? meta.title ?? "").slice(0, 200);
-        const dedupKey = await dedupKeyFor(request, env, id);
-        if (await env.IMPORTS.get(dedupKey)) {
-          return json({ id, count, deduped: true }); // already counted this account/IP
+        const markers = await dedupMarkersFor(request, env, id);
+        // Already counted if ANY axis (this account, or this IP) has been seen.
+        const seen = await Promise.all(markers.map((marker) => env.IMPORTS.get(marker)));
+        if (seen.some(Boolean)) {
+          return json({ id, count, deduped: true });
         }
-        await env.IMPORTS.put(dedupKey, "1", { expirationTtl: DEDUP_TTL });
+        await Promise.all(
+          markers.map((marker) => env.IMPORTS.put(marker, "1", { expirationTtl: DEDUP_TTL })),
+        );
         count += 1;
         await env.IMPORTS.put(countKey, "", { metadata: { count, title } });
         return json({ id, count });


### PR DESCRIPTION
The "one install per person" dedup on the scenario import counter split into two separate namespaces that never cross-checked:

- a **signed-in website** import was deduped by **account only**
- an **app / anonymous** import was deduped by **IP only**

So the same website user counted **twice** if they imported once signed out and once signed in, or from two networks — the account marker and the IP marker lived in different keyspaces.

## Fix (`tools/import-counter/worker.js`)
A `/hit` now consumes a **set** of dedup markers and counts only if **none** already exist:

- **Website** (import forwarded by the registry Worker): writes an **account marker AND an IP marker**, and is skipped if **either** was already seen for that scenario → once per account *and* per IP.
- **App / anonymous web**: **IP marker only** (there is no account) → once per IP.

Key formats are unchanged (an account marker always carries `:a:`, an IP hash never does — they can't collide), so **existing dedup markers keep working**. The registry Worker already forwards the real browser IP *and* the account token, so there's no forwarder change — only the counter's decision logic and its docs.

## Verified
An in-memory-KV harness drove the real `/hit` handler across 8 cases, all green:
- App, 2 distinct IPs → **2**; same machine re-import / same-NAT second player → not double-counted.
- Website anonymous, 2 real IPs → **2**.
- Website signed-in, same account across 2 IPs → **1**.
- **The bug**: same person, signed-out then signed-in on one IP → **1** (was 2).
- Signed-in then anonymous on one IP → **1**.
- Shared IP, two different accounts → **1** (once per IP, as requested).
- 3 genuinely distinct people → **3**.
- Spoofed `X-OH-Account` headers with no forward secret → **1** (can't inflate).

## Deploy note
This is a Cloudflare Worker — merging doesn't deploy it. Redeploy with `cd tools/import-counter && wrangler deploy` for the change to take effect. Existing counts and markers are preserved.
