### PR TITLE
feat(i18n): separate AI chat language from UI language (beta)

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -7,7 +7,7 @@ import {
     setProviderField,
 } from "./providerConfig.js";
 import { JSON_URLS, readJson } from "../../runtime/assets.js";
-import { languageDirective } from "../../runtime/i18n.js";
+import { chatLanguageDirective, languageDirective } from "../../runtime/i18n.js";
 import { difficultyDirective } from "../../runtime/difficulty.js";
 import { normalizePromptPack } from "./gameplayPrompts.js";
 import {
@@ -943,7 +943,9 @@ export async function callAI(systemPrompt, history, opts = {}) {
     // Non-English players get replies in their language at the source —
     // native answers beat post-translating them (see runtime/i18n.js).
     const { languageMode = "ui", ...providerOpts } = opts;
-    const directive = languageMode === "none" ? "" : languageDirective();
+    const directive = languageMode === "none" ? ""
+        : languageMode === "chat" ? chatLanguageDirective()
+        : languageDirective();
     if (directive) {
         systemPrompt = `${systemPrompt}\n\n${directive}`;
     }
@@ -1088,7 +1090,7 @@ export async function sendMessage(userMessage, opts) {
     advisorHistory = compactConversationHistory(advisorHistory);
 
     try {
-        const reply = await callAI(systemPrompt, advisorHistory, opts);
+        const reply = await callAI(systemPrompt, advisorHistory, { ...opts, languageMode: "chat" });
         advisorHistory.push({ role: "model", parts: [{ text: reply }] });
         return reply;
     } catch (err) {
@@ -1150,7 +1152,7 @@ export async function sendDiplomaticMessage(playerMessage, speakingAs, countries
     ];
 
     try {
-        const raw = await callAI(freshPrompt, historyWithInstruction, opts);
+        const raw = await callAI(freshPrompt, historyWithInstruction, { ...opts, languageMode: "chat" });
         const { reply, reaction } = parseReaction(raw);
         diplomaticHistory.push({ role: "model", parts: [{ text: `[${speakingAs}]: ${reply}` }] });
         return { reply, reaction };

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -939,26 +939,27 @@ async function callAnthropicCompatible(systemPrompt, history, {
     }
 }
 
-export async function callAI(systemPrompt, history, opts) {
+export async function callAI(systemPrompt, history, opts = {}) {
     // Non-English players get replies in their language at the source —
     // native answers beat post-translating them (see runtime/i18n.js).
-    const directive = languageDirective();
+    const { languageMode = "ui", ...providerOpts } = opts;
+    const directive = languageMode === "none" ? "" : languageDirective();
     if (directive) {
         systemPrompt = `${systemPrompt}\n\n${directive}`;
     }
 
     switch (getStoredProvider()) {
     case "openai":
-        return callOpenAI(systemPrompt, history, opts);
+        return callOpenAI(systemPrompt, history, providerOpts);
     case "anthropic":
-        return callAnthropic(systemPrompt, history, opts);
+        return callAnthropic(systemPrompt, history, providerOpts);
     case "anthropic-compatible":
-        return callAnthropicCompatible(systemPrompt, history, opts);
+        return callAnthropicCompatible(systemPrompt, history, providerOpts);
     case "openai-compatible":
-        return callOpenAICompatible(systemPrompt, history, opts);
+        return callOpenAICompatible(systemPrompt, history, providerOpts);
     case "gemini":
     default:
-        return callGemini(systemPrompt, history, opts);
+        return callGemini(systemPrompt, history, providerOpts);
     }
 }
 

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import { Chart, registerables } from "chart.js";
 import { sendMessage, startChat, loadHistory } from "../AI/main.jsx";
 import { JSON_URLS, readJson, writeJson } from "../../runtime/assets.js";
+import { chatLanguageDiffersFromUi, isRtlLanguage, resolveChatLanguage } from "../../runtime/i18n.js";
 import StatsPane from "./stats.jsx";
 
 Chart.register(...registerables);
@@ -192,6 +193,10 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
     const [hasBootstrapped, setHasBootstrapped] = useState(false);
     const [activeTab, setActiveTab] = useState("advisor");
     const inputRef = useRef(null);
+    // A reply already in the chat language must skip the UI translator, which
+    // would render it back into the interface language.
+    const chatDiffers = chatLanguageDiffersFromUi();
+    const chatDir = chatDiffers && isRtlLanguage(resolveChatLanguage()) ? "rtl" : undefined;
 
     useEffect(() => {
         if (isAdvisorOpen) setHasOpened(true);
@@ -340,6 +345,7 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
             const { text, chartConfig } = msg.role === "advisor"
             ? parseMessage(msg.text)
             : { text: msg.text, chartConfig: null };
+            const asWritten = msg.role === "advisor" && chatDiffers;
             return (
                 <div key={i} style={{ display: "flex", flexDirection: "column", alignItems: msg.role === "user" ? "flex-end" : "flex-start" }}>
                 {msg.role !== "user" && (
@@ -348,7 +354,7 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
                     </span>
                 )}
                 {/* Player-typed text stays verbatim under UI translation. */}
-                <div data-no-translate={msg.role === "user" ? "" : undefined} style={{
+                <div data-no-translate={msg.role === "user" || asWritten ? "" : undefined} dir={asWritten ? chatDir : undefined} style={{
                     maxWidth: "90%", width: chartConfig ? "90%" : undefined,
                     padding: "0.6rem 0.85rem",
                     borderRadius: msg.role === "user" ? "12px 12px 2px 12px" : "12px 12px 12px 2px",

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -12,6 +12,7 @@ import {
     readJson,
 } from "../../runtime/assets.js";
 import { flagEmojiFromGid } from "../../runtime/countryFlags.js";
+import { chatLanguageDiffersFromUi, isRtlLanguage, resolveChatLanguage } from "../../runtime/i18n.js";
 import { readChatsState, writeChatsState } from "../../runtime/gameState.js";
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -164,6 +165,9 @@ const GearIcon = () => (
 const MessageBubble = ({ msg }) => {
     const isPlayer = msg.role === "user";
     const isError  = msg.role === "error";
+    // See advisor.jsx: errors are UI strings, so only a leader's own words are
+    // held back from the translator.
+    const asWritten = !isPlayer && !isError && chatLanguageDiffersFromUi();
     const flag     = useCountryFlag(isPlayer || isError ? {} : { code: msg.code, name: msg.speaker });
     const reactions = Object.entries(msg.reactions ?? {});
     const reactionFlags = useCountryFlags(reactions.map(([name, { code }]) => ({ name, code })));
@@ -195,7 +199,7 @@ const MessageBubble = ({ msg }) => {
         )}
 
         {/* Player-typed text stays verbatim under UI translation. */}
-        <div data-no-translate={isPlayer ? "" : undefined} style={{
+        <div data-no-translate={isPlayer || asWritten ? "" : undefined} dir={asWritten && isRtlLanguage(resolveChatLanguage()) ? "rtl" : undefined} style={{
             padding: "0.6rem 0.85rem",
             borderRadius: isPlayer ? "12px 12px 2px 12px" : "12px 12px 12px 2px",
             backgroundColor: isPlayer

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -9,8 +9,11 @@ import {
     setReasoningEnabled,
 } from "../AI/providerConfig.js";
 import {
+    AUTO_LANGUAGE,
     getLanguageOptions,
+    getStoredChatLanguage,
     getStoredLanguage,
+    setStoredChatLanguage,
     setStoredLanguage,
 } from "../../runtime/i18n.js";
 import {
@@ -98,16 +101,62 @@ function groupProviders(options) {
     return groups;
 }
 
-const LanguageSelector = () => {
+// leadingOption is prepended and survives filtering, so the chat picker's
+// "Same as interface" can always be gone back to.
+const LanguagePicker = ({ label, current, onSelect, saving = false, helperText, leadingOption }) => {
     const [query, setQuery] = useState("");
-    const [saving, setSaving] = useState(false);
-    const current = getStoredLanguage();
     const options = getLanguageOptions();
     const normalizedQuery = query.trim().toLowerCase();
     const filtered = normalizedQuery
         ? options.filter((option) =>
             `${option.name} ${option.native} ${option.code}`.toLowerCase().includes(normalizedQuery))
         : options;
+    const listed = filtered.some((option) => option.code === current) || leadingOption?.value === current;
+
+    return (
+        <div style={fieldGroupStyle}>
+        <label style={labelStyle}>{label}</label>
+        <input
+        style={{ ...inputStyle, marginBottom: "0.4rem" }}
+        type="text"
+        value={query}
+        placeholder="Search languages..."
+        onChange={(event) => setQuery(event.target.value)}
+        />
+        <select
+        data-no-translate
+        value={listed ? current : ""}
+        onChange={(event) => onSelect(event.target.value)}
+        style={{ ...inputStyle, cursor: "pointer", opacity: saving ? 0.6 : 1 }}
+        >
+        {!listed && (
+            <option value="" disabled>
+            {filtered.length ? `${filtered.length} matches — pick one` : "No matching language"}
+            </option>
+        )}
+        {leadingOption && (
+            <option value={leadingOption.value} style={{ color: "black" }}>
+            {leadingOption.label}
+            </option>
+        )}
+        {filtered.map((option) => (
+            <option key={option.code} value={option.code} style={{ color: "black" }}>
+            {option.name}{option.native && option.native !== option.name ? ` — ${option.native}` : ""}
+            </option>
+        ))}
+        </select>
+        {helperText && (
+            <div style={helperStyle}>
+            {helperText}
+            </div>
+        )}
+        </div>
+    );
+};
+
+const LanguageSelector = () => {
+    const [saving, setSaving] = useState(false);
+    const current = getStoredLanguage();
 
     const applyLanguage = async (code) => {
         if (!code || code === current || saving) {
@@ -123,33 +172,31 @@ const LanguageSelector = () => {
     };
 
     return (
-        <div style={fieldGroupStyle}>
-        <label style={labelStyle}>Language</label>
-        <input
-        style={{ ...inputStyle, marginBottom: "0.4rem" }}
-        type="text"
-        value={query}
-        placeholder="Search languages..."
-        onChange={(event) => setQuery(event.target.value)}
+        <LanguagePicker label="Language" current={current} onSelect={applyLanguage} saving={saving} />
+    );
+};
+
+// Steers prompts only, so no reload — the next message picks it up.
+const ChatLanguageSelector = () => {
+    const [current, setCurrent] = useState(getStoredChatLanguage);
+
+    const applyLanguage = (code) => {
+        if (!code || code === current) {
+            return;
+        }
+
+        setStoredChatLanguage(code);
+        setCurrent(code);
+    };
+
+    return (
+        <LanguagePicker
+        label="AI chat language"
+        current={current}
+        onSelect={applyLanguage}
+        helperText="What the advisor and diplomatic chats reply in."
+        leadingOption={{ value: AUTO_LANGUAGE, label: "Same as interface" }}
         />
-        <select
-        data-no-translate
-        value={filtered.some((option) => option.code === current) ? current : ""}
-        onChange={(event) => applyLanguage(event.target.value)}
-        style={{ ...inputStyle, cursor: "pointer", opacity: saving ? 0.6 : 1 }}
-        >
-        {!filtered.some((option) => option.code === current) && (
-            <option value="" disabled>
-            {filtered.length ? `${filtered.length} matches — pick one` : "No matching language"}
-            </option>
-        )}
-        {filtered.map((option) => (
-            <option key={option.code} value={option.code} style={{ color: "black" }}>
-            {option.name}{option.native && option.native !== option.name ? ` — ${option.native}` : ""}
-            </option>
-        ))}
-        </select>
-        </div>
     );
 };
 
@@ -798,6 +845,7 @@ const SettingsMenu = ({
         />
 
         <LanguageSelector />
+        <ChatLanguageSelector />
 
         <Toggle label="Fullscreen" enabled={isFullscreenEnabled} onToggle={onToggleFullscreen} />
         <Toggle label="3D Globe" enabled={isGlobeEnabled} onToggle={onToggleGlobe} />

--- a/src/runtime/i18n.js
+++ b/src/runtime/i18n.js
@@ -7,6 +7,12 @@
 const STORAGE_KEY = "ui_language";
 export const DEFAULT_LANGUAGE = "en";
 
+// What the advisor and diplomatic chats reply in, so the interface can be read
+// in one language and the chats held in another. "auto" follows the UI
+// language, as the game did before. Device-local: it only steers prompts.
+const CHAT_STORAGE_KEY = "ai_chat_language";
+export const AUTO_LANGUAGE = "auto";
+
 // The 50 most spoken languages, hand-curated: recognizable English name
 // first, endonym after. A full ISO dump read like random letters here.
 export const LANGUAGES = [
@@ -130,20 +136,61 @@ export const syncLanguageFromServer = async () => {
   return false;
 };
 
+export const getStoredChatLanguage = () => {
+  try {
+    const stored = localStorage.getItem(CHAT_STORAGE_KEY);
+    return stored && stored.trim() ? stored.trim() : AUTO_LANGUAGE;
+  } catch {
+    return AUTO_LANGUAGE;
+  }
+};
+
+export const setStoredChatLanguage = (code) => {
+  try {
+    if (!code || code === AUTO_LANGUAGE) {
+      localStorage.removeItem(CHAT_STORAGE_KEY);
+    } else {
+      localStorage.setItem(CHAT_STORAGE_KEY, code);
+    }
+  } catch {
+    // Private-mode storage failures just leave the chats on the UI language.
+  }
+};
+
+export const resolveChatLanguage = () => {
+  const stored = getStoredChatLanguage();
+  return stored === AUTO_LANGUAGE ? getStoredLanguage() : stored;
+};
+
+export const chatLanguageDiffersFromUi = () => resolveChatLanguage() !== getStoredLanguage();
+
 export const isRtlLanguage = (code) => RTL_LANGUAGES.has(code);
 
 // Appended to every AI system prompt (see callAI) so replies arrive in the
 // player's language natively instead of being machine-translated after.
-export const languageDirective = (code = getStoredLanguage()) => {
-  if (code === DEFAULT_LANGUAGE) {
+export const languageDirective = (code = getStoredLanguage(), { force = false } = {}) => {
+  if (code === DEFAULT_LANGUAGE && !force) {
     return "";
   }
 
   const name = languageDisplayName(code);
   return (
-    `LANGUAGE: The player's interface language is ${name} (${code}). ` +
+    `LANGUAGE: The player reads ${name} (${code}). ` +
     `Write ALL natural-language text in ${name} — prose replies, titles, descriptions, summaries, and suggestions. ` +
     `If the response must be JSON, keep the JSON structure, keys, ISO codes, and date formats exactly as specified, ` +
     `but write every human-readable string value in ${name}.`
   );
+};
+
+// force: English is the authored language, so it goes unstated by default —
+// but a chat deliberately held in it against a non-English interface must say
+// so, and must override the language of earlier replies.
+export const chatLanguageDirective = () => {
+  const code = resolveChatLanguage();
+  const directive = languageDirective(code, { force: chatLanguageDiffersFromUi() });
+  if (!directive) {
+    return "";
+  }
+
+  return `${directive} Reply in ${languageDisplayName(code)} regardless of the language of earlier messages.`;
 };

--- a/src/runtime/i18n.js
+++ b/src/runtime/i18n.js
@@ -134,8 +134,7 @@ export const isRtlLanguage = (code) => RTL_LANGUAGES.has(code);
 
 // Appended to every AI system prompt (see callAI) so replies arrive in the
 // player's language natively instead of being machine-translated after.
-export const languageDirective = () => {
-  const code = getStoredLanguage();
+export const languageDirective = (code = getStoredLanguage()) => {
   if (code === DEFAULT_LANGUAGE) {
     return "";
   }

--- a/src/runtime/translator.js
+++ b/src/runtime/translator.js
@@ -320,7 +320,7 @@ const translateBatch = async (strings) => {
 
   const raw = await callAI(systemPrompt, [
     { role: "user", parts: [{ text: JSON.stringify(strings) }] },
-  ]);
+  ], { languageMode: "none" });
   const translations = extractJsonArray(raw);
 
   if (!translations) {


### PR DESCRIPTION
Mirrors #439 by @dagahan onto this channel (their PR targets main only). Same three commits, cherry-picked unchanged, authorship preserved.

## Summary
A device-local **AI chat language** setting, independent of the server-synced UI language, used only to steer advisor/diplomatic chat replies. Defaults to "auto" (follows the UI language — unchanged behavior when left unset).

- `callAI` takes a `languageMode` (`ui` / `chat` / `none`) so the right directive is picked per call site, and the DOM translator uses `"none"` so it doesn't corrupt its own translation prompt.
- Advisor/diplomatic replies are marked `data-no-translate` (and RTL-flagged) when the chat language differs from the UI language, so the translator doesn't re-render a reply that already arrived in the right language.
- Settings gains an "AI chat language" picker with a "Same as interface" option.

## Reviewed (see #439)
- All i18n exports present; `helperStyle` is defined (no undefined-identifier / black-screen risk).
- Directive logic unit-tested across every UI×chat combination, including explicit-English-chat-against-non-English-UI (the `force` path) — 18/18 assertions pass.
- Full `vite build` passes in isolation.
- Note (non-blocking): gameplay AI (events/jumps/GM) and the Stats-tab intelligence briefing stay on the UI language by design, matching the PR's "advisor/diplomatic chat only" scope.
