### PR TITLE
i18n: AI chat replies in the chosen language + drop the "auto" option (alpha)

### DIFF
--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -9,7 +9,6 @@ import {
     setReasoningEnabled,
 } from "../AI/providerConfig.js";
 import {
-    AUTO_LANGUAGE,
     getLanguageOptions,
     getStoredChatLanguage,
     getStoredLanguage,
@@ -101,9 +100,7 @@ function groupProviders(options) {
     return groups;
 }
 
-// leadingOption is prepended and survives filtering, so the chat picker's
-// "Same as interface" can always be gone back to.
-const LanguagePicker = ({ label, current, onSelect, saving = false, helperText, leadingOption }) => {
+const LanguagePicker = ({ label, current, onSelect, saving = false, helperText }) => {
     const [query, setQuery] = useState("");
     const options = getLanguageOptions();
     const normalizedQuery = query.trim().toLowerCase();
@@ -111,7 +108,7 @@ const LanguagePicker = ({ label, current, onSelect, saving = false, helperText, 
         ? options.filter((option) =>
             `${option.name} ${option.native} ${option.code}`.toLowerCase().includes(normalizedQuery))
         : options;
-    const listed = filtered.some((option) => option.code === current) || leadingOption?.value === current;
+    const listed = filtered.some((option) => option.code === current);
 
     return (
         <div style={fieldGroupStyle}>
@@ -132,11 +129,6 @@ const LanguagePicker = ({ label, current, onSelect, saving = false, helperText, 
         {!listed && (
             <option value="" disabled>
             {filtered.length ? `${filtered.length} matches — pick one` : "No matching language"}
-            </option>
-        )}
-        {leadingOption && (
-            <option value={leadingOption.value} style={{ color: "black" }}>
-            {leadingOption.label}
             </option>
         )}
         {filtered.map((option) => (
@@ -194,8 +186,7 @@ const ChatLanguageSelector = () => {
         label="AI chat language"
         current={current}
         onSelect={applyLanguage}
-        helperText="What the advisor and diplomatic chats reply in."
-        leadingOption={{ value: AUTO_LANGUAGE, label: "Same as interface" }}
+        helperText="What the advisor and diplomatic chats reply in. Defaults to your interface language."
         />
     );
 };

--- a/src/runtime/i18n.js
+++ b/src/runtime/i18n.js
@@ -182,12 +182,17 @@ export const languageDirective = (code = getStoredLanguage(), { force = false } 
   );
 };
 
-// force: English is the authored language, so it goes unstated by default —
-// but a chat deliberately held in it against a non-English interface must say
-// so, and must override the language of earlier replies.
+// A chat ALWAYS pins its language — force: true, even for English. English is
+// unstated elsewhere (it is the authored default), but a chat is different: the
+// player is conversing with a specific counterpart, and when that counterpart is
+// e.g. China — or the scenario is thick with non-English context — the model
+// drifts into that language with nothing to pull it back, so an English player
+// gets Chinese replies. Forcing the directive (plus the "regardless of earlier
+// messages" clause, which also stops a conversation drifting once one reply
+// slips) makes the chat-language setting actually hold, English included.
 export const chatLanguageDirective = () => {
   const code = resolveChatLanguage();
-  const directive = languageDirective(code, { force: chatLanguageDiffersFromUi() });
+  const directive = languageDirective(code, { force: true });
   if (!directive) {
     return "";
   }

--- a/src/runtime/i18n.js
+++ b/src/runtime/i18n.js
@@ -8,10 +8,10 @@ const STORAGE_KEY = "ui_language";
 export const DEFAULT_LANGUAGE = "en";
 
 // What the advisor and diplomatic chats reply in, so the interface can be read
-// in one language and the chats held in another. "auto" follows the UI
-// language, as the game did before. Device-local: it only steers prompts.
+// in one language and the chats held in another. Defaults to the UI language —
+// an unset value follows it — and a player can pick a different chat language.
+// Device-local: it only steers prompts.
 const CHAT_STORAGE_KEY = "ai_chat_language";
-export const AUTO_LANGUAGE = "auto";
 
 // The 50 most spoken languages, hand-curated: recognizable English name
 // first, endonym after. A full ISO dump read like random letters here.
@@ -139,15 +139,16 @@ export const syncLanguageFromServer = async () => {
 export const getStoredChatLanguage = () => {
   try {
     const stored = localStorage.getItem(CHAT_STORAGE_KEY);
-    return stored && stored.trim() ? stored.trim() : AUTO_LANGUAGE;
+    // No explicit choice ⇒ follow the UI language.
+    return stored && stored.trim() ? stored.trim() : getStoredLanguage();
   } catch {
-    return AUTO_LANGUAGE;
+    return getStoredLanguage();
   }
 };
 
 export const setStoredChatLanguage = (code) => {
   try {
-    if (!code || code === AUTO_LANGUAGE) {
+    if (!code) {
       localStorage.removeItem(CHAT_STORAGE_KEY);
     } else {
       localStorage.setItem(CHAT_STORAGE_KEY, code);
@@ -157,10 +158,9 @@ export const setStoredChatLanguage = (code) => {
   }
 };
 
-export const resolveChatLanguage = () => {
-  const stored = getStoredChatLanguage();
-  return stored === AUTO_LANGUAGE ? getStoredLanguage() : stored;
-};
+// getStoredChatLanguage already falls back to the UI language when unset, so
+// this is just the stored (or inherited) code — no "auto" sentinel any more.
+export const resolveChatLanguage = () => getStoredChatLanguage();
 
 export const chatLanguageDiffersFromUi = () => resolveChatLanguage() !== getStoredLanguage();
 


### PR DESCRIPTION
Two related fixes to the AI chat language (one file of logic + the settings picker). Answers the Discord report that **the AI chat replies in Chinese even when it should be English**, and the follow-up ask to **drop the "auto" option**.

## 1. The chat always pins its language (fixes the Chinese drift)
The advisor and diplomatic chats (`callAI` `languageMode: "chat"`) get their instruction from `chatLanguageDirective()`, which for an **English** player returned an **empty string** — English is normally left unstated, and the force flag was off whenever the chat language equalled the UI language. With nothing pinning the reply language, messaging **China** (the model replies *as* that country's leader) drifted into Chinese. Now `chatLanguageDirective()` forces the directive unconditionally, so the resolved language is always pinned — English included — with the "reply in X regardless of earlier messages" anti-drift clause.

## 2. Removed the "auto / Same as interface" option
Per your call, the AI chat language now **defaults to the UI language** directly (an unset value follows it) instead of a separate `auto` sentinel:
- `getStoredChatLanguage()` falls back to the UI language; `resolveChatLanguage()` is just the stored/inherited code; `AUTO_LANGUAGE` is gone.
- The picker's "Same as interface" entry is removed (and with it the now-unused `leadingOption` support in `LanguagePicker` — the UI-language picker already renders without it).
- A non-English player's chats still default to their own language; picking a specific chat language pins it; clearing it follows the UI again.

## Verified
Unit test against the **real** module (15/15): unset chat follows the UI language (en/zh/fr); the English directive is now non-empty with the anti-drift clause; explicit choices pin + store; clearing follows the UI again; `AUTO_LANGUAGE` is gone. Both files bundle clean. The settings dropdown reuses the UI-language picker's existing (production-proven) no-`leadingOption` render path, so it can't break the render.

Files: `src/runtime/i18n.js`, `src/Game/GameUI/settings.jsx`.
