### PR TITLE
Three fixes: web-sync over-upload, empty AI chats, landless-player flag

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -766,7 +766,7 @@ export const buildGeneratedChat = async (chatLike, linkEventId, world, { fallbac
     ?? countries.find((country) => !matchesPlayer(country))
     ?? countries[0];
 
-  return normalizeChatEntry({
+  const entry = normalizeChatEntry({
     countries,
     id: chatLike?.id,
     linkedEventId: linkEventId,
@@ -790,6 +790,15 @@ export const buildGeneratedChat = async (chatLike, linkEventId, world, { fallbac
     // event's title, else at least the participants.
     title: chatLike?.title || fallbackTitle || `Chat with ${countries.map((country) => country.name).join(", ")}`,
   });
+  // The initiating polity always speaks first. If no first message survives
+  // normalization (the model gave no openingMessage, or only blank text), this
+  // would be a titled-but-empty "mystery chat" the player can't make sense of
+  // ("no clue why talks started"). Drop it instead of opening an empty thread —
+  // such chats otherwise slipped through on the salvage/final AI attempt (where
+  // validateChatOpener is no longer enforced) and as opener-less idle-diplomacy
+  // notes. Every caller already treats a null return as "no chat".
+  if (!entry || entry.messages.length === 0) return null;
+  return entry;
 };
 
 // Region ownership is keyed by the map's own region id (GID_1, e.g. "DEU.2_1"),
@@ -2088,12 +2097,17 @@ export const maybeSendIdleDiplomacy = async ({ chance = IDLE_DIPLOMACY_CHANCE } 
       timeoutMs: 60000,
       userMessage:
         "A quiet moment between rounds. Decide whether any single polity would send the player a short diplomatic note right now. Return JSON only.",
-      validatePayload: async (candidate) => {
+      validatePayload: async (candidate, { finalAttempt } = {}) => {
         if (candidate?.chat == null) return "";
         const countries = await resolveInvitees(candidate.chat.countries, bundle.world);
-        return countries.length > 0
-          ? ""
-          : "$.chat.countries must contain at least one known polity (or chat must be null).";
+        if (countries.length === 0) {
+          return "$.chat.countries must contain at least one known polity (or chat must be null).";
+        }
+        // Strict on attempt 1: make the model give the note a title AND a first
+        // line, so the player can see why the polity reached out. Salvage on the
+        // final attempt — buildGeneratedChat drops an opener-less note rather
+        // than posting an empty "mystery" thread.
+        return finalAttempt ? "" : validateChatOpener(candidate.chat, "$.chat");
       },
       variables,
     });

--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -3,6 +3,7 @@ import { JSON_URLS, getNationTags, loadRegionCatalog, readJson } from "../../run
 import { resolveAllCountryTags, resolveCountryTags } from "../../runtime/countryTags.js";
 import {
   buildActionDisplayText,
+  isPolityLandless,
   normalizeActionEntry,
   normalizeActions,
   normalizeChats,
@@ -298,12 +299,11 @@ export const buildPlayerPolityRegionsText = async (bundle, regionCatalog = null)
   // Zero regions AND the polity exists = deliberately landless. Distinguish that
   // from a scenario that simply ships no override list (a stock modern map, where
   // the player owns their country through the base tiles, not an override).
+  // isPolityLandless is the shared source of truth for that line (see gameState).
   if (!owns) {
-    const isKnownPolity = Boolean(normalizeWorldState(bundle.world).polityOverrides?.[playerCode]);
-    if (entries.length === 0 && !isKnownPolity) {
-      return "No explicit player region override list is currently recorded.";
-    }
-    return LANDLESS_PLAYER_TEXT;
+    return isPolityLandless(world, playerCode)
+      ? LANDLESS_PLAYER_TEXT
+      : "No explicit player region override list is currently recorded.";
   }
   const regions = regionCatalog ?? await loadRegions();
   const lookup = new Map(regions.map((region) => [region.id, region]));

--- a/src/Game/GameUI/other.jsx
+++ b/src/Game/GameUI/other.jsx
@@ -1,6 +1,7 @@
 /*! Open Historia — portions (mobile country/date row) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { memo, useEffect, useState } from "react";
 import { JSON_URLS, readJson } from "../../runtime/assets.js";
+import { isPolityLandless, readWorldState } from "../../runtime/gameState.js";
 import { useIsMobile } from "../../runtime/useIsMobile.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagEmojiFromGid, flagImageUrlFromGid } from "../../runtime/countryFlags.js";
@@ -46,15 +47,36 @@ const FallbackBadge = ({ label }) => (
 
 const Other = memo(function Other({ rightShift = "0.5rem" }) {
     const [country, setCountry] = useState(null);
+    // A LANDLESS player is a stateless actor (a person, a movement, a
+    // government-in-exile) whose game.country may still resolve to a real ISO
+    // code — but they are NOT that country, so the badge must not borrow its
+    // flag. Neutral placeholder instead. Refreshed on the same 5s cadence as the
+    // stats pane so gaining/losing all territory flips the badge within a poll.
+    const [landless, setLandless] = useState(false);
     const [imageFailed, setImageFailed] = useState(false);
     const isMobile = useIsMobile();
     // The player sees the FULL country name in the tooltip, never the code.
     const displayName = useCountryDisplayName(country);
 
     useEffect(() => {
-        readJson(JSON_URLS.game, { defaultValue: {} })
-        .then((data) => setCountry(data.country))
-        .catch((err) => console.error("Failed to load game.json:", err));
+        let cancelled = false;
+        const refresh = async () => {
+            try {
+                const data = await readJson(JSON_URLS.game, { defaultValue: {} });
+                if (cancelled) return;
+                const code = data.country;
+                setCountry(code);
+                // force:false rides the memoized world read (cheap; a real jump
+                // invalidates the cache, so this still sees territory changes).
+                const world = await readWorldState({ force: false });
+                if (!cancelled) setLandless(isPolityLandless(world, code));
+            } catch (err) {
+                if (!cancelled) console.error("Failed to load game.json:", err);
+            }
+        };
+        refresh();
+        const intervalId = window.setInterval(refresh, 5000);
+        return () => { cancelled = true; window.clearInterval(intervalId); };
     }, []);
 
     useEffect(() => {
@@ -65,8 +87,10 @@ const Other = memo(function Other({ rightShift = "0.5rem" }) {
     // badge and the date widget would overlap on a portrait screen.
     if (isMobile || !country) return null;
 
-    const flagUrl = flagImageUrlFromGid(country);
-    const flagEmoji = flagEmojiFromGid(country);
+    // Landless → never borrow the code-derived country flag; fall through to the
+    // neutral FallbackBadge (both null makes the render pick it).
+    const flagUrl = landless ? null : flagImageUrlFromGid(country);
+    const flagEmoji = landless ? null : flagEmojiFromGid(country);
 
     return (
         <div

--- a/src/Game/GameUI/stats.jsx
+++ b/src/Game/GameUI/stats.jsx
@@ -1,7 +1,7 @@
 /*! Open Historia — national stats pane © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { JSON_URLS, getNationFlags } from "../../runtime/assets.js";
-import { readGameData, readWorldState } from "../../runtime/gameState.js";
+import { isPolityLandless, readGameData, readWorldState } from "../../runtime/gameState.js";
 import { useLibraryState } from "../../runtime/library.js";
 import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagImageUrlFromGid } from "../../runtime/countryFlags.js";
@@ -110,6 +110,10 @@ const StatsPane = ({ active }) => {
     const [polity, setPolity] = useState(null); // world.polityOverrides[target]
     const [state, setState] = useState({ status: "idle", sheet: null, error: "" });
     const [flagFailed, setFlagFailed] = useState(false);
+    // Is the PLAYER stateless (holds no territory)? A landless player's code may
+    // still resolve to a real country, but they are not it — so their own row
+    // must show the neutral initials, never that country's flag.
+    const [playerLandless, setPlayerLandless] = useState(false);
     // Author-set flags from the scenario (flags.json). Memoized in assets.js, so
     // this is one fetch per scenario; {} for every scenario that sets none.
     const [customFlags, setCustomFlags] = useState({});
@@ -212,8 +216,11 @@ const StatsPane = ({ active }) => {
         setFlagFailed(false);
         loadSheet();
         readWorldState({ force: false })
-            .then((world) => setPolity(world?.polityOverrides?.[targetCountry] ?? null))
-            .catch(() => setPolity(null));
+            .then((world) => {
+                setPolity(world?.polityOverrides?.[targetCountry] ?? null);
+                setPlayerLandless(isPolityLandless(world, player.code));
+            })
+            .catch(() => { setPolity(null); setPlayerLandless(false); });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [active, targetCountry, player.date]);
 
@@ -221,7 +228,11 @@ const StatsPane = ({ active }) => {
     const isPlayer = targetCountry && targetCountry.toUpperCase() === String(player.code).toUpperCase();
     // An author-set flag (scenario flags.json) wins over the code-derived one, so a
     // custom era polity shows the flag its map-maker drew instead of initials.
-    const flagUrl = customFlags[targetCountry] || polity?.flag || flagImageUrlFromGid(targetCountry);
+    // But a landless PLAYER never borrows the code-derived country flag (a
+    // stateless actor is not the country its code resolves to) — their own row
+    // falls through to the neutral initials unless they set a flag of their own.
+    const suppressDerivedFlag = isPlayer && playerLandless;
+    const flagUrl = customFlags[targetCountry] || polity?.flag || (suppressDerivedFlag ? "" : flagImageUrlFromGid(targetCountry));
     const initials = String(targetCountry).replace(/[^A-Za-z]/g, "").slice(0, 2).toUpperCase() || "??";
 
     const breakdown = useMemo(() => {

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -904,6 +904,31 @@ export const normalizeWorldState = (world) => {
   };
 };
 
+// Does a polity currently hold no territory? A stateless actor — a
+// government-in-exile, a movement, or a person with no country of their own.
+// Single source of truth for "landless", used by both the AI prompt
+// (buildPlayerPolityRegionsText) and the UI flag resolvers: a landless polity
+// with no flag of its own must NOT borrow the code-derived country flag (a
+// "stateless person in Japan" is not Japan), so the flag shows neutral instead.
+//
+// The distinction that matters: owning a region via an override = has land; but
+// a scenario that ships NO override list at all means the polity owns its country
+// through the base map tiles (a stock modern map), which is NOT landless.
+export const isPolityLandless = (world, code) => {
+  const polityCode = normalizeString(code);
+  if (!polityCode) return false;
+  const normalized = normalizeWorldState(world);
+  const entries = Object.entries(normalized.regionOwnershipOverrides);
+  const owns = entries.some(
+    ([, ownerCode]) => normalizeString(ownerCode).toLowerCase() === polityCode.toLowerCase(),
+  );
+  if (owns) return false;
+  const isKnownPolity = Boolean(normalized.polityOverrides?.[polityCode]);
+  // No override list AND not a declared polity = stock map, owns via base tiles.
+  if (entries.length === 0 && !isKnownPolity) return false;
+  return true;
+};
+
 // Recover a Gregorian date stored in a loose format back to strict YYYY-MM-DD.
 // Older builds wrote the model's stopDate verbatim, so real saves hold values
 // like "2016-12-31T00:00:00.000Z" or "December 31, 2016" — the header displays

--- a/src/runtime/web/account.js
+++ b/src/runtime/web/account.js
@@ -131,9 +131,27 @@ const decodeRecord = (str) => JSON.parse(str, (_key, value) => {
   return value;
 });
 
-// Stable content hash of a record (over the same encoding encryptRecord signs),
-// so the sync engine can cheaply tell whether a record changed since last push.
-export const recordFingerprint = (obj) => sha256Hex(encodeRecord(obj));
+// Play-tracking stats live inside the game/scenario records for the main menu's
+// "Last Played"/"Most Played" rows, but they must NOT drive sync: merely OPENING
+// a game bumps lastPlayedAt + playCount (on the game AND its scenario), and since
+// the fingerprint is over the whole record, that would re-upload both blobs —
+// including a scenario's heavy map assets — for a stat tick nobody edited. Hash a
+// view WITHOUT these fields so only real content edits change the fingerprint.
+// The ciphertext below still encodes the FULL record, so the stats round-trip and
+// ride along on the next genuine edit.
+const VOLATILE_META_FIELDS = ["lastPlayedAt", "playCount"];
+const syncHashView = (obj) => {
+  if (!obj || typeof obj !== "object" || !obj.meta || typeof obj.meta !== "object") return obj;
+  if (!VOLATILE_META_FIELDS.some((field) => field in obj.meta)) return obj;
+  const meta = { ...obj.meta };
+  for (const field of VOLATILE_META_FIELDS) delete meta[field];
+  return { ...obj, meta };
+};
+
+// Stable content hash of a record, so the sync engine can cheaply tell whether a
+// record's SYNCABLE content changed since last push. Computed over syncHashView
+// (play-stats excluded) — encryptRecord's sha256 must use the same view.
+export const recordFingerprint = (obj) => sha256Hex(encodeRecord(syncHashView(obj)));
 
 // --- AES-256-GCM: encrypt a record to base64(iv||ciphertext); decrypt back. ---
 const aesKey = async () => {
@@ -147,7 +165,9 @@ export const encryptRecord = async (obj) => {
   const ct = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-GCM", iv }, await aesKey(), plaintext));
   const out = new Uint8Array(iv.length + ct.length);
   out.set(iv); out.set(ct, iv.length);
-  return { ciphertext: bytesToBase64(out), sha256: await sha256Hex(encodeRecord(obj)) };
+  // sha256 (change-detection metadata) is over the play-stat-free view so it
+  // agrees with recordFingerprint; the ciphertext above is the FULL record.
+  return { ciphertext: bytesToBase64(out), sha256: await sha256Hex(encodeRecord(syncHashView(obj))) };
 };
 export const decryptRecord = async (ciphertextB64) => {
   const all = base64ToBytes(ciphertextB64);

--- a/src/runtime/web/sync.js
+++ b/src/runtime/web/sync.js
@@ -62,7 +62,7 @@ const deleteLocal = async (blobId) => {
 };
 
 // Pull server changes newer than what we last synced.
-const pull = async (versions) => {
+const pull = async (versions, onWork) => {
   // syncManifest() is intentionally outside the try — an auth/network failure
   // there is a real, whole-sync error. A single BAD BLOB (e.g. one that won't
   // decrypt) is caught per-item so it can't red-line the whole sync.
@@ -70,6 +70,8 @@ const pull = async (versions) => {
     try {
       const known = versions[s.blob_id];
       if (known && s.version <= known.version) continue;
+      // A newer server version to apply — real work, so the widget may show it.
+      onWork?.();
       if (s.deleted) {
         await deleteLocal(s.blob_id);
         versions[s.blob_id] = { version: s.version, deleted: true };
@@ -84,7 +86,7 @@ const pull = async (versions) => {
 };
 
 // Push local changes; last-writer-wins on conflict (take the server copy).
-const push = async (versions) => {
+const push = async (versions, onWork) => {
   const local = await collectLocal();
   // upserts (new or locally-changed records) — each isolated so one bad record
   // (unserializable, too large, a decrypt conflict) can't fail the whole sync.
@@ -92,6 +94,8 @@ const push = async (versions) => {
     try {
       const known = versions[blobId];
       if (known && !known.deleted && known.sha === sha) continue;
+      // This record's syncable content actually changed — a real upload.
+      onWork?.();
       const { ciphertext, sha256 } = await encryptRecord(rec);
       const res = await syncPutBlob(blobId, ciphertext, sha256, known?.version || 0);
       if (res.status === 200) versions[blobId] = { version: res.version, sha: sha256 };
@@ -109,6 +113,7 @@ const push = async (versions) => {
   for (const [blobId, known] of Object.entries(versions)) {
     if (known.deleted || local.has(blobId) || blobId.startsWith("kv:")) continue;
     try {
+      onWork?.();
       const res = await syncDeleteBlob(blobId, known.version);
       if (res.status === 200) versions[blobId] = { version: res.version, deleted: true };
       else if (res.status === 409 && res.current) {
@@ -123,11 +128,20 @@ let running = false;
 export const syncNow = async () => {
   if (running || !accountConfigured() || !(await isSignedIn()) || !(await getDek())) return;
   running = true;
-  window.dispatchEvent(new CustomEvent("oh:sync", { detail: { state: "syncing" } }));
+  // Show "Syncing…" only once a real transfer starts. The engine polls every 20s
+  // (and on tab hide) to reconcile — an empty pass with nothing to move must not
+  // flash the widget as if it were uploading, which reads as "why is it syncing
+  // when I did nothing".
+  let announcedWork = false;
+  const onWork = () => {
+    if (announcedWork) return;
+    announcedWork = true;
+    window.dispatchEvent(new CustomEvent("oh:sync", { detail: { state: "syncing" } }));
+  };
   try {
     const versions = await kvGet(VERSIONS_KEY, {});
-    await pull(versions);
-    await push(versions);
+    await pull(versions, onWork);
+    await push(versions, onWork);
     await kvPut(VERSIONS_KEY, versions);
     window.dispatchEvent(new CustomEvent("oh:sync", { detail: { state: "ok", at: Date.now() } }));
   } catch (error) {


### PR DESCRIPTION
Three independent fixes, folded into one PR per channel (was #443/#444/#445, #448/#449/#450, #451/#452/#453). Non-overlapping files (7 total), one commit each.

---

## 1. Web sync: stop re-uploading records for a play-stat tick *(web build only)*
`src/runtime/web/account.js`, `src/runtime/web/sync.js`

Answers "why does it sync when I didn't do anything?"
- **It really was uploading.** Just *opening* a game stamps `lastPlayedAt`/`playCount` on the game **and** its scenario (the menu's Last/Most Played rows). The change-detector hashed the whole record, so that tick re-uploaded both blobs — including the scenario's heavy map assets. The change-detection hash now excludes those play-stat fields; the ciphertext still carries them, so they ride along on the next genuine edit.
- **The false "Syncing…" flash.** `syncNow` flipped the widget to "syncing" at the start of every 20s poll. It now announces "syncing" only once a real blob is actually pulled/pushed/deleted.

## 2. AI diplomacy: never open an empty "mystery" chat
`src/Game/AI/gameplay.js`

Answers "chats open with no title / no starting message." `buildGeneratedChat` could return a chat with an empty `messages` array (title-only) when the model gave no opening line — and `validateChatOpener` was enforced only on the strict first attempt, so opener-less chats slipped through on the salvage attempt and as idle-diplomacy notes. Now `buildGeneratedChat` drops any chat with no surviving first message (the initiating polity always speaks first), and idle diplomacy requires a titled first line on attempt 1.

## 3. Flags: a landless (stateless) player no longer borrows a country's flag
`src/runtime/gameState.js`, `src/Game/AI/promptContext.js`, `src/Game/GameUI/other.jsx`, `src/Game/GameUI/stats.jsx`

Answers "stateless faction without a flag defaults to the scenario default." When the player is **landless** (holds no territory) and has no flag of their own, the badge and stats header now show the neutral placeholder instead of the flag derived from a real ISO code their `game.country` resolves to. New shared `isPolityLandless` is the single source of truth (also used by the AI prompt, so the two can't drift); it treats a stock map — where you own your country via base tiles — as *not* landless, so a normal player's flag is untouched. Player-scoped, so inspecting other countries is unaffected.

---

### Verification
- **Sync:** unit test over the exact encode/hash logic (play-stat-only diff → identical fingerprint, ciphertext keeps the stats). Web build compiles. (Full engine can't be booted locally — needs the live Worker + a signed-in account.)
- **Empty chat:** unit test over the real chat-normalization pipeline (10/10 — opener-less/whitespace/title-less drop; real chats survive).
- **Landless flag:** unit test on `isPolityLandless` (8/8), plus end-to-end in a built app — a landed "Japan" showed `flagcdn/jp.svg`; stripping its territory to zero flipped the badge to the neutral "J" placeholder.
- All files bundle clean.
