### PR TITLE
Flags: a landless (stateless) player no longer borrows a country's flag

### DIFF
--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -3,6 +3,7 @@ import { JSON_URLS, getNationTags, loadRegionCatalog, readJson } from "../../run
 import { resolveAllCountryTags, resolveCountryTags } from "../../runtime/countryTags.js";
 import {
   buildActionDisplayText,
+  isPolityLandless,
   normalizeActionEntry,
   normalizeActions,
   normalizeChats,
@@ -298,12 +299,11 @@ export const buildPlayerPolityRegionsText = async (bundle, regionCatalog = null)
   // Zero regions AND the polity exists = deliberately landless. Distinguish that
   // from a scenario that simply ships no override list (a stock modern map, where
   // the player owns their country through the base tiles, not an override).
+  // isPolityLandless is the shared source of truth for that line (see gameState).
   if (!owns) {
-    const isKnownPolity = Boolean(normalizeWorldState(bundle.world).polityOverrides?.[playerCode]);
-    if (entries.length === 0 && !isKnownPolity) {
-      return "No explicit player region override list is currently recorded.";
-    }
-    return LANDLESS_PLAYER_TEXT;
+    return isPolityLandless(world, playerCode)
+      ? LANDLESS_PLAYER_TEXT
+      : "No explicit player region override list is currently recorded.";
   }
   const regions = regionCatalog ?? await loadRegions();
   const lookup = new Map(regions.map((region) => [region.id, region]));

--- a/src/Game/GameUI/other.jsx
+++ b/src/Game/GameUI/other.jsx
@@ -1,6 +1,7 @@
 /*! Open Historia — portions (mobile country/date row) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { memo, useEffect, useState } from "react";
 import { JSON_URLS, readJson } from "../../runtime/assets.js";
+import { isPolityLandless, readWorldState } from "../../runtime/gameState.js";
 import { useIsMobile } from "../../runtime/useIsMobile.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagEmojiFromGid, flagImageUrlFromGid } from "../../runtime/countryFlags.js";
@@ -46,15 +47,36 @@ const FallbackBadge = ({ label }) => (
 
 const Other = memo(function Other({ rightShift = "0.5rem" }) {
     const [country, setCountry] = useState(null);
+    // A LANDLESS player is a stateless actor (a person, a movement, a
+    // government-in-exile) whose game.country may still resolve to a real ISO
+    // code — but they are NOT that country, so the badge must not borrow its
+    // flag. Neutral placeholder instead. Refreshed on the same 5s cadence as the
+    // stats pane so gaining/losing all territory flips the badge within a poll.
+    const [landless, setLandless] = useState(false);
     const [imageFailed, setImageFailed] = useState(false);
     const isMobile = useIsMobile();
     // The player sees the FULL country name in the tooltip, never the code.
     const displayName = useCountryDisplayName(country);
 
     useEffect(() => {
-        readJson(JSON_URLS.game, { defaultValue: {} })
-        .then((data) => setCountry(data.country))
-        .catch((err) => console.error("Failed to load game.json:", err));
+        let cancelled = false;
+        const refresh = async () => {
+            try {
+                const data = await readJson(JSON_URLS.game, { defaultValue: {} });
+                if (cancelled) return;
+                const code = data.country;
+                setCountry(code);
+                // force:false rides the memoized world read (cheap; a real jump
+                // invalidates the cache, so this still sees territory changes).
+                const world = await readWorldState({ force: false });
+                if (!cancelled) setLandless(isPolityLandless(world, code));
+            } catch (err) {
+                if (!cancelled) console.error("Failed to load game.json:", err);
+            }
+        };
+        refresh();
+        const intervalId = window.setInterval(refresh, 5000);
+        return () => { cancelled = true; window.clearInterval(intervalId); };
     }, []);
 
     useEffect(() => {
@@ -65,8 +87,10 @@ const Other = memo(function Other({ rightShift = "0.5rem" }) {
     // badge and the date widget would overlap on a portrait screen.
     if (isMobile || !country) return null;
 
-    const flagUrl = flagImageUrlFromGid(country);
-    const flagEmoji = flagEmojiFromGid(country);
+    // Landless → never borrow the code-derived country flag; fall through to the
+    // neutral FallbackBadge (both null makes the render pick it).
+    const flagUrl = landless ? null : flagImageUrlFromGid(country);
+    const flagEmoji = landless ? null : flagEmojiFromGid(country);
 
     return (
         <div

--- a/src/Game/GameUI/stats.jsx
+++ b/src/Game/GameUI/stats.jsx
@@ -1,7 +1,7 @@
 /*! Open Historia — national stats pane © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { JSON_URLS, getNationFlags } from "../../runtime/assets.js";
-import { readGameData, readWorldState } from "../../runtime/gameState.js";
+import { isPolityLandless, readGameData, readWorldState } from "../../runtime/gameState.js";
 import { useLibraryState } from "../../runtime/library.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagImageUrlFromGid } from "../../runtime/countryFlags.js";
@@ -110,6 +110,10 @@ const StatsPane = ({ active }) => {
     const [polity, setPolity] = useState(null); // world.polityOverrides[target]
     const [state, setState] = useState({ status: "idle", sheet: null, error: "" });
     const [flagFailed, setFlagFailed] = useState(false);
+    // Is the PLAYER stateless (holds no territory)? A landless player's code may
+    // still resolve to a real country, but they are not it — so their own row
+    // must show the neutral initials, never that country's flag.
+    const [playerLandless, setPlayerLandless] = useState(false);
     // Author-set flags from the scenario (flags.json). Memoized in assets.js, so
     // this is one fetch per scenario; {} for every scenario that sets none.
     const [customFlags, setCustomFlags] = useState({});
@@ -212,8 +216,11 @@ const StatsPane = ({ active }) => {
         setFlagFailed(false);
         loadSheet();
         readWorldState({ force: false })
-            .then((world) => setPolity(world?.polityOverrides?.[targetCountry] ?? null))
-            .catch(() => setPolity(null));
+            .then((world) => {
+                setPolity(world?.polityOverrides?.[targetCountry] ?? null);
+                setPlayerLandless(isPolityLandless(world, player.code));
+            })
+            .catch(() => { setPolity(null); setPlayerLandless(false); });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [active, targetCountry, player.date]);
 
@@ -221,7 +228,11 @@ const StatsPane = ({ active }) => {
     const isPlayer = targetCountry && targetCountry.toUpperCase() === String(player.code).toUpperCase();
     // An author-set flag (scenario flags.json) wins over the code-derived one, so a
     // custom era polity shows the flag its map-maker drew instead of initials.
-    const flagUrl = customFlags[targetCountry] || polity?.flag || flagImageUrlFromGid(targetCountry);
+    // But a landless PLAYER never borrows the code-derived country flag (a
+    // stateless actor is not the country its code resolves to) — their own row
+    // falls through to the neutral initials unless they set a flag of their own.
+    const suppressDerivedFlag = isPlayer && playerLandless;
+    const flagUrl = customFlags[targetCountry] || polity?.flag || (suppressDerivedFlag ? "" : flagImageUrlFromGid(targetCountry));
     const initials = String(targetCountry).replace(/[^A-Za-z]/g, "").slice(0, 2).toUpperCase() || "??";
 
     const breakdown = useMemo(() => {

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -904,6 +904,31 @@ export const normalizeWorldState = (world) => {
   };
 };
 
+// Does a polity currently hold no territory? A stateless actor — a
+// government-in-exile, a movement, or a person with no country of their own.
+// Single source of truth for "landless", used by both the AI prompt
+// (buildPlayerPolityRegionsText) and the UI flag resolvers: a landless polity
+// with no flag of its own must NOT borrow the code-derived country flag (a
+// "stateless person in Japan" is not Japan), so the flag shows neutral instead.
+//
+// The distinction that matters: owning a region via an override = has land; but
+// a scenario that ships NO override list at all means the polity owns its country
+// through the base map tiles (a stock modern map), which is NOT landless.
+export const isPolityLandless = (world, code) => {
+  const polityCode = normalizeString(code);
+  if (!polityCode) return false;
+  const normalized = normalizeWorldState(world);
+  const entries = Object.entries(normalized.regionOwnershipOverrides);
+  const owns = entries.some(
+    ([, ownerCode]) => normalizeString(ownerCode).toLowerCase() === polityCode.toLowerCase(),
+  );
+  if (owns) return false;
+  const isKnownPolity = Boolean(normalized.polityOverrides?.[polityCode]);
+  // No override list AND not a declared polity = stock map, owns via base tiles.
+  if (entries.length === 0 && !isKnownPolity) return false;
+  return true;
+};
+
 // Recover a Gregorian date stored in a loose format back to strict YYYY-MM-DD.
 // Older builds wrote the model's stopDate verbatim, so real saves hold values
 // like "2016-12-31T00:00:00.000Z" or "December 31, 2016" — the header displays


### PR DESCRIPTION
Fixes a Discord report: **a stateless faction with no flag of its own shows a country's flag** ("defaults to scenario default") on the player's own flag badge.

## Cause
Confirmed surface: the player's persistent flag badge (bottom-right) and the stats-pane header. When the player's `game.country` resolves to a real ISO code but the player owns **no territory** — e.g. a "stateless person in Japan" scenario — the badge derives *that country's* flag from the code, even though the player isn't that country. A made-up faction name already resolves to neutral (its name isn't an ISO code), so this only bites when the code is a real country.

## Fix
When the **player is landless** (holds no territory) and has no flag of their own, show the neutral placeholder instead of the code-derived country flag.

- **`gameState.js`** — new `isPolityLandless(world, code)`, the single source of truth for "holds no territory". Owning a region via an override = has land; a scenario that ships **no** override list at all is a stock map where the player owns their country through base tiles (**not** landless) — the exact line the AI already drew.
- **`promptContext.js`** — `buildPlayerPolityRegionsText` now uses `isPolityLandless`, so the UI and the AI prompt can't drift (same three outcomes: owns / landless / stock map).
- **`other.jsx`** (persistent badge) and **`stats.jsx`** (pane header, **player-scoped** — inspecting other/conquered countries is untouched): suppress the code-derived flag when the player is landless → falls through to the existing neutral badge / initials. A flag the player **did** set (`flags.json` / `polity.flag`) still wins; only the borrowed code-derived flag is dropped.

## Verified
- `isPolityLandless` unit-tested (8/8): owns land, declared-but-landless, override-list-but-owns-none, stock-map-not-landless, case-insensitive owner match, empty code, null world.
- **End-to-end in a built app**: a landed player "Japan" showed `flagcdn.com/jp.svg`; after stripping its territory to zero regions (nothing else changed), the badge dropped the `<img>` and rendered the neutral **"J"** placeholder — the landless gate is the only variable.
- All four files bundle clean.

Note on the edge case: a real country the player is leading that gets conquered to zero regions would also read as landless and go neutral — consistent with "a stateless actor shows a neutral flag." Player-scoped, so it never affects inspecting AI countries.
