### PR TITLE
i18n: label the interface setting 'UI language' (apply #442 to beta)

### DIFF
--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -172,7 +172,7 @@ const LanguageSelector = () => {
     };
 
     return (
-        <LanguagePicker label="Language" current={current} onSelect={applyLanguage} saving={saving} />
+        <LanguagePicker label="UI language" current={current} onSelect={applyLanguage} saving={saving} />
     );
 };
 


### PR DESCRIPTION
Applies #442 to the other two channels. #442 relabeled the interface-language picker `Language` -> `UI language` on main (to disambiguate it from the AI-chat-language picker added by #439), but that follow-up only landed on main. alpha/beta still show the old `Language`. This brings them in line so all three channels match. Byte-identical to #442's diff. Label-only; no behavior change.