### PR TITLE
AI diplomacy: never open an empty 'mystery' chat (no title / no first message) (alpha)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -766,7 +766,7 @@ export const buildGeneratedChat = async (chatLike, linkEventId, world, { fallbac
     ?? countries.find((country) => !matchesPlayer(country))
     ?? countries[0];
 
-  return normalizeChatEntry({
+  const entry = normalizeChatEntry({
     countries,
     id: chatLike?.id,
     linkedEventId: linkEventId,
@@ -790,6 +790,15 @@ export const buildGeneratedChat = async (chatLike, linkEventId, world, { fallbac
     // event's title, else at least the participants.
     title: chatLike?.title || fallbackTitle || `Chat with ${countries.map((country) => country.name).join(", ")}`,
   });
+  // The initiating polity always speaks first. If no first message survives
+  // normalization (the model gave no openingMessage, or only blank text), this
+  // would be a titled-but-empty "mystery chat" the player can't make sense of
+  // ("no clue why talks started"). Drop it instead of opening an empty thread —
+  // such chats otherwise slipped through on the salvage/final AI attempt (where
+  // validateChatOpener is no longer enforced) and as opener-less idle-diplomacy
+  // notes. Every caller already treats a null return as "no chat".
+  if (!entry || entry.messages.length === 0) return null;
+  return entry;
 };
 
 // Region ownership is keyed by the map's own region id (GID_1, e.g. "DEU.2_1"),
@@ -2088,12 +2097,17 @@ export const maybeSendIdleDiplomacy = async ({ chance = IDLE_DIPLOMACY_CHANCE } 
       timeoutMs: 60000,
       userMessage:
         "A quiet moment between rounds. Decide whether any single polity would send the player a short diplomatic note right now. Return JSON only.",
-      validatePayload: async (candidate) => {
+      validatePayload: async (candidate, { finalAttempt } = {}) => {
         if (candidate?.chat == null) return "";
         const countries = await resolveInvitees(candidate.chat.countries, bundle.world);
-        return countries.length > 0
-          ? ""
-          : "$.chat.countries must contain at least one known polity (or chat must be null).";
+        if (countries.length === 0) {
+          return "$.chat.countries must contain at least one known polity (or chat must be null).";
+        }
+        // Strict on attempt 1: make the model give the note a title AND a first
+        // line, so the player can see why the polity reached out. Salvage on the
+        // final attempt — buildGeneratedChat drops an opener-less note rather
+        // than posting an empty "mystery" thread.
+        return finalAttempt ? "" : validateChatOpener(candidate.chat, "$.chat");
       },
       variables,
     });


### PR DESCRIPTION
Fixes a Discord-reported bug: **some AI chats open with no title and no starting message**, so the player has no idea why talks began — while others come through fine.

## Cause
Every AI-initiated chat is built by `buildGeneratedChat`, which returned a chat with an **empty `messages` array** (title-only) when the model gave no opening line. `normalizeChatEntry` only requires ≥1 country — not a title or messages — so `{ countries, title:"", messages:[] }` persisted and rendered as a blank thread. Two ways an opener-less chat reached it:

1. **Timeline jumps:** `validateChatOpener` (which requires a title + a first message) is enforced **only on the strict first attempt**. On the salvage/final attempt, an opener-less `createdChat` / `diplomaticOutreach` passed straight through.
2. **Idle diplomacy:** `maybeSendIdleDiplomacy`'s validator only checked that a country existed — never the note text — and the "new chat" branch added it with no message check.

That's the "some do, others don't": whether the model happened to include an opener on its first attempt.

## Fix
- **`buildGeneratedChat` now returns `null` when no first message survives normalization** (no `openingMessage`, or only blank/whitespace text). The initiating polity always speaks first, so a message-less chat is a broken "mystery" thread — drop it rather than show it. The check runs *after* normalization, so a whitespace-only opener (which `normalizeChatMessage` strips) is caught too. All three callers already treat `null` as "no chat".
- **`maybeSendIdleDiplomacy`** now validates strict-on-attempt-1 (require a title **and** a first line, so the model retries with a real note) / salvage-on-final (dropped by `buildGeneratedChat` if still empty), matching the `createdChats`/`outreach` discipline.

Kept chats are unaffected: any chat with a real first message still shows, and its title falls back to the model's title → the causing event's title → `Chat with <participants>` (never empty).

## Verified
Unit test over the **real** `normalizeChatEntry`/`normalizeChatMessage` pipeline + the `buildGeneratedChat` tail: opener-less, whitespace-opener, and title-and-opener-less chats all drop; real-opener, `messages[]`-only, empty-title, and event-fallback-title chats all survive with their first message intact (10/10). `esbuild` bundle clean.

Single file: `src/Game/AI/gameplay.js`.
