### PR TITLE
Web sync: stop re-uploading records for a play-stat tick; quiet the idle Syncing flash (beta)

### DIFF
--- a/src/runtime/web/account.js
+++ b/src/runtime/web/account.js
@@ -131,9 +131,27 @@ const decodeRecord = (str) => JSON.parse(str, (_key, value) => {
   return value;
 });
 
-// Stable content hash of a record (over the same encoding encryptRecord signs),
-// so the sync engine can cheaply tell whether a record changed since last push.
-export const recordFingerprint = (obj) => sha256Hex(encodeRecord(obj));
+// Play-tracking stats live inside the game/scenario records for the main menu's
+// "Last Played"/"Most Played" rows, but they must NOT drive sync: merely OPENING
+// a game bumps lastPlayedAt + playCount (on the game AND its scenario), and since
+// the fingerprint is over the whole record, that would re-upload both blobs —
+// including a scenario's heavy map assets — for a stat tick nobody edited. Hash a
+// view WITHOUT these fields so only real content edits change the fingerprint.
+// The ciphertext below still encodes the FULL record, so the stats round-trip and
+// ride along on the next genuine edit.
+const VOLATILE_META_FIELDS = ["lastPlayedAt", "playCount"];
+const syncHashView = (obj) => {
+  if (!obj || typeof obj !== "object" || !obj.meta || typeof obj.meta !== "object") return obj;
+  if (!VOLATILE_META_FIELDS.some((field) => field in obj.meta)) return obj;
+  const meta = { ...obj.meta };
+  for (const field of VOLATILE_META_FIELDS) delete meta[field];
+  return { ...obj, meta };
+};
+
+// Stable content hash of a record, so the sync engine can cheaply tell whether a
+// record's SYNCABLE content changed since last push. Computed over syncHashView
+// (play-stats excluded) — encryptRecord's sha256 must use the same view.
+export const recordFingerprint = (obj) => sha256Hex(encodeRecord(syncHashView(obj)));
 
 // --- AES-256-GCM: encrypt a record to base64(iv||ciphertext); decrypt back. ---
 const aesKey = async () => {
@@ -147,7 +165,9 @@ export const encryptRecord = async (obj) => {
   const ct = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-GCM", iv }, await aesKey(), plaintext));
   const out = new Uint8Array(iv.length + ct.length);
   out.set(iv); out.set(ct, iv.length);
-  return { ciphertext: bytesToBase64(out), sha256: await sha256Hex(encodeRecord(obj)) };
+  // sha256 (change-detection metadata) is over the play-stat-free view so it
+  // agrees with recordFingerprint; the ciphertext above is the FULL record.
+  return { ciphertext: bytesToBase64(out), sha256: await sha256Hex(encodeRecord(syncHashView(obj))) };
 };
 export const decryptRecord = async (ciphertextB64) => {
   const all = base64ToBytes(ciphertextB64);

--- a/src/runtime/web/sync.js
+++ b/src/runtime/web/sync.js
@@ -62,7 +62,7 @@ const deleteLocal = async (blobId) => {
 };
 
 // Pull server changes newer than what we last synced.
-const pull = async (versions) => {
+const pull = async (versions, onWork) => {
   // syncManifest() is intentionally outside the try — an auth/network failure
   // there is a real, whole-sync error. A single BAD BLOB (e.g. one that won't
   // decrypt) is caught per-item so it can't red-line the whole sync.
@@ -70,6 +70,8 @@ const pull = async (versions) => {
     try {
       const known = versions[s.blob_id];
       if (known && s.version <= known.version) continue;
+      // A newer server version to apply — real work, so the widget may show it.
+      onWork?.();
       if (s.deleted) {
         await deleteLocal(s.blob_id);
         versions[s.blob_id] = { version: s.version, deleted: true };
@@ -84,7 +86,7 @@ const pull = async (versions) => {
 };
 
 // Push local changes; last-writer-wins on conflict (take the server copy).
-const push = async (versions) => {
+const push = async (versions, onWork) => {
   const local = await collectLocal();
   // upserts (new or locally-changed records) — each isolated so one bad record
   // (unserializable, too large, a decrypt conflict) can't fail the whole sync.
@@ -92,6 +94,8 @@ const push = async (versions) => {
     try {
       const known = versions[blobId];
       if (known && !known.deleted && known.sha === sha) continue;
+      // This record's syncable content actually changed — a real upload.
+      onWork?.();
       const { ciphertext, sha256 } = await encryptRecord(rec);
       const res = await syncPutBlob(blobId, ciphertext, sha256, known?.version || 0);
       if (res.status === 200) versions[blobId] = { version: res.version, sha: sha256 };
@@ -109,6 +113,7 @@ const push = async (versions) => {
   for (const [blobId, known] of Object.entries(versions)) {
     if (known.deleted || local.has(blobId) || blobId.startsWith("kv:")) continue;
     try {
+      onWork?.();
       const res = await syncDeleteBlob(blobId, known.version);
       if (res.status === 200) versions[blobId] = { version: res.version, deleted: true };
       else if (res.status === 409 && res.current) {
@@ -123,11 +128,20 @@ let running = false;
 export const syncNow = async () => {
   if (running || !accountConfigured() || !(await isSignedIn()) || !(await getDek())) return;
   running = true;
-  window.dispatchEvent(new CustomEvent("oh:sync", { detail: { state: "syncing" } }));
+  // Show "Syncing…" only once a real transfer starts. The engine polls every 20s
+  // (and on tab hide) to reconcile — an empty pass with nothing to move must not
+  // flash the widget as if it were uploading, which reads as "why is it syncing
+  // when I did nothing".
+  let announcedWork = false;
+  const onWork = () => {
+    if (announcedWork) return;
+    announcedWork = true;
+    window.dispatchEvent(new CustomEvent("oh:sync", { detail: { state: "syncing" } }));
+  };
   try {
     const versions = await kvGet(VERSIONS_KEY, {});
-    await pull(versions);
-    await push(versions);
+    await pull(versions, onWork);
+    await push(versions, onWork);
     await kvPut(VERSIONS_KEY, versions);
     window.dispatchEvent(new CustomEvent("oh:sync", { detail: { state: "ok", at: Date.now() } }));
   } catch (error) {


### PR DESCRIPTION
Two fixes to the website account sync (web build only), answering "why does it sync when I didn't do anything?"

## 1. It was actually uploading — opening a game re-uploaded whole records for a stat tick
`setActiveGame` stamps `lastPlayedAt` + `playCount` on the **game** and increments `playCount` on its **scenario** (feeding the main menu's Last/Most Played rows). The sync change-detector fingerprints the **entire record**, so a stat tick changed the hash and re-uploaded *both* blobs — and in the web build a scenario record carries the heavy map assets (pmtiles/geojson/cover). So just **opening a game to look at it re-uploaded a multi-MB scenario** for a counter increment.

Fix: the change-detection hash (`recordFingerprint` and `encryptRecord`'s `sha256`) now runs over a view **without** `lastPlayedAt`/`playCount`, so a play-stat tick no longer counts as a content change. The **ciphertext still encodes the full record**, so the stats round-trip and ride along on the next genuine edit. Real edits (rename, a jump that wrote events) still change the fingerprint and still sync.

## 2. The "Syncing…" indicator flashed on every idle poll
`syncNow` set the widget to "syncing" at the **start** of every 20-second reconciliation pass, before checking whether anything actually changed — so it looked like it was uploading when it was only polling. It now surfaces "syncing" only once a real blob is actually pulled, pushed, or deleted; an empty pass stays "Synced". (This also makes the indicator a real diagnostic: if it still flips to "Syncing…" while idle, something genuinely changed.)

## Verified
Unit test over the exact encode/hash logic: a record differing **only** in `lastPlayedAt`/`playCount` produces an **identical fingerprint** (no upload), while the ciphertext keeps the new stats (no data loss); real edits and manifest changes still differ; a scenario's `playCount` bump is **not** seen as a change (the heavy blob isn't re-uploaded). Web build (`--mode web`) compiles.

**Honest limitation:** I can't fully boot the web sync here (it needs the live registry Worker + a signed-in account + the DEK), so the sync engine itself wasn't exercised end-to-end — the logic is proven by the unit test and a static trace of the indicator path, not a live round-trip.

**Deploy note:** the first sync after this lands re-uploads each record once (the hash basis changed), then settles.
