### PR TITLE
feat(i18n): label the interface setting "UI language"

### DIFF
--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -172,7 +172,7 @@ const LanguageSelector = () => {
     };
 
     return (
-        <LanguagePicker label="Language" current={current} onSelect={applyLanguage} saving={saving} />
+        <LanguagePicker label="UI language" current={current} onSelect={applyLanguage} saving={saving} />
     );
 };
 


### PR DESCRIPTION
Now that "AI chat language" sits right below it, plain "Language" is ambiguous. Names what it controls.