### PR TITLE
Fix annexed regions painting the wrong colour + stop retaining scenario geometry and stale PMTiles (beta)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -73,6 +73,11 @@ app.use((req, res, next) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  // PMTiles range reads are cross-origin from the phone shell. Range is
+  // CORS-safelisted so 206s work, but pmtiles' recovery path for a very small
+  // archive reads Content-Range off a 416 — and a non-exposed header reads as
+  // absent, which it reports as a hard error.
+  res.setHeader("Access-Control-Expose-Headers", "Content-Range, Content-Length, Accept-Ranges");
   // Chrome's Private Network Access preflights loopback/LAN targets and
   // requires this opt-in on top of regular CORS.
   res.setHeader("Access-Control-Allow-Private-Network", "true");

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -95,6 +95,57 @@ const fallbackColorFromOwner = (owner = "") => {
   return `rgb(${r}, ${g}, ${b})`;
 };
 
+// "#c0507a" / "#c07" / "rgb(192, 80, 122)" -> [r,g,b]; null when unparseable.
+// world.polityOverrides stores colours as CSS strings while colors.json stores
+// RGB triplets, so the two namespaces need a bridge before they can be merged.
+const parseColorToRgb = (value) => {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  const hex = raw.replace(/^#/, "");
+  if (/^[0-9a-f]{6}$/i.test(hex)) {
+    const n = parseInt(hex, 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+  if (/^[0-9a-f]{3}$/i.test(hex)) {
+    return [
+      parseInt(`${hex[0]}${hex[0]}`, 16),
+      parseInt(`${hex[1]}${hex[1]}`, 16),
+      parseInt(`${hex[2]}${hex[2]}`, 16),
+    ];
+  }
+  const match = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(raw);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])].map((c) => Math.max(0, Math.min(255, c)));
+};
+
+// Palettes are owner -> [r,g,b]. Re-reading colors.json hands back a fresh object
+// every time; swapping identity for identical contents would rebuild every
+// MapLibre match expression on the map, so compare contents before accepting it.
+const shallowEqualColors = (a, b) => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a);
+  if (keysA.length !== Object.keys(b).length) return false;
+  for (const key of keysA) {
+    const left = a[key];
+    const right = b[key];
+    if (left === right) continue;
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+    for (let i = 0; i < left.length; i += 1) {
+      if (left[i] !== right[i]) return false;
+    }
+  }
+  return true;
+};
+
+// Case/diacritic/punctuation-folded owner key, so "Côte d'Ivoire", "cote divoire"
+// and "COTE D'IVOIRE" all reach the same palette entry.
+const ownerFoldKey = (value) =>
+  String(value ?? "")
+    .normalize("NFD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+
 // ---- Disputed-region stripes ------------------------------------------------
 // A region whose `claimants` list names the countries contesting it renders
 // striped in their colors (current administrator first). The stripe tile's
@@ -629,11 +680,74 @@ const WorldMap = ({ isGlobe = false }) => {
     return () => map.off("click", handleRegionClick);
   }, [handleRegionClick, map]);
 
+  // The palette is re-read whenever colors.json is written (every AI turn can mint
+  // or recolour a polity, and the main menu's faction creator writes the player's
+  // own colour over an already-mounted map). Fetching once on mount left any
+  // owner coloured after mount painting a procedural fallback for the rest of the
+  // session — healed only by a reload. `oh:colors-updated` is dispatched by the
+  // asset layer's write path; the epoch re-runs this effect.
+  const [colorsEpoch, setColorsEpoch] = useState(0);
   useEffect(() => {
-    getNationColors()
-      .then(setColorMap)
-      .catch((error) => console.error("Error loading colors:", error));
+    const bump = () => setColorsEpoch((n) => n + 1);
+    window.addEventListener("oh:colors-updated", bump);
+    return () => window.removeEventListener("oh:colors-updated", bump);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getNationColors()
+      .then((next) => {
+        if (cancelled) return;
+        // Only swap the object when the contents actually differ — a new identity
+        // rebuilds every MapLibre match expression below.
+        setColorMap((prev) => (shallowEqualColors(prev, next) ? prev : next));
+      })
+      .catch((error) => console.error("Error loading colors:", error));
+    return () => {
+      cancelled = true;
+    };
+  }, [colorsEpoch]);
+
+  // ONE owner -> rgb resolver for every paint path. colors.json and the live
+  // polity registry (world.polityOverrides) are two different namespaces: a
+  // polity can be correctly NAMED by the registry while colors.json has no key
+  // for it — shipped example: "British Empire" owns 426 regions in
+  // world-war-ii-1939-copy with its colour (#c0507a) only in polityOverrides.
+  // Resolving the name but not the colour painted those regions a muddy
+  // procedural fallback, which reads to a player as "the map didn't annex it".
+  const resolveOwnerRgb = useCallback(
+    (owner) => {
+      if (!owner) return null;
+      const exact = colorMap[owner];
+      if (exact) return exact;
+      const registry = parseColorToRgb(polityOverrides?.[owner]?.color);
+      if (registry) return registry;
+      const fold = ownerFoldKey(owner);
+      if (fold) {
+        for (const [key, rgb] of Object.entries(colorMap)) {
+          if (ownerFoldKey(key) === fold) return rgb;
+        }
+        for (const [key, entry] of Object.entries(polityOverrides ?? {})) {
+          const names = [key, ...(Array.isArray(entry?.aliases) ? entry.aliases : [])];
+          if (!names.some((name) => ownerFoldKey(name) === fold)) continue;
+          const rgb = parseColorToRgb(entry?.color);
+          if (rgb) return rgb;
+          const palette = colorMap[key];
+          if (palette) return palette;
+        }
+      }
+      return fallbackRgbFromOwner(owner);
+    },
+    [colorMap, polityOverrides],
+  );
+
+  const ownerColorCss = useCallback(
+    (owner) => {
+      const rgb = resolveOwnerRgb(owner);
+      return rgb ? `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})` : NEUTRAL_LAND_COLOR;
+    },
+    [resolveOwnerRgb],
+  );
 
 
   // Load custom region geometry once, only when the active map declares it. Stock
@@ -703,9 +817,7 @@ const WorldMap = ({ isGlobe = false }) => {
     const fallback = buildFallbackColorExpression();
     const regionOverrideStops = Object.entries(regionOwnershipOverrides).flatMap(([regionId, ownerCode]) => [
       regionId,
-      colorMap[ownerCode]
-        ? `rgb(${colorMap[ownerCode][0]}, ${colorMap[ownerCode][1]}, ${colorMap[ownerCode][2]})`
-        : fallbackColorFromOwner(ownerCode),
+      ownerColorCss(ownerCode),
     ]);
 
     return {
@@ -721,7 +833,7 @@ const WorldMap = ({ isGlobe = false }) => {
         : fallback,
       "fill-opacity": 0.66,
     };
-  }, [colorMap, regionOwnershipOverrides]);
+  }, [colorMap, regionOwnershipOverrides, ownerColorCss]);
 
   // Fill for custom (editor) regions: we pre-compute a _fillColor property onto
   // every feature so the MapLibre paint expression is just ["get", "_fillColor"]
@@ -731,19 +843,12 @@ const WorldMap = ({ isGlobe = false }) => {
   const enrichedCustomRegionData = useMemo(() => {
     if (!customRegionData?.features) return customRegionData;
 
-    const colorByOwner = {};
-    for (const [iso, rgb] of Object.entries(colorMap)) {
-      colorByOwner[iso] = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
-    }
-
     const overrideColor = {};
     for (const [regionId, ownerCode] of Object.entries(regionOwnershipOverrides)) {
-      overrideColor[regionId] = colorMap[ownerCode]
-        ? `rgb(${colorMap[ownerCode][0]}, ${colorMap[ownerCode][1]}, ${colorMap[ownerCode][2]})`
-        : fallbackColorFromOwner(ownerCode);
+      overrideColor[regionId] = ownerColorCss(ownerCode);
     }
 
-    const rgbForOwner = (owner) => colorMap[owner] ?? fallbackRgbFromOwner(owner);
+    const rgbForOwner = (owner) => resolveOwnerRgb(owner) ?? fallbackRgbFromOwner(owner);
 
     return {
       ...customRegionData,
@@ -753,10 +858,8 @@ const WorldMap = ({ isGlobe = false }) => {
         let fillColor;
         if (overrideColor[id]) {
           fillColor = overrideColor[id];
-        } else if (props.owner && colorByOwner[props.owner]) {
-          fillColor = colorByOwner[props.owner];
         } else if (props.owner) {
-          fillColor = fallbackColorFromOwner(props.owner);
+          fillColor = ownerColorCss(props.owner);
         } else {
           fillColor = NEUTRAL_LAND_COLOR;
         }
@@ -793,7 +896,7 @@ const WorldMap = ({ isGlobe = false }) => {
         };
       }),
     };
-  }, [customRegionData, colorMap, regionOwnershipOverrides, regionClaimants]);
+  }, [customRegionData, colorMap, regionOwnershipOverrides, regionClaimants, ownerColorCss, resolveOwnerRgb]);
 
   // GADM disputed regions also paint the stock tiles (the crisp z>6.5 layer):
   // GID_1 -> stripe-tile id stops for the tile twin of the disputed layer.
@@ -835,14 +938,7 @@ const WorldMap = ({ isGlobe = false }) => {
     const stops = [];
     for (const [regionId, owner] of ownerByRegionId) {
       if (!regionId.includes(".")) continue; // drawn regions aren't in the tiles
-      stops.push(
-        regionId,
-        owner
-          ? colorMap[owner]
-            ? `rgb(${colorMap[owner][0]}, ${colorMap[owner][1]}, ${colorMap[owner][2]})`
-            : fallbackColorFromOwner(owner)
-          : NEUTRAL_LAND_COLOR,
-      );
+      stops.push(regionId, owner ? ownerColorCss(owner) : NEUTRAL_LAND_COLOR);
     }
     if (!stops.length) return { "fill-opacity": 0 };
     return {
@@ -850,7 +946,7 @@ const WorldMap = ({ isGlobe = false }) => {
       // Fades in as the seed-geometry far layer fades out.
       "fill-opacity": TILE_FILL_FADE,
     };
-  }, [customActive, ownerByRegionId, colorMap]);
+  }, [customActive, ownerByRegionId, colorMap, ownerColorCss]);
 
   // Stock country fills/borders render ONLY once the world is known to be a
   // stock world. Gating on the customRegions FLAG (not customActive, which

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -160,6 +160,12 @@ const invalidateDerivedCachesForWrite = (url) => {
   if (url && url === JSON_URLS.colors) {
     nationColorsPromise = null;
     nationColorsPromiseKey = "";
+    // Dropping the memo only helps the NEXT caller. The map reads the palette
+    // once per mount, so without a nudge an owner coloured mid-session keeps
+    // painting a procedural fallback until a reload. Consumers listen for this.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("oh:colors-updated"));
+    }
   }
   if (url && url === JSON_URLS.flags) {
     nationFlagsPromise = null;
@@ -178,7 +184,35 @@ let mapRuntimeConfigured = false;
 let vectorTileModulesPromise = null;
 
 export const setRuntimeAssetEndpoints = ({ token = "" } = {}) => {
-  runtimeAssetToken = String(token ?? "").trim();
+  const nextToken = String(token ?? "").trim();
+
+  // Every JSON_URL carries ?v=<token>, and the value caches are keyed by that
+  // full URL with no eviction, no cap and no TTL anywhere. When the token changes
+  // — a library mutation: creating/selecting/saving a scenario or game, or an
+  // asset upload — the previous generation's entries become unreachable BY
+  // CONSTRUCTION (nothing can rebuild those URL strings) yet stay strongly
+  // referenced from module scope forever. On a scenario whose regions.geojson is
+  // ~55 MB that strands ~190 MB of parsed GeoJSON per switch, which is the
+  // unbounded growth that eventually OOMs the tab.
+  //
+  // Sweep BEFORE the URLs are rebuilt below — the old strings are the only
+  // handles to those entries. PMTILES_ARCHIVES deliberately carry no token, so
+  // their warmed buffers are keyed stably and are NOT swept here.
+  if (nextToken !== runtimeAssetToken) {
+    for (const url of Object.values(JSON_URLS)) {
+      if (!url) continue;
+      jsonValueCache.delete(url);
+      jsonRequestCache.delete(url);
+    }
+    // Keyed by asset key ("world", "events", ...) rather than by URL, so these
+    // entries do not rotate with the token — meaning they would otherwise serve
+    // the PREVIOUS game's state after a switch. Clearing is a correctness fix as
+    // much as a memory one.
+    runtimeJsonValueCache.clear();
+    runtimeJsonRequestCache.clear();
+  }
+
+  runtimeAssetToken = nextToken;
 
   JSON_URLS.advisor = withRuntimeToken("/api/runtime/json/advisor");
   JSON_URLS.actions = withRuntimeToken("/api/runtime/json/actions");

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -140,6 +140,24 @@ const binaryRequestCache = new Map();
 const pmtilesArchives = new Map();
 const pmtilesCache = new SharedPromiseCache(256);
 
+// Which URLs have ever produced a genuinely-parsed payload. Cheap boolean
+// bookkeeping that survives when the VALUE is deliberately not retained, so
+// "did the custom geometry resolve?" stays answerable (see loadRegionCatalog).
+const jsonLoadedUrls = new Set();
+
+// The scenario geometry is never worth retaining: its only long-lived reader
+// keeps it in React state (Nations.jsx / Cities.jsx, both force:true), so the
+// value-cache copy is a second parsed FeatureCollection — ~190 MB on a 55 MB
+// regions.geojson — held for nobody.
+//
+// MUST be evaluated synchronously at call time. JSON_URLS.* are reassigned on
+// every token change and the cache sweep runs BEFORE that reassignment, so
+// deciding this after an await would compare the old URL against the new value,
+// judge it cacheable, and pin a copy under a URL nothing can reach or sweep
+// again — resurrecting the exact leak, on the scenario-switch path.
+const isNoStoreJsonUrl = (url) =>
+  url === JSON_URLS.regionsGeojson || url === JSON_URLS.citiesGeojson;
+
 const pmtilesProtocol = new Protocol();
 let pmtilesProtocolReady = false;
 let nationColorsPromise = null;
@@ -196,13 +214,38 @@ export const setRuntimeAssetEndpoints = ({ token = "" } = {}) => {
   // unbounded growth that eventually OOMs the tab.
   //
   // Sweep BEFORE the URLs are rebuilt below — the old strings are the only
-  // handles to those entries. PMTILES_ARCHIVES deliberately carry no token, so
-  // their warmed buffers are keyed stably and are NOT swept here.
+  // handles to those entries.
   if (nextToken !== runtimeAssetToken) {
     for (const url of Object.values(JSON_URLS)) {
       if (!url) continue;
       jsonValueCache.delete(url);
       jsonRequestCache.delete(url);
+      // Must rotate with the URLs: a stale entry would claim the NEXT
+      // generation's geometry had already resolved.
+      jsonLoadedUrls.delete(url);
+    }
+
+    // PMTILES_ARCHIVES rotate too — buildAbsoluteUrl runs the path through
+    // withRuntimeToken, so these URLs also carry ?v=<token>. Left unswept they
+    // stranded the warmed archive buffers (regions ~101 MB + countries ~60 MB +
+    // cities ~1.5 MB) once per token generation, unreachable and permanent.
+    //
+    // It is also a correctness fix: /api/runtime/pmtiles/:key resolves to the
+    // ACTIVE scenario's override when it has one, so the same path can serve
+    // different bytes after a switch. A header/directory cached against the old
+    // archive would then be applied to the new one's bytes — offsets landing in
+    // the wrong place, which surfaces as decompression errors or silently
+    // garbled geometry rather than a clean failure.
+    for (const url of Object.values(PMTILES_ARCHIVES)) {
+      if (!url) continue;
+      binaryValueCache.delete(url);
+      binaryRequestCache.delete(url);
+      pmtilesArchives.delete(url);
+      // Protocol keys its registry by source.getKey(), which is the URL.
+      // Guarded: `tiles` is internal to the pmtiles package.
+      pmtilesProtocol?.tiles?.delete?.(url);
+      // Header entry; directory entries age out of the LRU on their own.
+      pmtilesCache?.cache?.delete?.(url);
     }
     // Keyed by asset key ("world", "events", ...) rather than by URL, so these
     // entries do not rotate with the token — meaning they would otherwise serve
@@ -498,7 +541,15 @@ export const ensureBasemapProtocol = () => {
   }
 };
 
-export const readJson = async (url, { defaultValue, force = false, signal } = {}) => {
+export const readJson = async (url, { cache, defaultValue, force = false, signal } = {}) => {
+  // Snapshot the decision NOW, never inside the request closure — see
+  // isNoStoreJsonUrl for why an post-await evaluation strands an entry.
+  const store = cache === undefined ? !isNoStoreJsonUrl(url) : cache !== false;
+  // Never let a stale entry outlive the opt-out: without this, an entry pinned
+  // before the URL joined the no-store set would keep being served forever by
+  // the unforced read below (and stay pinned, defeating the point).
+  if (!store) jsonValueCache.delete(url);
+
   if (!force && jsonValueCache.has(url)) {
     return cloneJson(jsonValueCache.get(url));
   }
@@ -513,7 +564,13 @@ export const readJson = async (url, { defaultValue, force = false, signal } = {}
   const request = (async () => {
     const { response } = await fetchWithPersistence(url, { signal });
     const data = await response.json();
-    jsonValueCache.set(url, data);
+    // Recorded INSIDE the try, before the catch below: a failed read must leave
+    // this false so loadRegionCatalog retries instead of pinning a stock-only
+    // catalog. "Did we get a value?" is not a usable substitute — an originator
+    // carrying a defaultValue resolves the SHARED batched promise to that
+    // default on failure, so every awaiter sees a value either way.
+    jsonLoadedUrls.add(url);
+    if (store) jsonValueCache.set(url, data);
     return data;
   })()
     .catch((error) => {
@@ -542,10 +599,19 @@ export const warmJson = async (url, options = {}) => {
   };
 };
 
-export const primeJson = (url, data) => {
+export const primeJson = (url, data, { cache } = {}) => {
+  const store = cache === undefined ? !isNoStoreJsonUrl(url) : cache !== false;
+  jsonLoadedUrls.add(url);
+  jsonRequestCache.delete(url);
+  if (!store) {
+    // DELETE rather than merely skip: leaving an older entry behind would let
+    // the unforced read path serve the pre-write document for the rest of the
+    // session (stale region names) AND keep the copy pinned.
+    jsonValueCache.delete(url);
+    return data;
+  }
   const snapshot = cloneJson(data);
   jsonValueCache.set(url, snapshot);
-  jsonRequestCache.delete(url);
   return cloneJson(snapshot);
 };
 
@@ -1016,16 +1082,23 @@ export const loadRegionCatalog = async ({ force = false } = {}) => {
       // Regions the stock tiles don't know — shapes DRAWN in the map editor
       // (reg_* ids) and seed-only regions — get their names from the active
       // scenario's own geometry, so the AI can talk about them by name instead
-      // of raw ids. Usually already in the JSON cache (the map fetched it).
+      // of raw ids.
       let customRegionsResolved = true;
       try {
         const custom = await readJson(JSON_URLS.regionsGeojson, { defaultValue: null });
-        // readJson returns the default WITHOUT caching on a transient failure,
-        // but DOES cache a genuine "no custom geometry" result. That lets us
-        // tell a dropped fetch (retry) apart from a scenario that simply has no
-        // custom regions (stock names are correct) — so one failed request on a
-        // custom map can't pin a blank political map for the whole session.
-        customRegionsResolved = jsonValueCache.has(JSON_URLS.regionsGeojson);
+        // readJson RECORDS a genuine parse (it deliberately does not retain this
+        // document — see isNoStoreJsonUrl) and records nothing on a transient
+        // failure. That lets us tell a dropped fetch (retry) apart from a
+        // scenario that simply has no custom regions (stock names are correct),
+        // so one failed request on a custom map can't pin a blank political map
+        // for the whole session.
+        //
+        // Do NOT "simplify" this to a test on `custom` itself: the server
+        // answers a geometry-less scenario with a 200 empty FeatureCollection,
+        // and dropping `defaultValue` above doesn't work either — when a
+        // concurrent forced reader is the batched originator, its own default
+        // resolves this promise too, so a failure arrives as a value with no throw.
+        customRegionsResolved = jsonLoadedUrls.has(JSON_URLS.regionsGeojson);
         for (const feature of custom?.features ?? []) {
           const props = feature?.properties ?? {};
           const id = props.id != null ? String(props.id) : "";

--- a/src/runtime/countryLabels.js
+++ b/src/runtime/countryLabels.js
@@ -632,6 +632,20 @@ export const loadCountryLabelCollections = async ({ force = false, ownedCodes = 
     }
 
     const built = await buildCountryLabelCollections(tileData, ownedCodes);
+
+    // An empty result is almost always a degraded z0 read (a missing or garbled
+    // tile resolves to undefined rather than throwing), not a genuinely
+    // label-less world. Persisting it is unrecoverable: the payload validator
+    // accepts an empty FeatureCollection, so every later boot serves the empty
+    // cache and the country labels stay gone across reloads. Serve it once,
+    // memoize nothing, and let the next call rebuild.
+    const isEmpty =
+      !built?.pointLabelData?.features?.length && !built?.curvedLabelData?.features?.length;
+    if (isEmpty) {
+      console.warn("Country labels came back empty — not caching, will rebuild.");
+      return built;
+    }
+
     countryLabelsValue = built;
     countryLabelsValueKey = cacheKey;
 


### PR DESCRIPTION
Two things from the same audit, in one PR per channel: the annexation paint bug, and the memory retention behind the OOM crash.

**No zoom or tile-source cap is changed.** `countries-source` / `regions-source` stay at `maxzoom={8}` deliberately (see the comment at Nations.jsx — z9/z10 seeds broke the editor), and the camera cap stays `maxZoom={16}`.

---

## 1. Annexed regions painted the wrong colour

*"The map isn't properly annexing another country even though the inspect tool says that region is part of their country."*

Owner **names** and owner **colours** were resolved by two different, non-equivalent paths. The name path is live and registry-backed (`world.polityOverrides`) — what the inspect popup, country panel and labels use. The colour path was a strict exact-key index into a **mount-time snapshot** of `colors.json` that never consulted `polityOverrides`. Any owner the name path knows but the palette doesn't paints a muted procedural fallback: the region *is* repainted, just in a colour matching nothing in the player's UI.

**This ships in the data today:** `world-war-ii-1939-copy` has `British Empire` owning **426 regions**, colour `#c0507a` present in `polityOverrides`, no `colors.json` key at all.

- One shared owner→rgb resolver: exact palette → live registry colour (`#rrggbb`/`#rgb`/`rgb()`) → case/diacritic/punctuation-folded match across both incl. aliases → existing hash fallback. All five paint paths route through it.
- The palette is re-read when `colors.json` is written instead of once per mount, so a polity created or recoloured mid-session (an AI turn, a cheat recolour, the player's own faction colour written over an already-mounted map) paints correctly with no reload. Contents are compared before swapping so match expressions don't rebuild.

**Verified:** all 426 British Empire regions paint `rgb(192,80,122)` (was `rgb(69,104,149)`); a country created mid-session then given a region paints its true `rgb(18,200,255)` live (old behaviour `rgb(159,154,84)`).

---

## 2. Memory retention

- **Stale-token sweep.** JSON asset caches are keyed by tokenised URL with no eviction, cap or TTL; every library mutation stranded the previous generation — unreachable by construction, permanently referenced. Also fixes the runtime-json caches (keyed by *asset key*, so a switch could serve the previous game's state).
- **The scenario geometry is no longer double-stored.** `readJson` kept the parsed value *and* returned a clone — ~190 MB retained for nobody on a 52.8 MB `regions.geojson`, since the only long-lived reader keeps its own copy in React state. The cache entry is now skipped for the geometry URLs, decided **synchronously at call time** (deciding after an `await` would compare a pre-switch URL against a post-switch value and pin a copy nothing can reach or sweep).
  - The `jsonValueCache.has()` "did the geometry resolve?" probe is replaced by explicit bookkeeping, recorded on a genuine parse and rotated with the token. Without that the region-catalog memo is destroyed on every build → 52.8 MB re-parsed **on every region click**.
  - **Clones are deliberately kept.** Two callers mutate the result in place (a region rename writes back; a prompt build sorts the city features), so sharing one object would corrupt what the map renders.
- **PMTiles caches are swept on token change.** `buildAbsoluteUrl` runs these paths through `withRuntimeToken`, so the archive URLs carry `?v=` too — the in-repo comment claiming otherwise was wrong. Unswept they stranded the warmed buffers (regions ~101 MB + countries ~60 MB + cities ~1.5 MB) **per token generation**. Also a correctness fix: the same path serves a different scenario's bytes after a switch, so a header/directory cached against the old archive would be applied to the new one's.
- **Country labels are never persisted empty.** An empty result is a degraded z0 read, not a label-less world, and the validator accepts it — one bad read removed country labels across every later reload until the cache key changed.
- Exposes `Content-Range`/`Content-Length`/`Accept-Ranges` for the phone shell's 416 recovery path on a very small archive.

**Verified in a booted browser** (default scenario, 52.8 MB geometry): map paints at z2/z6/z7 and when overzoomed past the z8 source cap; 13 country labels render; **exactly one** geometry request on load and still one after five region clicks (the memo holds); scenario switch repaints with the new game's data and no staleness; range requests answer `206` with a correct `Content-Range`.

**Honest limitation:** I could not get a trustworthy MB delta from `performance.memory` — it counts uncollected garbage and my own instrumentation contaminated it. The reductions are verified structurally (entries provably deleted; buffers no longer stranded), not as a measured number. A DevTools heap snapshot with forced GC, reading the Retainers pane for `jsonValueCache`/`binaryValueCache`/`pmtilesArchives`, is the check that would quantify it.

**Still outstanding** (deliberately not in this PR): dropping the PMTiles *prime* entirely (~162 MB steady state — needs its own verification pass), and the hosted-web-build `idbGetAll` on every tile range request.
