### PR TITLE
Throttle idle globe updates to ~15fps (incorporates #435) + two review fixes (alpha)

### DIFF
--- a/src/Game/Map/GlobeEffects.jsx
+++ b/src/Game/Map/GlobeEffects.jsx
@@ -1,4 +1,4 @@
-/*! Open Historia — globe celestial rendering, day/night lighting + orbit © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+﻿/*! Open Historia — globe celestial rendering, day/night lighting + orbit © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import { useEffect } from "react";
 import { useMap } from "react-map-gl/maplibre";
 import {
@@ -20,8 +20,21 @@ import { MAP_SETTING_KEYS, useMapSetting } from "../../runtime/mapSettings.js";
 
 const ROTATION_DEG_PER_MS = 360 / (10 * 60 * 1000);
 const INTERACTION_GRACE_MS = 3000;
-const CELESTIAL_FRAME_MS = 1000 / 60;
-const LIGHTING_FRAME_MS = 1000 / 60;
+// While the user is actively dragging/zooming, redraw the sun/lighting every
+// frame so it tracks the camera precisely. While idle (including during
+// auto-rotate), the same visual result is indistinguishable at a much lower
+// rate, so throttle down hard — this is the single biggest lever on
+// sustained CPU/GPU load, since idle auto-rotate used to force a full
+// MapLibre re-render plus a from-scratch lighting repaint 60 times a second,
+// forever, even with the phone just sitting on a table.
+const CELESTIAL_FRAME_MS_ACTIVE = 1000 / 60;
+const CELESTIAL_FRAME_MS_IDLE = 1000 / 15;
+const LIGHTING_FRAME_MS_ACTIVE = 1000 / 60;
+const LIGHTING_FRAME_MS_IDLE = 1000 / 15;
+// Idle auto-rotation itself doesn't need a fresh jumpTo() every animation
+// frame either — updating the camera 15x/sec still reads as smooth rotation
+// but avoids tripling MapLibre's re-render work compared to 60x/sec.
+const IDLE_ROTATE_FRAME_MS = 1000 / 15;
 // The terminator creeps 0.25°/minute as the real Earth turns; refresh on this
 // cadence even when the map is fully idle (no render events fire then), so the
 // day/night line stays live without a per-frame cost.
@@ -43,7 +56,6 @@ const GlobeEffects = ({ active }) => {
     const mapInstance = map.getMap?.() ?? map;
 
     let frameId = 0;
-    let lastTick = performance.now();
     let lastInteraction = 0;
     let disposed = false;
     let contextLost = false;
@@ -87,8 +99,23 @@ const GlobeEffects = ({ active }) => {
           ?.getProjectionDataForCustomLayer?.(true)
           ?.projectionTransition,
       );
+      // The globe<->mercator morph fades the stars/lighting overlays via
+      // projectionTransition (an opacity: exactly 1 on the settled globe, 0 on
+      // flat mercator, strictly between only mid-fade). That morph isn't driven
+      // by a map "move", and toggling projection fires no interaction event, so
+      // without this it would read as idle and the fade would step at 15fps.
+      // Keep the fade itself at full rate; only the settled globe throttles.
+      const isMorphing = projectionTransition > 0 && projectionTransition < 1;
+      // Only active dragging/zooming needs full 60fps precision. Idle —
+      // whether that's auto-rotating or just sitting still — settles for
+      // 15fps, which looks identical but is a fraction of the CPU/GPU cost.
+      const isIdle = !isMorphing
+        && (autoRotationActive
+          || (!mapInstance.isMoving() && now - lastInteraction > INTERACTION_GRACE_MS));
+      const celestialFrameMs = isIdle ? CELESTIAL_FRAME_MS_IDLE : CELESTIAL_FRAME_MS_ACTIVE;
+      const lightingFrameMs = isIdle ? LIGHTING_FRAME_MS_IDLE : LIGHTING_FRAME_MS_ACTIVE;
       if (projectionTransition > 0
-        && (forceLighting || now - lastCelestialDraw >= CELESTIAL_FRAME_MS)) {
+        && (forceLighting || now - lastCelestialDraw >= celestialFrameMs)) {
         lastCelestialDraw = now;
         starsVisible = true;
         drawCelestialStars({
@@ -134,7 +161,7 @@ const GlobeEffects = ({ active }) => {
       }
 
       if (projectionTransition > 0) {
-        const lightingDelay = LIGHTING_FRAME_MS - (now - lastLightingDraw);
+        const lightingDelay = lightingFrameMs - (now - lastLightingDraw);
         if (forceLighting || lightingDelay <= 0) {
           if (lightingTimer) clearTimeout(lightingTimer);
           lightingTimer = 0;
@@ -164,15 +191,25 @@ const GlobeEffects = ({ active }) => {
       }
     };
 
+    let lastRotateTick = performance.now();
     const tick = (now) => {
       if (disposed || contextLost || !mapInstance.style) return;
-      const dt = now - lastTick;
-      lastTick = now;
       const idle = now - lastInteraction > INTERACTION_GRACE_MS;
       autoRotationActive = idle && !autoRotateDisabled && !mapInstance.isMoving();
       if (autoRotationActive) {
-        const center = mapInstance.getCenter();
-        mapInstance.jumpTo({ center: [center.lng - ROTATION_DEG_PER_MS * dt, center.lat] });
+        // Advancing the camera on every animation frame forces MapLibre to
+        // fully re-render 60x/sec forever while idle. Stepping at ~15fps
+        // instead (using the real elapsed time so the rotation *speed* is
+        // unaffected) looks identical but cuts that sustained render load
+        // roughly 4x — the main thing that was cooking phones on this screen.
+        const rotateDt = now - lastRotateTick;
+        if (rotateDt >= IDLE_ROTATE_FRAME_MS) {
+          lastRotateTick = now;
+          const center = mapInstance.getCenter();
+          mapInstance.jumpTo({ center: [center.lng - ROTATION_DEG_PER_MS * rotateDt, center.lat] });
+        }
+      } else {
+        lastRotateTick = now;
       }
       frameId = requestAnimationFrame(tick);
     };
@@ -199,7 +236,9 @@ const GlobeEffects = ({ active }) => {
     const handleContextRestored = () => {
       contextLost = false;
       syncVisuals();
-      lastTick = performance.now();
+      // Reset the rotation clock so the first tick after a WebGL context loss
+      // doesn't advance the globe by the whole (possibly long) lost interval.
+      lastRotateTick = performance.now();
       frameId = requestAnimationFrame(tick);
     };
     mapCanvas.addEventListener("webglcontextlost", handleContextLost);


### PR DESCRIPTION
Incorporates the globe-lag fix from #435 by @Noobcoder191, plus the two fixes from reviewing it — landed on all three channels (#435 only targeted main).

## The core change (from #435)
On the globe screen, idle auto-rotate advanced the camera via `jumpTo()` every animation frame (~60/s), and since `jumpTo` triggers a MapLibre render, that cascaded into a full render + a from-scratch stars/lighting repaint 60×/second, forever — even sitting still. Idle work (the auto-rotation step and the sun/lighting overlays) now runs at ~15fps.

Rotation **speed is unchanged**: the throttled step advances by the *real elapsed* time, so total degrees over any interval match the per-frame version. Verified by simulation over 1s–10min: drift is bounded to a single sub-threshold window (~0.04°) and never accumulates; jump count drops ~4.5×.

## The two review fixes on top
1. **Drop the dead `lastTick`.** Its only reader (`dt`) was removed by #435, leaving three writes and no reads. Removed — and the WebGL context-restore path now resets `lastRotateTick` instead, so the first tick after a context loss doesn't advance the globe by the whole (possibly long) lost interval.
2. **Keep the globe↔mercator morph at full rate.** The stars/lighting overlays fade via `projectionTransition`, which isn't a map "move" and (when reached via the settings toggle) fires no interaction event — so the entry/exit fade was being classified as idle and stepping at 15fps. Now guarded on `isMorphing` (opacity strictly between 0 and 1). The sun element was already updating outside the throttle, so only the star fade and terminator shading were affected; this restores their smoothness during the morph.

## Verified
- **Rotation-speed sim:** original 360.007° vs throttled 359.978° over 10 min — drift within one throttle window, ~4.5× fewer jumps.
- **Booted on globe mode:** renders 599 region features, no black screen; settled-globe `projectionTransition` is **exactly 1**, so `isMorphing` is false and the throttle engages at rest (the guard does not defeat the optimization); a mid-morph opacity (0.5) correctly forces 60fps.
- Builds clean; file parses.

**Honest caveat** (same as the original review): the visual smoothness of the entry/exit morph and the exact idle frame rate can't be measured in my headless harness (it shims `requestAnimationFrame`, which would corrupt the timing under test), so a glance on a real device toggling globe mode is worth doing — but the math and the runtime state checks above cover the correctness risks.

Supersedes #435 — once this lands, #435 should be closed (its single-file change would then conflict with the incorporated version).
