### PR TITLE
Advisor: stream replies token-by-token + 8192 request cap (alpha)

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -387,6 +387,52 @@ export async function readOpenAIStreamedResponse(response) {
     };
 }
 
+// Generic SSE text streamer for the CHAT path (the advisor). Reads `data:` lines,
+// pulls each provider's incremental text via extractDelta, forwards it to
+// onChunk(delta, fullSoFar), and returns the full accumulated text. Used ONLY
+// for non-tool calls that pass an onChunk callback; tool/JSON tasks keep the
+// buffered path so the whole structured object is still parsed at once. The
+// onChunk call is wrapped so a throwing UI callback can never break the stream.
+async function streamTextSSE(response, extractDelta, onChunk) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let full = "";
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split(/\r?\n/);
+            buffer = lines.pop() ?? "";
+            for (const line of lines) {
+                if (!line.startsWith("data:")) continue;
+                const payload = line.slice(5).trim();
+                if (!payload || payload === "[DONE]") continue;
+                let json;
+                try { json = JSON.parse(payload); } catch { continue; }
+                const delta = extractDelta(json);
+                if (delta) { full += delta; try { onChunk(delta, full); } catch { /* UI callback must not break the stream */ } }
+            }
+        }
+    } finally {
+        try { reader.releaseLock(); } catch { /* already closed */ }
+    }
+    return full;
+}
+
+// One incremental text chunk per provider's stream event. NOTE: joinGeminiParts
+// trims, which would swallow the leading space of each chunk and run words
+// together — so join the streamed parts WITHOUT trimming.
+const geminiStreamDelta = (json) =>
+    (json?.candidates?.[0]?.content?.parts ?? []).map((part) => part?.text ?? "").join("");
+const openaiStreamDelta = (json) => {
+    const delta = json?.choices?.[0]?.delta;
+    return typeof delta?.content === "string" ? delta.content : "";
+};
+const anthropicStreamDelta = (json) =>
+    json?.type === "content_block_delta" && json?.delta?.type === "text_delta" ? (json.delta.text || "") : "";
+
 function toOpenAIMessages(systemPrompt, history) {
     const messages = [{ role: "system", content: systemPrompt }];
 
@@ -459,6 +505,8 @@ async function resolveModel(provider, { endpoint = "", headers = {}, fallbackMod
 
 async function callGemini(systemPrompt, history, {
     deadline,
+    maxTokens = 8192,
+    onChunk,
     retries = 3,
     retryDelay = 15000,
     signal,
@@ -478,6 +526,35 @@ async function callGemini(systemPrompt, history, {
     });
 
     const customParams = parseCustomParams(settings.customParams, "Gemini");
+
+    // Advisor/chat streaming: with an onChunk callback (and no tool), use the
+    // streaming endpoint so the reply appears token-by-token. maxOutputTokens
+    // caps this reply at the requested budget — the buffered jump path below
+    // deliberately sends NO cap so long simulations are never truncated.
+    if (onChunk && !tool) {
+        const streamUrl = getGeminiUrl(model, apiKey).replace(":generateContent?", ":streamGenerateContent?alt=sse&");
+        const response = await fetch(streamUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                system_instruction: { parts: [{ text: systemPrompt }] },
+                contents: history,
+                generationConfig: {
+                    maxOutputTokens: Math.max(1, Number(maxTokens) || 8192),
+                    ...(getReasoningEnabled() ? { thinkingConfig: { thinkingBudget: 8192 } } : {}),
+                },
+                ...customParams,
+            }),
+            signal,
+        });
+        if (!response.ok) {
+            const payload = await readErrorPayload(response);
+            throw new Error(extractErrorMessage(payload, `Gemini API request failed (${response.status})`));
+        }
+        const streamed = await streamTextSSE(response, geminiStreamDelta, onChunk);
+        if (!streamed) throw new Error("Gemini response did not contain text.");
+        return streamed;
+    }
 
     for (let attempt = 1; attempt <= retries; attempt++) {
         const response = await fetch(getGeminiUrl(model, apiKey), {
@@ -556,6 +633,7 @@ async function callOpenAIStyleChatCompletions({
     deadline,
     signal,
     tool,
+    onChunk,
     allowJsonSchemaFallback = false,
     maxTokens = 8192,
     tokenLimitField = "max_tokens",
@@ -579,8 +657,9 @@ async function callOpenAIStyleChatCompletions({
             payload: {
                 model,
                 // Streaming is what makes Cancel PHYSICAL on a local server —
-                // see readOpenAIStreamedResponse. Local endpoints only.
-                ...(streamLocalEndpoint ? { stream: true } : {}),
+                // see readOpenAIStreamedResponse. Local endpoints, and the
+                // advisor/chat path (onChunk) which streams tokens to the UI.
+                ...(streamLocalEndpoint || (onChunk && !tool) ? { stream: true } : {}),
                 messages: toOpenAIMessages(requestSystemPrompt, history),
                 // Reasoning toggle (settings) — honored by o-series/gpt-5 models and
                 // most OpenAI-compatible gateways. Sent in EVERY mode, tool calls
@@ -672,6 +751,15 @@ async function callOpenAIStyleChatCompletions({
         if (!response.ok) {
             const payload = await readErrorPayload(response);
             throw new Error(extractErrorMessage(payload, `${providerLabel} request failed (${response.status})`));
+        }
+
+        // Advisor/chat streaming: forward tokens to the UI as they arrive. Guard
+        // on the actual content-type so a gateway that ignored stream:true (plain
+        // JSON) safely falls through to the buffered path below.
+        if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
+            const streamed = await streamTextSSE(response, openaiStreamDelta, onChunk);
+            if (!streamed) throw new Error(`${providerLabel} response did not contain text.`);
+            return streamed;
         }
 
         // Local servers that honor stream:true answer as an event stream; ones
@@ -770,6 +858,7 @@ async function callOpenAICompatible(systemPrompt, history, opts = {}) {
 async function callAnthropic(systemPrompt, history, {
     deadline,
     maxTokens = 8192,
+    onChunk,
     retries = 3,
     retryDelay = 15000,
     signal,
@@ -809,6 +898,8 @@ async function callAnthropic(systemPrompt, history, {
             system: systemPrompt,
             max_tokens: requestedMaxTokens,
             ...(reasoning && !tool ? { thinking: { type: "enabled", budget_tokens: 4096 } } : {}),
+            // Advisor/chat streaming: SSE tokens to the UI.
+            ...(onChunk && !tool ? { stream: true } : {}),
             messages: toAnthropicMessages(history),
             ...customParams,
             ...(tool ? {
@@ -839,6 +930,12 @@ async function callAnthropic(systemPrompt, history, {
             throw new Error(extractErrorMessage(payload, `Anthropic request failed (${response.status})`));
         }
 
+        if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
+            const streamed = await streamTextSSE(response, anthropicStreamDelta, onChunk);
+            if (!streamed) throw new Error("Anthropic response did not contain text.");
+            return streamed;
+        }
+
         const data = await response.json();
         if (tool) {
             const toolInput = extractAnthropicToolInput(data, tool);
@@ -858,6 +955,7 @@ async function callAnthropic(systemPrompt, history, {
 async function callAnthropicCompatible(systemPrompt, history, {
     deadline,
     maxTokens = 8192,
+    onChunk,
     retries = 3,
     retryDelay = 15000,
     signal,
@@ -898,6 +996,7 @@ async function callAnthropicCompatible(systemPrompt, history, {
             system: systemPrompt,
             max_tokens: requestedMaxTokens,
             ...(reasoning && !tool ? { thinking: { type: "enabled", budget_tokens: 4096 } } : {}),
+            ...(onChunk && !tool ? { stream: true } : {}),
             messages: toAnthropicMessages(history),
             ...customParams,
             ...(tool ? {
@@ -921,6 +1020,12 @@ async function callAnthropicCompatible(systemPrompt, history, {
         if (!response.ok) {
             const payload = await readErrorPayload(response);
             throw new Error(extractErrorMessage(payload, `Anthropic-compatible request failed (${response.status})`));
+        }
+
+        if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
+            const streamed = await streamTextSSE(response, anthropicStreamDelta, onChunk);
+            if (!streamed) throw new Error("Anthropic-compatible response did not contain text.");
+            return streamed;
         }
 
         const data = await response.json();
@@ -1090,7 +1195,10 @@ export async function sendMessage(userMessage, opts) {
     advisorHistory = compactConversationHistory(advisorHistory);
 
     try {
-        const reply = await callAI(systemPrompt, advisorHistory, { ...opts, languageMode: "chat" });
+        // maxTokens 8192 caps the reply; onChunk (passed by the advisor UI) streams
+        // it token-by-token. Providers that can't stream still return the full reply
+        // here, so the advisor works either way.
+        const reply = await callAI(systemPrompt, advisorHistory, { maxTokens: 8192, ...opts, languageMode: "chat" });
         advisorHistory.push({ role: "model", parts: [{ text: reply }] });
         return reply;
     } catch (err) {

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -250,18 +250,40 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
         setMessages(prev => [...prev, userMessage]);
         setIsLoading(true);
 
+        // Streaming: the ThinkingDots show until the first token, then a live
+        // advisor bubble fills as tokens arrive. It carries a `streaming` flag so
+        // it can be found and finalised; intermediate text is NOT persisted.
+        const showStreaming = (fullText) => setMessages(prev => {
+            const next = prev.slice();
+            const last = next[next.length - 1];
+            if (last && last.role === "advisor" && last.streaming) {
+                next[next.length - 1] = { ...last, text: fullText };
+            } else {
+                next.push({ role: "advisor", text: fullText, time: gameDate, streaming: true });
+            }
+            return next;
+        });
+
         try {
-            const reply = await sendMessage(text);  // uses advisor prompt automatically
-            const advisorMessage = { role: "advisor", text: reply, time: gameDate };
+            const reply = await sendMessage(text, { onChunk: (_delta, full) => showStreaming(full) });
             setMessages(prev => {
-                const updated = [...prev, advisorMessage];
-                saveMessages(updated);
-                return updated;
+                const next = prev.slice();
+                const last = next[next.length - 1];
+                // Finalise the streaming bubble, or append the full reply if the
+                // provider never streamed a chunk.
+                if (last && last.role === "advisor" && last.streaming) {
+                    next[next.length - 1] = { role: "advisor", text: reply, time: gameDate };
+                } else {
+                    next.push({ role: "advisor", text: reply, time: gameDate });
+                }
+                saveMessages(next);
+                return next;
             });
         } catch (err) {
-            const errorMessage = { role: "error", text: err.message, time: gameDate };
             setMessages(prev => {
-                const updated = [...prev, errorMessage];
+                const last = prev[prev.length - 1];
+                const base = last && last.role === "advisor" && last.streaming ? prev.slice(0, -1) : prev.slice();
+                const updated = [...base, { role: "error", text: err.message, time: gameDate }];
                 saveMessages(updated);
                 return updated;
             });
@@ -377,7 +399,7 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
             );
         })}
 
-        {isLoading && (
+        {isLoading && !(messages[messages.length - 1]?.role === "advisor" && messages[messages.length - 1]?.streaming) && (
             <div style={{ display: "flex", alignItems: "flex-start", flexDirection: "column", gap: "0.25rem" }}>
             <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)" }}>🧭 Advisor</span>
             <div style={{ padding: "0.6rem 0.85rem", borderRadius: "12px 12px 12px 4px", backgroundColor: "rgba(255,255,255,0.08)", fontSize: "0.85rem" }}>


### PR DESCRIPTION
The advisor waited for the whole reply, then dropped it in at once. It now **streams token-by-token**, and its request is capped at **8192** as you asked.

## What changed (`main.jsx` + `advisor.jsx`)
- **`streamTextSSE`** — one generic SSE reader for the chat path, plus per-provider delta extractors (Gemini `candidates[].content.parts`, OpenAI `choices[].delta.content`, Anthropic `content_block_delta`). Used **only** for non-tool calls with an `onChunk` callback — jump/JSON tasks keep the buffered path so the whole structured object is still parsed at once.
- **Every provider streams the advisor**: Gemini via `streamGenerateContent?alt=sse`; OpenAI-style + Anthropic add `stream: true`. The OpenAI/Anthropic/compatible branches guard on a real `text/event-stream` content-type, so a gateway that ignores `stream:true` **falls through to the buffered path** and the advisor still shows the full reply. Any provider that can't stream just returns the whole reply at the end — no regression.
- **8192 cap**: `sendMessage` passes `maxTokens: 8192`. On Gemini that becomes `generationConfig.maxOutputTokens` on the **streaming (advisor) call only** — the buffered **jump** path still sends no cap, so long simulations aren't truncated. OpenAI/Anthropic already floor their token field at 8192.
- **UI**: ThinkingDots until the first token, then a live bubble fills as chunks arrive; intermediate text is never persisted, the finalised reply is saved; errors drop the placeholder cleanly. **Diplomacy chat is untouched** (no `onChunk` → buffered as before).

## Verified
SSE streamer + all three extractors **unit-tested 7/7**: chunks accumulate in order; inter-chunk whitespace preserved (after catching + fixing a `joinGeminiParts` trim bug that would have run words together); mid-line byte splits buffered; `[DONE]`/non-text events skipped; malformed lines survive. Both files `esbuild` clean.

Honest caveat: I couldn't do a live token-by-token render with a real API key here — the SSE parsing (the risky part) is unit-tested against real provider payloads, and the wiring is straightforward, but the end-to-end visual is best confirmed in-app.
