### PR TITLE
AI: default Gemini model to gemini-3.6-flash-lite (beta)

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -20,7 +20,7 @@ import {
 // Supports Gemini, OpenAI, Anthropic, and OpenAI-compatible endpoints
 // Usage: import { sendMessage, sendDiplomaticMessage, startChat, startDiplomaticChat, loadHistory, loadDiplomaticHistory, buildDiplomaticSystemPrompt } from './main.jsx'
 
-const GEMINI_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview";
+const GEMINI_DEFAULT_MODEL = "gemini-3.6-flash-lite";
 const ANTHROPIC_DEFAULT_MODEL = "claude-haiku-4-5";
 const OPENAI_API_ENDPOINT = "https://api.openai.com/v1";
 const ANTHROPIC_API_ENDPOINT = "https://api.anthropic.com/v1";

--- a/src/Game/AI/providerConfig.js
+++ b/src/Game/AI/providerConfig.js
@@ -42,7 +42,7 @@ export const PROVIDER_OPTIONS = [
 const PROVIDER_SETTINGS = {
     gemini: {
         apiKey: { storageKey: "gemini_api_key", defaultValue: "" },
-        model: { storageKey: "gemini_model", defaultValue: "gemini-3.1-flash-lite-preview" },
+        model: { storageKey: "gemini_model", defaultValue: "gemini-3.6-flash-lite" },
         customParams: { storageKey: "gemini_custom_params", defaultValue: "" },
     },
     openai: {

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -452,7 +452,7 @@ const ProviderSettingsPanel = ({ provider, settings, onSettingChange }) => {
             label="Model"
             value={settings.geminiModel ?? ""}
             onChange={(value) => onSettingChange("geminiModel", value)}
-            placeholder="gemini-3.1-flash-lite-preview"
+            placeholder="gemini-3.6-flash-lite"
             helperText="Leave blank to use the built-in Gemini default."
             />
             <SettingsInput


### PR DESCRIPTION
Bumps the pre-filled Gemini model from **3.1-flash-lite-preview** to **`gemini-3.6-flash-lite`** in all three spots that carry it: the settings default (`providerConfig.js`), the no-model fallback (`main.jsx` `GEMINI_DEFAULT_MODEL`), and the empty-field placeholder (`settings.jsx`). Only affects new installs / anyone who never set their own model — an explicitly chosen model is untouched.