### PR TITLE
Embedded Android server: run the server in-process on the phone (foundation; native parts need on-device test)

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -30,11 +30,23 @@ jobs:
           java-version: "21"
 
       - name: Stamp the build number
-        # The connect screen compares this against "Build: N" in the release
-        # notes on every launch — that's the APK self-update check.
+        # The boot screen compares this against "Build: N" in the release notes
+        # on every launch — that's the APK self-update check.
         run: sed -i "s/__APP_BUILD__/${{ github.run_number }}/" mobile/www/index.html
 
+      - name: Build the game + assemble the embedded server
+        # The app now runs the real server in-process (nodejs-mobile), so the
+        # build needs the game bundle (dist) and the assembled Node project
+        # (mobile/nodejs-project) BEFORE cap sync copies it into the native app.
+        run: |
+          npm ci
+          npm run build
+          node scripts/build-mobile-server.mjs
+
       - name: Build the APK
+        # NOTE: this requires the nodejs-mobile-cordova plugin to be installed in
+        # mobile/ (npm i nodejs-mobile-cordova) and the android project regenerated.
+        # See mobile/README-embedded-server.md.
         run: |
           cd mobile
           npm ci
@@ -55,7 +67,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          NOTES="Thin Android client — connects to your Open Historia server (Termux on the same phone, or any host on your network). Download pax-historia.apk below and open it to install (allow installs from your browser when Android asks). On first launch it finds a Termux server on the same phone automatically, and the app updates itself when a newer build is published here.
+          NOTES="Open Historia for Android — runs its own server on the phone, no Termux or separate machine needed. Download pax-historia.apk below and open it to install (allow installs from your browser when Android asks). On first launch it starts the built-in server and downloads the world map (~200 MB); after that it's instant. You can still point it at a Termux/desktop/LAN server if you prefer. The app updates itself when a newer build is published here.
 
           Build: ${{ github.run_number }}"
           gh release create android --title "Android app" --notes "$NOTES" 2>/dev/null \

--- a/mobile/README-embedded-server.md
+++ b/mobile/README-embedded-server.md
@@ -1,0 +1,81 @@
+# Open Historia Android — embedded server
+
+The app used to be a thin WebView that connected to a server you had to run
+yourself (Termux, or a PC on your Wi‑Fi). It now **runs the real Open Historia
+server in-process on the phone** via [`nodejs-mobile`], so there's nothing to set
+up — launch it and play. You can still point it at a remote server if you want.
+
+## How it works
+
+```
+mobile/www/index.html      boot screen → starts the node server → connects to 127.0.0.1:3000
+mobile/nodejs-project/
+  main.js                  (committed) entry nodejs-mobile runs: picks a writable
+                           data dir, seeds defaults, starts server/server.js
+  fetchMapAssets.mjs       (committed) first-run download of the map binaries
+  server/ dist/ public/    (assembled) copied by scripts/build-mobile-server.mjs
+  seed/ node_modules/      (assembled) default scenarios + express
+  package.json map-assets.json (assembled)
+```
+
+- The server writes to a **writable** data dir (`OH_DATA_DIR`, resolved in
+  `server/dataDir.js`) because the bundled `server/data` is read-only inside the
+  APK. Default is a folder next to `main.js` (nodejs-mobile extracts the project
+  to a writable location).
+- **First run** seeds the default scenarios from `seed/` and downloads the
+  ~200 MB of map binaries (pmtiles/geojson) from the GitHub Release into
+  `OH_DATA_DIR/assets` and `OH_DATA_DIR/scenarios/…`. The server's pmtiles route
+  serves them from there (`resolveRuntimeBinaryAsset` prefers the fetched copy).
+- The server's only npm runtime dependency is **express**, so the bundled
+  `node_modules` is tiny (~3.4 MB); everything else is Node built-ins.
+
+## Status — what's verified vs. what still needs a device
+
+**Verified on desktop (Node):**
+- `server/dataDir.js` + all stores honour `OH_DATA_DIR`; desktop/Termux are
+  byte-identical when it's unset.
+- `main.js` seeds a fresh data dir and starts the real server (`/api/library` →
+  200, 7 default scenarios).
+- `scripts/build-mobile-server.mjs` assembles a lean project (dist 21 MB after
+  stripping tiles, node_modules 3.4 MB, seed has zero heavy files).
+- The pmtiles route serves the fetched file from `OH_DATA_DIR/assets` (desktop
+  still serves from the bundle).
+
+**NOT yet done / needs on-device work (I can't build or run an APK):**
+1. **Install the plugin and regenerate the native project** — the one manual step:
+   ```sh
+   cd mobile
+   npm i nodejs-mobile-cordova
+   npx cap sync android      # copies mobile/nodejs-project into the app + wires the plugin
+   ```
+   Confirm `window.nodejs` exists in the WebView and `nodejs.start("main.js", …)`
+   boots the server (the boot screen calls exactly this).
+2. **Verify the boot flow on a device** — cold start time, the 90 s server-wait
+   window in `index.html`, and the ~200 MB first-run map download UX.
+3. **APK size / ABIs** — nodejs-mobile adds a native libnode per ABI; check the
+   APK size and split per-ABI if needed.
+4. **CI** — `.github/workflows/android-apk.yml` now builds `dist` and assembles
+   the node project, but the APK step needs the plugin from step 1 committed to
+   `mobile/` for `cap sync` to bundle it.
+
+## Build & test locally
+
+```sh
+# from the repo root
+npm ci
+npm run build                 # produces dist/
+npm run build:mobile-server   # assembles mobile/nodejs-project/ (installs express)
+
+# exercise the embedded entry exactly as the phone will (desktop Node):
+OH_DATA_DIR=/tmp/oh PORT=3000 node mobile/nodejs-project/main.js
+#   → seeds /tmp/oh, downloads the map (~200 MB), serves http://127.0.0.1:3000
+
+# then the APK (after installing the plugin, step 1 above):
+cd mobile && npx cap sync android && cd android && ./gradlew assembleDebug
+```
+
+The assembled `mobile/nodejs-project/{server,dist,public,seed,node_modules,…}`
+is **build output** and is git-ignored; only `main.js`, `fetchMapAssets.mjs`, and
+`.gitignore` are committed.
+
+[`nodejs-mobile`]: https://github.com/nodejs-mobile/nodejs-mobile-cordova

--- a/mobile/nodejs-project/.gitignore
+++ b/mobile/nodejs-project/.gitignore
@@ -1,0 +1,13 @@
+# The Node project the Android app runs is ASSEMBLED by
+# scripts/build-mobile-server.mjs (server/, the built dist/, express, the seed
+# snapshot, the map manifest). That is build output, not source — never commit it.
+# Only main.js, fetchMapAssets.mjs, and this file are tracked.
+/server/
+/dist/
+/public/
+/seed/
+/node_modules/
+/runtime-data/
+/map-assets.json
+/package.json
+/package-lock.json

--- a/mobile/nodejs-project/fetchMapAssets.mjs
+++ b/mobile/nodejs-project/fetchMapAssets.mjs
@@ -1,0 +1,91 @@
+/*! Open Historia — embedded-server map-asset fetch © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// First-run download of the large map binaries for the EMBEDDED server. Same
+// release + checksums as the desktop scripts/fetch-map-assets.mjs, but every
+// asset is routed into the writable OH_DATA_DIR instead of the read-only bundle:
+//
+//   server/data/<x>   -> <DATA_DIR>/<x>        (scenario geojson, etc.)
+//   public/assets/<x> -> <DATA_DIR>/assets/<x> (regions/countries/cities pmtiles)
+//
+// See mobile/README-embedded-server.md § "Map data" — the server must serve
+// /assets/*.pmtiles from <DATA_DIR>/assets for the tiles to reach the WebView.
+// Best-effort and idempotent: skips a file that already matches (size, then
+// sha256), never throws in a way that stops the server.
+
+import { createHash } from "node:crypto";
+import { readFile, writeFile, stat, mkdir, rename, unlink } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
+
+// Map a manifest path (root-relative, from map-assets.json) to its embedded
+// location under the writable data dir.
+const targetFor = (dataDir, assetPath) => {
+  const normalized = assetPath.replace(/\\/g, "/");
+  if (normalized.startsWith("server/data/")) {
+    return path.join(dataDir, normalized.slice("server/data/".length));
+  }
+  if (normalized.startsWith("public/assets/")) {
+    return path.join(dataDir, "assets", normalized.slice("public/assets/".length));
+  }
+  // Anything else: mirror it verbatim under the data dir so it never lands in
+  // the read-only bundle.
+  return path.join(dataDir, normalized);
+};
+
+export const fetchMapAssets = async (dataDir) => {
+  if (typeof fetch !== "function") {
+    console.warn("[embedded] this Node is too old for fetch(); skipping map download");
+    return;
+  }
+  let manifest;
+  try {
+    // Bundled next to this file by the assembly script; falls back to the repo copy on desktop.
+    const candidates = [path.join(here, "map-assets.json"), path.join(here, "..", "..", "scripts", "map-assets.json")];
+    const found = await Promise.all(candidates.map((p) => readFile(p, "utf8").then((t) => ({ p, t }), () => null)));
+    const hit = found.find(Boolean);
+    if (!hit) throw new Error("map-assets.json not found");
+    manifest = JSON.parse(hit.t);
+  } catch (error) {
+    console.warn(`[embedded] cannot read map manifest (${error.message}); skipping map download`);
+    return;
+  }
+
+  const { owner, repo, release, assets = [] } = manifest;
+  if (!owner || !repo || !release || !assets.length) {
+    console.warn("[embedded] map manifest incomplete; skipping map download");
+    return;
+  }
+  const base = `https://github.com/${owner}/${repo}/releases/download/${encodeURIComponent(release)}`;
+
+  let downloaded = 0;
+  let present = 0;
+  let failed = 0;
+  for (const asset of assets) {
+    const dst = targetFor(dataDir, asset.path);
+    try {
+      const info = await stat(dst);
+      if (info.size === asset.bytes && sha256(await readFile(dst)) === asset.sha256) { present += 1; continue; }
+    } catch { /* missing — download */ }
+
+    const url = `${base}/${asset.asset}`;
+    const tmp = `${dst}.download`;
+    try {
+      const res = await fetch(url, { redirect: "follow" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (sha256(buf) !== asset.sha256) throw new Error("checksum mismatch");
+      await mkdir(path.dirname(dst), { recursive: true });
+      await writeFile(tmp, buf);
+      await rename(tmp, dst);
+      downloaded += 1;
+    } catch (error) {
+      console.warn(`[embedded] could not download ${asset.asset} (${error.message})`);
+      await unlink(tmp).catch(() => {});
+      failed += 1;
+    }
+  }
+  console.log(`[embedded] map assets: ${downloaded} downloaded, ${present} current, ${failed} failed`);
+};

--- a/mobile/nodejs-project/main.js
+++ b/mobile/nodejs-project/main.js
@@ -1,0 +1,68 @@
+/*! Open Historia — embedded server entry for the Android app © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// nodejs-mobile runs THIS file inside the app. It turns the phone into its own
+// Open Historia server so the app needs no Termux and no separate machine:
+//
+//   1. Pick a WRITABLE data dir. nodejs-mobile extracts this project to a
+//      writable location, so a folder next to this file is writable — the
+//      bundled server/data would be read-only. The native launcher may override
+//      it with OH_DATA_DIR (e.g. the app's Documents dir).
+//   2. First run: seed the writable dir from the bundled ./seed snapshot
+//      (default scenarios + manifests) so the library isn't empty.
+//   3. Best-effort: pull the large map binaries from the GitHub Release into the
+//      data dir (see fetchMapAssets) — never blocks the server from starting.
+//   4. Start the real server (server/server.js) bound to loopback. The WebView
+//      then loads http://127.0.0.1:<port> and the game runs same-origin.
+//
+// Everything here is plain Node + fs, so it runs identically on a desktop for
+// testing (`node mobile/nodejs-project/main.js`) and inside nodejs-mobile.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// 1. Writable data dir. server.js + every store read OH_DATA_DIR (see
+//    server/dataDir.js); set it before importing the server.
+const DATA_DIR = process.env.OH_DATA_DIR
+  ? path.resolve(process.env.OH_DATA_DIR)
+  : path.join(here, "runtime-data");
+process.env.OH_DATA_DIR = DATA_DIR;
+process.env.PORT = process.env.PORT || "3000";
+// The WebView loads http://127.0.0.1 same-origin, so cross-origin writes stay
+// off (the loopback bind + same-origin is the whole security model here).
+fs.mkdirSync(DATA_DIR, { recursive: true });
+
+// 2. First-run seed. "Empty" = no scenario manifest yet. Copy the bundled
+//    snapshot so the player has the default scenarios immediately. The heavy
+//    map binaries are NOT in the snapshot (they are fetched in step 3), so this
+//    stays small enough to ship inside the APK.
+const seedDir = path.join(here, "seed");
+const alreadySeeded = fs.existsSync(path.join(DATA_DIR, "scenario-manifest.json"));
+if (!alreadySeeded && fs.existsSync(seedDir)) {
+  try {
+    fs.cpSync(seedDir, DATA_DIR, { recursive: true });
+    console.log(`[embedded] seeded default data into ${DATA_DIR}`);
+  } catch (error) {
+    console.warn(`[embedded] seed failed (${error.message}); starting with an empty library`);
+  }
+}
+
+// 3. Map assets (best-effort, never fatal). The ~200 MB of pmtiles/geojson can't
+//    ship in the APK, so they download from the release on first run. Reused
+//    from scripts/fetch-map-assets.mjs; see ./fetchMapAssets.mjs for the
+//    OH_DATA_DIR-aware path mapping. Runs in the background — the server starts
+//    immediately and the map fills in as tiles arrive.
+try {
+  const { fetchMapAssets } = await import("./fetchMapAssets.mjs");
+  fetchMapAssets(DATA_DIR).catch((error) =>
+    console.warn(`[embedded] map-asset fetch failed (${error.message}); the map may be blank until retried`),
+  );
+} catch (error) {
+  console.warn(`[embedded] map-asset fetcher unavailable (${error.message})`);
+}
+
+// 4. Start the real server. It reads OH_DATA_DIR/PORT from the env set above.
+console.log(`[embedded] starting Open Historia server on 127.0.0.1:${process.env.PORT} (data: ${DATA_DIR})`);
+await import("./server/server.js");

--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -1,4 +1,4 @@
-<!-- Open Historia — Android app shell (connect screen + self-update) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). -->
+<!-- Open Historia — Android app shell (embedded server boot + self-update) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). -->
 <!doctype html>
 <html lang="en">
   <head>
@@ -62,26 +62,31 @@
         font-weight: 600;
       }
       .error { color: #f87171; font-size: 0.82rem; min-height: 1.1em; }
-      #connecting { display: none; }
+      .muted { color: rgba(255,255,255,0.4); font-size: 0.75rem; }
     </style>
   </head>
   <body>
-    <div class="card" id="setup">
+    <!-- Booting the on-device server (the default, zero-setup path). -->
+    <div class="card" id="booting">
+      <h1>Open Historia</h1>
+      <p id="bootStatus">Starting your server…</p>
+      <p class="muted" id="bootSub">First launch downloads the world map (~200&nbsp;MB); later launches are instant.</p>
+      <button class="ghost" id="useRemote" style="display:none">Connect to a different server instead</button>
+    </div>
+
+    <!-- Manual connect: fallback if the embedded server can't start, or to reach
+         a Termux / desktop / LAN server on purpose. -->
+    <div class="card" id="setup" style="display:none">
       <h1>Open Historia</h1>
       <p>
-        This app connects to a running Open Historia server — the one on this phone
+        Connect to a running Open Historia server — the one on this phone
         (Termux: <b>localhost:3000</b>) or any computer on your network.
       </p>
       <input id="server" type="url" inputmode="url" autocapitalize="off" autocorrect="off"
              placeholder="http://localhost:3000" value="http://localhost:3000" />
       <button id="connect">Connect &amp; Play</button>
+      <button class="ghost" id="useEmbedded">Use this phone's built-in server</button>
       <div class="error" id="error"></div>
-    </div>
-
-    <div class="card" id="connecting">
-      <h1>Open Historia</h1>
-      <p id="connectingTo">Connecting…</p>
-      <button class="ghost" id="cancel">Change server</button>
     </div>
 
     <div class="card" id="update" style="display: none">
@@ -97,19 +102,24 @@
 
     <script>
       const KEY = "pax-server-url";
-      // Stamped with the CI run number at build time; hand-built ("dev")
-      // copies skip the update check entirely.
+      // The embedded server always listens here. Kept in sync with
+      // mobile/nodejs-project/main.js (process.env.PORT default).
+      const EMBEDDED_URL = "http://127.0.0.1:3000";
       const APP_BUILD = "__APP_BUILD__";
-      // Self-update polls the organisation repository's rolling "android"
-      // release (the android-apk.yml workflow publishes there) — the asset
-      // name pax-historia.apk must never change (installed apps look for
-      // exactly that name).
       const RELEASE_API = "https://api.github.com/repos/Open-Historia/open-historia/releases/tags/android";
+
+      const booting = document.getElementById("booting");
       const setup = document.getElementById("setup");
-      const connecting = document.getElementById("connecting");
+      const bootStatus = document.getElementById("bootStatus");
       const input = document.getElementById("server");
       const errorBox = document.getElementById("error");
       let autoTimer = null;
+
+      const show = (el) => {
+        for (const id of ["booting", "setup", "update"]) {
+          document.getElementById(id).style.display = id === el ? "flex" : "none";
+        }
+      };
 
       const normalize = (raw) => {
         let url = String(raw || "").trim();
@@ -118,30 +128,19 @@
         return url.replace(/\/+$/, "");
       };
 
-      // Probe via NATIVE http when available: the WebView's fetch is subject
-      // to CORS and Chrome's Private Network Access rules for loopback
-      // targets ("TypeError: Failed to fetch" with the server running fine),
-      // while native requests are not. Navigation afterwards is unaffected by
-      // those policies, and the game then runs same-origin on the server.
-      const probe = async (url) => {
+      // Probe via NATIVE http when available: the WebView's fetch is subject to
+      // CORS and Chrome's Private Network Access rules for loopback targets,
+      // while native requests are not. Navigation afterwards is unaffected.
+      const probe = async (url, timeout = 4000) => {
         const native = window.Capacitor && window.Capacitor.Plugins && window.Capacitor.Plugins.CapacitorHttp;
         if (native) {
-          const res = await native.request({
-            url: url + "/api/library",
-            method: "GET",
-            connectTimeout: 4000,
-            readTimeout: 4000,
-          });
-          if (!res || res.status < 100 || res.status >= 500) {
-            throw new Error("HTTP " + (res && res.status));
-          }
+          const res = await native.request({ url: url + "/api/library", method: "GET", connectTimeout: timeout, readTimeout: timeout });
+          if (!res || res.status < 100 || res.status >= 500) throw new Error("HTTP " + (res && res.status));
           return;
         }
-        await fetch(url + "/api/library", { signal: AbortSignal.timeout(4000) });
+        await fetch(url + "/api/library", { signal: AbortSignal.timeout(timeout) });
       };
 
-      // Probe the server first so a typo shows an error here instead of a
-      // WebView error page the user can't navigate back from.
       const connect = async (raw) => {
         const url = normalize(raw);
         if (!url) return;
@@ -151,98 +150,108 @@
           localStorage.setItem(KEY, url);
           window.location.replace(url);
         } catch (err) {
-          showSetup();
-          // Show the real failure — "TypeError: Failed to fetch" vs a timeout
-          // point at very different problems when debugging on a phone.
+          show("setup");
           const detail = err && err.name ? " (" + err.name + (err.message ? ": " + err.message : "") + ")" : "";
           errorBox.textContent = "Could not reach " + url + " — is the server running?" + detail;
         }
       };
 
-      const showSetup = () => {
-        if (autoTimer) clearTimeout(autoTimer);
-        connecting.style.display = "none";
-        setup.style.display = "flex";
-      };
+      const showSetup = () => { if (autoTimer) clearTimeout(autoTimer); show("setup"); };
 
       document.getElementById("connect").addEventListener("click", () => connect(input.value));
       input.addEventListener("keydown", (e) => { if (e.key === "Enter") connect(input.value); });
-      document.getElementById("cancel").addEventListener("click", showSetup);
+      document.getElementById("useEmbedded").addEventListener("click", () => startEmbeddedServer(true));
 
-      const startNormalFlow = () => {
-        // A remembered server auto-connects after a short grace period.
-        const saved = localStorage.getItem(KEY);
-        if (saved) {
-          input.value = saved;
-          setup.style.display = "none";
-          connecting.style.display = "flex";
-          document.getElementById("connectingTo").textContent = "Connecting to " + saved + "…";
-          autoTimer = setTimeout(() => connect(saved), 1500);
-        } else {
-          // First launch: look for a Termux server on this phone — if it's
-          // there, go straight into the game with zero typing.
-          const guess = "http://localhost:3000";
-          setup.style.display = "none";
-          connecting.style.display = "flex";
-          document.getElementById("connectingTo").textContent = "Looking for a server on this phone…";
-          probe(guess)
-            .then(() => {
-              localStorage.setItem(KEY, guess);
-              window.location.replace(guess);
-            })
-            .catch(() => {
-              showSetup();
-              errorBox.textContent = "";
-            });
+      // ── Embedded server ──────────────────────────────────────────────────────
+      // nodejs-mobile-cordova exposes window.nodejs. main.js starts the real
+      // server (server/server.js) on 127.0.0.1:3000 with a writable data dir.
+      // We poll until it answers, then navigate into it same-origin.
+      let nodeStarted = false;
+      const startNode = () => {
+        if (nodeStarted) return true;
+        const nodejs = window.nodejs;
+        if (!nodejs || typeof nodejs.start !== "function") return false;
+        try {
+          // redirectOutputToLogcat helps debugging the embedded server on device.
+          nodejs.start("main.js", (err) => { if (err) console.error("[app] nodejs.start error:", err); },
+            { redirectOutputToLogcat: true });
+          nodeStarted = true;
+          return true;
+        } catch (err) {
+          console.error("[app] failed to start embedded node:", err);
+          return false;
         }
       };
 
-      // APK self-update: every launch compares this build against the rolling
-      // "android" release; a newer one auto-downloads (the native download
-      // listener hands the APK to the system browser). Only the app does this
-      // — the regular web version never ships this page.
+      const waitForServer = async () => {
+        // The first cold start (extract project + install/seed) can take a while.
+        const deadline = Date.now() + 90000;
+        while (Date.now() < deadline) {
+          try { await probe(EMBEDDED_URL, 3000); return true; }
+          catch { await new Promise((r) => setTimeout(r, 1500)); }
+        }
+        return false;
+      };
+
+      const startEmbeddedServer = async (forced) => {
+        show("booting");
+        bootStatus.textContent = "Starting your server…";
+        if (!startNode()) {
+          // No nodejs-mobile (e.g. an old build) — fall back to manual connect.
+          if (forced) errorBox.textContent = "This build has no built-in server; connect to one instead.";
+          showSetup();
+          return;
+        }
+        const up = await waitForServer();
+        if (up) {
+          localStorage.setItem(KEY, EMBEDDED_URL);
+          window.location.replace(EMBEDDED_URL);
+        } else {
+          bootStatus.textContent = "The built-in server didn't respond.";
+          document.getElementById("useRemote").style.display = "block";
+          document.getElementById("useRemote").addEventListener("click", showSetup, { once: true });
+        }
+      };
+
+      // ── Normal launch flow ───────────────────────────────────────────────────
+      const startNormalFlow = () => {
+        // A server the user explicitly chose before (a remote/LAN one) auto-reconnects.
+        const saved = localStorage.getItem(KEY);
+        if (saved && saved !== EMBEDDED_URL) {
+          input.value = saved;
+          show("booting");
+          bootStatus.textContent = "Connecting to " + saved + "…";
+          autoTimer = setTimeout(() => connect(saved), 1200);
+          return;
+        }
+        // Default: boot this phone's own server.
+        startEmbeddedServer(false);
+      };
+
+      // ── Self-update (unchanged) ───────────────────────────────────────────────
       const checkForUpdate = async () => {
         if (!/^\d+$/.test(APP_BUILD)) return null; // dev build
         try {
-          const response = await fetch(RELEASE_API, {
-            headers: { Accept: "application/vnd.github+json" },
-            signal: AbortSignal.timeout(4000),
-          });
+          const response = await fetch(RELEASE_API, { headers: { Accept: "application/vnd.github+json" }, signal: AbortSignal.timeout(4000) });
           if (!response.ok) return null;
           const release = await response.json();
           const remote = String(release.body || "").match(/Build:\s*(\d+)/i);
           if (!remote || Number(remote[1]) <= Number(APP_BUILD)) return null;
           const asset = (release.assets || []).find((a) => a.name === "pax-historia.apk");
           return asset ? { build: remote[1], url: asset.browser_download_url } : null;
-        } catch {
-          return null; // offline / rate-limited — just play
-        }
+        } catch { return null; }
       };
 
       checkForUpdate().then((update) => {
-        if (!update) {
-          startNormalFlow();
-          return;
-        }
-        setup.style.display = "none";
-        connecting.style.display = "none";
-        document.getElementById("update").style.display = "flex";
-        // Explicit button — the reliable path. (The download is handed to the
-        // system browser by the native download listener.)
-        document.getElementById("downloadUpdate").addEventListener("click", () => {
-          window.location.href = update.url;
-        });
-        document.getElementById("skipUpdate").addEventListener("click", () => {
-          document.getElementById("update").style.display = "none";
-          startNormalFlow();
-        });
+        if (!update) { startNormalFlow(); return; }
+        show("update");
+        document.getElementById("downloadUpdate").addEventListener("click", () => { window.location.href = update.url; });
+        document.getElementById("skipUpdate").addEventListener("click", () => { startNormalFlow(); });
       });
 
-      // Which build is this? Shown in the corner so bug reports can say.
       const badge = document.createElement("div");
       badge.textContent = "build " + (/^\d+$/.test(APP_BUILD) ? APP_BUILD : "dev");
-      badge.style.cssText =
-        "position:fixed;bottom:0.6rem;right:0.9rem;color:rgba(255,255,255,0.28);font-size:0.7rem;";
+      badge.style.cssText = "position:fixed;bottom:0.6rem;right:0.9rem;color:rgba(255,255,255,0.28);font-size:0.7rem;";
       document.body.appendChild(badge);
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "dev:web": "node scripts/seed-web-defaults.mjs && vite --mode web",
     "build": "vite build",
+    "build:mobile-server": "node scripts/build-mobile-server.mjs",
     "build:web": "node scripts/seed-web-defaults.mjs && vite build --mode web --outDir dist-web --emptyOutDir",
     "build:site": "node scripts/seed-web-defaults.mjs && vite build --mode web --base /play/ --outDir dist-web --emptyOutDir && node scripts/assemble-site.mjs",
     "lint": "eslint .",

--- a/scripts/build-mobile-server.mjs
+++ b/scripts/build-mobile-server.mjs
@@ -1,0 +1,86 @@
+/*! Open Historia — assembles the embedded Node server for the Android app © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Populates mobile/nodejs-project/ with everything nodejs-mobile needs to run the
+// real server in-process inside the APK:
+//
+//   mobile/nodejs-project/
+//     main.js, fetchMapAssets.mjs   (committed entry — not touched here)
+//     package.json                  (express only — the server's sole npm dep)
+//     node_modules/                 (npm install express, run here)
+//     server/                       (copied from ./server)
+//     dist/                         (copied from ./dist — build it first)
+//     public/lang/                  (server's built-in lang fallback)
+//     map-assets.json               (release manifest for first-run map fetch)
+//     seed/                         (default scenarios MINUS the heavy geojson/
+//                                    pmtiles, which fetchMapAssets pulls at runtime)
+//
+// Run AFTER `vite build` (needs ./dist). Idempotent: wipes and rebuilds the
+// copied dirs each time, leaving the committed main.js/fetchMapAssets.mjs alone.
+//
+// Deliberately excludes the ~200 MB map binaries — they can't ship in an APK and
+// are downloaded on first run (see mobile/nodejs-project/fetchMapAssets.mjs).
+import { cpSync, rmSync, mkdirSync, existsSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const OUT = path.join(ROOT, "mobile", "nodejs-project");
+const SKIP_INSTALL = process.argv.includes("--no-install");
+
+const die = (msg) => { console.error(`build-mobile-server: ${msg}`); process.exit(1); };
+if (!existsSync(path.join(ROOT, "server", "server.js"))) die("run from the repo root (server/server.js not found)");
+if (!existsSync(path.join(ROOT, "dist", "index.html"))) die("dist/ is missing — run `vite build` first");
+
+// Files fetched at runtime, never bundled (too big for an APK).
+const HEAVY = /\.(pmtiles|geojson)$|cities-seed\.json$/i;
+const copyLight = (src, dst) =>
+  cpSync(src, dst, { recursive: true, filter: (from) => !(statSync(from).isFile() && HEAVY.test(from)) });
+
+console.log("build-mobile-server: assembling", path.relative(ROOT, OUT));
+for (const dir of ["server", "dist", "public", "seed", "node_modules"]) {
+  rmSync(path.join(OUT, dir), { recursive: true, force: true });
+}
+mkdirSync(OUT, { recursive: true });
+
+// 1. Server code + the built game. The built dist may include the heavy pmtiles
+//    (vite copies public/ verbatim); strip them — they're fetched at runtime and
+//    served from <DATA_DIR>/assets, not the bundle.
+cpSync(path.join(ROOT, "server"), path.join(OUT, "server"), { recursive: true });
+copyLight(path.join(ROOT, "dist"), path.join(OUT, "dist"));
+
+// 2. The server's read-only lang fallback (public/lang). public/assets pmtiles
+//    are intentionally NOT copied.
+mkdirSync(path.join(OUT, "public"), { recursive: true });
+if (existsSync(path.join(ROOT, "public", "lang"))) {
+  cpSync(path.join(ROOT, "public", "lang"), path.join(OUT, "public", "lang"), { recursive: true });
+}
+
+// 3. Seed: default scenarios + manifests, minus the heavy map files.
+mkdirSync(path.join(OUT, "seed"), { recursive: true });
+const dataSrc = path.join(ROOT, "server", "data");
+for (const entry of ["scenario-manifest.json", "game-manifest.json", "scenarios"]) {
+  const from = path.join(dataSrc, entry);
+  if (existsSync(from)) copyLight(from, path.join(OUT, "seed", entry));
+}
+
+// 4. Map manifest for the first-run fetch.
+cpSync(path.join(ROOT, "scripts", "map-assets.json"), path.join(OUT, "map-assets.json"));
+
+// 5. package.json — express is the server's only runtime npm dependency; mirror
+//    the root's pinned version so the phone runs the same express as desktop.
+const rootDeps = JSON.parse(readFileSync(path.join(ROOT, "package.json"), "utf8")).dependencies || {};
+writeFileSync(path.join(OUT, "package.json"), JSON.stringify({
+  name: "open-historia-embedded-server",
+  private: true,
+  type: "module",
+  main: "main.js",
+  dependencies: { express: rootDeps.express || "^5.1.0" },
+}, null, 2) + "\n");
+
+// 6. Install express into the project so the APK bundles node_modules.
+if (!SKIP_INSTALL) {
+  console.log("build-mobile-server: installing express into the node project...");
+  execSync("npm install --omit=dev --no-audit --no-fund", { cwd: OUT, stdio: "inherit" });
+}
+
+console.log("build-mobile-server: done. mobile/nodejs-project/ is ready for `cap sync`.");

--- a/server/basemapStore.js
+++ b/server/basemapStore.js
@@ -14,11 +14,9 @@
 import crypto from "crypto";
 import fs from "fs";
 import path from "path";
-import url from "url";
 import { resolveChildPath } from "./security.js";
+import { DATA_DIR } from "./dataDir.js";
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-const DATA_DIR = path.join(__dirname, "data");
 const BASEMAPS_DIR = path.join(DATA_DIR, "basemaps");
 const MANIFEST_PATH = path.join(DATA_DIR, "basemaps-manifest.json");
 

--- a/server/dataDir.js
+++ b/server/dataDir.js
@@ -1,0 +1,18 @@
+/*! Open Historia — writable data-dir resolver © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// The single writable data root, shared by every server store (games, scenarios,
+// basemaps, flags, map-editor docs, ui-settings, lang packs, hub cache, import
+// pings). Defaults to server/data — the layout desktop and Termux have always
+// used, so those builds are byte-identical.
+//
+// An EMBEDDED server (the Android app runs server.js in-process via nodejs-mobile)
+// sets OH_DATA_DIR to a writable sandbox path, because the server/data that ships
+// inside the APK is READ-ONLY. The app seeds first-run defaults into that dir.
+import path from "path";
+import url from "url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+export const DATA_DIR = process.env.OH_DATA_DIR
+  ? path.resolve(process.env.OH_DATA_DIR)
+  : path.join(__dirname, "data");

--- a/server/flagStore.js
+++ b/server/flagStore.js
@@ -10,11 +10,9 @@
 
 import fs from "fs";
 import path from "path";
-import url from "url";
 import crypto from "crypto";
+import { DATA_DIR } from "./dataDir.js";
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-const DATA_DIR = path.join(__dirname, "data");
 const FLAGS_PATH = path.join(DATA_DIR, "flags-library.json");
 
 const readAll = () => {

--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -13,18 +13,23 @@ import {
   needsMigration as needsOwnerMigration,
   rekeyOwnerMap,
 } from "./ownerMigration.js";
+import { DATA_DIR as SERVER_DATA_DIR } from "./dataDir.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.join(__dirname, "..");
 const DIST_DIR = path.join(PROJECT_ROOT, "dist");
 const PUBLIC_DIR = path.join(PROJECT_ROOT, "public");
-const SERVER_DATA_DIR = path.join(__dirname, "data");
 const SCENARIOS_DIR = path.join(SERVER_DATA_DIR, "scenarios");
 const GAMES_DIR = path.join(SERVER_DATA_DIR, "games");
 const SCENARIO_MANIFEST_PATH = path.join(SERVER_DATA_DIR, "scenario-manifest.json");
 const GAME_MANIFEST_PATH = path.join(SERVER_DATA_DIR, "game-manifest.json");
 
 const PMTILES_ASSETS_DIR = path.join(PUBLIC_DIR, "assets");
+// The embedded Android server ships no pmtiles in its read-only bundle; it
+// downloads them into OH_DATA_DIR/assets on first run (see the app's
+// fetchMapAssets). Desktop has no such dir, so this simply doesn't exist there
+// and serving falls through to PMTILES_ASSETS_DIR unchanged.
+const DATA_ASSETS_DIR = path.join(SERVER_DATA_DIR, "assets");
 
 const DEFAULT_SCENARIO_ID = "default";
 const DEFAULT_GAME_ID = "default";
@@ -2371,6 +2376,12 @@ const resolveRuntimeBinaryAsset = (assetKey) => {
       contentType: "application/octet-stream",
       sourcePath: scenarioOverridePath,
     };
+  }
+
+  // Embedded server: prefer the pmtiles fetched into the writable data dir.
+  const fetchedPath = path.join(DATA_ASSETS_DIR, PMTILES_ASSET_FILES[assetKey]);
+  if (fs.existsSync(fetchedPath)) {
+    return { contentType: "application/octet-stream", sourcePath: fetchedPath };
   }
 
   const fallbackPath = path.join(PMTILES_ASSETS_DIR, PMTILES_ASSET_FILES[assetKey]);

--- a/server/mapEditorStore.js
+++ b/server/mapEditorStore.js
@@ -10,11 +10,9 @@
 
 import fs from "fs";
 import path from "path";
-import url from "url";
 import { resolveChildPath } from "./security.js";
+import { DATA_DIR } from "./dataDir.js";
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-const DATA_DIR = path.join(__dirname, "data");
 const DOCS_DIR = path.join(DATA_DIR, "mapeditor-documents");
 const MANIFEST_PATH = path.join(DATA_DIR, "mapeditor-manifest.json");
 

--- a/server/server.js
+++ b/server/server.js
@@ -54,6 +54,7 @@ import {
   isAllowedHubUrl,
   parseByteRange,
 } from "./security.js";
+import { DATA_DIR } from "./dataDir.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const app = express();
@@ -157,7 +158,7 @@ const streamBinaryFile = (req, res, sourcePath, contentType = "application/octet
 // Global client preferences (currently the UI language) shared by every
 // device that plays through this server — the phone app and desktop browser
 // see the same choice, instead of each browser keeping its own.
-const uiSettingsFile = path.join(__dirname, "data", "ui-settings.json");
+const uiSettingsFile = path.join(DATA_DIR, "ui-settings.json");
 
 const readUiSettings = () => {
   try {
@@ -180,7 +181,7 @@ app.get("/api/ui-settings", (_req, res) => {
 const shippedLangDir = fs.existsSync(path.join(distDir, "lang"))
   ? path.join(distDir, "lang")
   : path.join(__dirname, "../public/lang");
-const savedLangDir = path.join(__dirname, "data", "lang");
+const savedLangDir = path.join(DATA_DIR, "lang");
 
 const readLangPack = (dir, code) => {
   try {
@@ -565,7 +566,7 @@ app.post("/api/server/shutdown", (_req, res) => {
 // bumping its GitHub download count — the second import onward is served locally
 // and never touches GitHub. Bundle URLs are immutable (a new version gets a new
 // URL), so a cached copy can't go stale. Keyed on the requested URL.
-const HUB_CACHE_DIR = path.join(__dirname, "data", "hub-cache");
+const HUB_CACHE_DIR = path.join(DATA_DIR, "hub-cache");
 const hubCachePaths = (fileUrl) => {
   const hash = crypto.createHash("sha256").update(fileUrl).digest("hex");
   return { body: path.join(HUB_CACHE_DIR, `${hash}.body`), type: path.join(HUB_CACHE_DIR, `${hash}.type`) };
@@ -652,7 +653,7 @@ app.get("/api/hub/file", async (req, res) => {
 const IMPORT_COUNTER_URL = (
   process.env.OH_IMPORT_COUNTER_URL ?? "https://oh-import-counter.nichojkrol.workers.dev"
 ).replace(/\/+$/, "");
-const IMPORT_PING_DIR = path.join(__dirname, "data", "import-pings");
+const IMPORT_PING_DIR = path.join(DATA_DIR, "import-pings");
 app.post("/api/hub/import-log", jsonParser, (req, res) => {
   res.json({ ok: true }); // ack at once — telemetry must never delay or fail the import
   (async () => {


### PR DESCRIPTION
Makes the Android app run its **own** Open Historia server in-process (via `nodejs-mobile`) so it needs no Termux and no separate machine. Manual connect to a remote/LAN server stays as a fallback.

## ⚠️ Status — read before merging
I built and **verified the whole server side on desktop Node**, but I **cannot build or run an Android APK** here. The native `nodejs-mobile` wiring, the on-device boot flow, and the ~200 MB first-run map download are **written to spec but need on-device build + test** before this reaches players. Full breakdown + the one remaining native step: `mobile/README-embedded-server.md`. Targeting **alpha** for that iteration.

## Verified on desktop
- **`server/dataDir.js`** — one `OH_DATA_DIR` for every writable store; default `server/data`, so desktop/Termux are byte-identical. Boot-tested: writes go there, `server/data` untouched, `/api/library` → 200.
- **pmtiles serving** — serves the fetched archive from `OH_DATA_DIR/assets` when present, else the bundle. Verified both directions.
- **`mobile/nodejs-project/main.js`** — seeds the default scenarios and starts the real server; booted on desktop → **7 scenarios**, server up.
- **`scripts/build-mobile-server.mjs`** (`npm run build:mobile-server`) — lean project: `dist` 81 MB → **21 MB** (tiles stripped), `node_modules` = express only (**3.4 MB**).
- **`fetchMapAssets.mjs`** — first-run map download, path-mapped into the writable dir.

## Needs a device (written, not verified)
- `mobile/www/index.html` — boots the embedded server, waits, connects; manual-connect + self-update kept.
- `.github/workflows/android-apk.yml` — now builds `dist` + assembles the node project before the APK (included in this PR).
- **The one manual native step:** `cd mobile && npm i nodejs-mobile-cordova && npx cap sync android` (see the README).

## Not touched
Desktop and the hosted web build are unaffected — every change is gated behind `OH_DATA_DIR` being set (only the app sets it).
