### PR TITLE
AI: map-change fix + advisor streaming + Gemini 3.5 default

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -411,6 +411,13 @@ const runJsonTask = async (taskKey, {
   if (["jumpForward", "autoJumpForward"].includes(taskKey)) {
     const playerName = normalizeString(variables.playerPolity) || "the player's polity";
     systemPrompt = `${systemPrompt}\n\n[Player Agency]\n${playerName} is controlled by a human player. Never commit ${playerName} to a major decision the player did not actually make: do not sign treaties, alliances, ceasefires, surrenders, trade pacts, unions, or other binding agreements on the player's behalf, do not accept or reject offers for them, and do not have ${playerName} take landmark unilateral action (declaring war, ceding territory, changing government) unless it directly executes one of the player's planned actions, chat replies, or explicit requests. When another polity seeks such an agreement or decision from the player, present it as something the player can answer: a diplomaticOutreach entry or an impacts.createdChats chat where the counterpart speaks first and makes the proposal, or an event describing the offer as OPEN and awaiting the player's response. Events remain free to narrate what other polities do among themselves and to resolve the player's own queued actions exactly as ordered.`;
+    // Map truth: the recurring field report is the OPPOSITE failure — invasions
+    // narrated turn after turn with zero regionTransfers, so the map never moves.
+    // Appended at call time for the same reason as [Player Agency]: existing
+    // campaigns carry frozen prompts, so a defaultPrompts.json rule never
+    // reaches them. This also disarms an over-cautious reading of the agency
+    // rule above ("don't act for the player") as "don't move the map".
+    systemPrompt = `${systemPrompt}\n\n[Map Truth]\nTerritorial narration and the map must never disagree. If an event's title or description says territory was captured, seized, occupied, annexed, ceded, liberated, retaken, or otherwise changed hands, that SAME event MUST carry impacts.regionTransfers entries covering every region it names or implies — a capture claim with no regionTransfers is invalid output that breaks the map. When you do not know a region's exact id, put its plain name in regionId and the engine will resolve it; emit one entry per affected region. Resolving ${playerName}'s own ordered military operations into their territorial outcomes is REQUIRED and is never a player-agency violation: the agency rule restricts unprompted decisions, not the map consequences of offensives the player actually ordered. In an active war, sustained successful offensives normally transfer regions every jump. If nothing genuinely changed hands this period, keep capture language out of the event text.`;
   }
 
   // Reputation context: how the world currently regards the player, and how the
@@ -440,7 +447,12 @@ const runJsonTask = async (taskKey, {
     for (let outputAttempt = 1; outputAttempt <= 2; outputAttempt += 1) {
       const response = await callAI(systemPrompt, history, {
         deadline,
-        maxTokens: taskKey === "jumpForward" || taskKey === "autoJumpForward" ? 16384 : 8192,
+        // One request budget for every task. This is only a per-response output
+        // ceiling for providers that take one (OpenAI-compatible/Anthropic
+        // floor it at 8192 in main.jsx; Gemini sends no cap at all and ignores
+        // this value entirely) — jump tasks used to request 16384, which only
+        // raised that ceiling on capped providers.
+        maxTokens: 8192,
         signal: controller.signal,
         tool,
       });
@@ -975,6 +987,12 @@ const validateChatOpener = (chatLike, path) => {
   return "";
 };
 
+// Event text that claims territory changed hands. Word-boundary anchored so
+// "preoccupied" or "occupational" never match; deliberately narrow (capture
+// verbs, not war verbs) so a defensive battle that moved no borders — a
+// legitimate zero-transfer turn — never trips the reluctance guard below.
+const CAPTURE_LANGUAGE = /\b(captur\w*|seiz\w*|annex\w*|conquer\w*|occup(?:y|ies|ied|ation)|overr[au]n|liberat\w*|retak\w*|retaken|recaptur\w*|cedes?|ceded|ceding|cession|fell to|falls? to)\b/i;
+
 // Strict/salvage discipline, the same contract clampTimelineDates follows:
 // the FIRST attempt returns corrective errors so the model can fix its own
 // answer; the SECOND attempt never rejects a finished generation — invalid
@@ -989,6 +1007,28 @@ export const validateGeneratedWorldChanges = async (candidate, world, { strictTr
   const unresolvedTransfers = await resolveRegionTransfers(containers, world);
   if (strict && unresolvedTransfers.length > 0) {
     return buildTransferFeedback(unresolvedTransfers);
+  }
+  // Reluctance guard (strict attempt only): events that NARRATE a capture while
+  // the whole payload ships ZERO regionTransfers are the recurring field report
+  // — "two turns of invasions and not a single province transferred". One
+  // corrective retry asks the model to reconcile narration with the map (or to
+  // strip the capture language if genuinely nothing changed hands). English
+  // verb heuristic only — a non-English game just never gets this extra nudge —
+  // and the final attempt always passes through salvage, so it can never cost a
+  // finished turn. Only for event-shaped payloads: a $.impacts container has no
+  // narration to check.
+  if (strict && Array.isArray(candidate?.events)) {
+    const totalTransfers = containers.reduce(
+      (sum, { impacts }) => sum + normalizeArray(impacts?.regionTransfers).length,
+      0,
+    );
+    if (totalTransfers === 0) {
+      const captureEvent = candidate.events.find((event) =>
+        CAPTURE_LANGUAGE.test(`${normalizeString(event?.title)} ${normalizeString(event?.description)}`));
+      if (captureEvent) {
+        return `Your events describe territory changing hands (e.g. "${normalizeString(captureEvent.title) || "an event"}") but the payload contains ZERO impacts.regionTransfers. Territorial narration and the map must never disagree: add impacts.regionTransfers entries ({"regionId": exact id or the region's plain name, "toCode": the new owner}) to EVERY event whose text says a region was captured, seized, occupied, annexed, ceded, liberated, or retaken, covering each region it names or implies. If nothing genuinely changed hands in this period, remove the capture language from those events instead, and resend.`;
+      }
+    }
   }
   const unitIds = new Set(normalizeWorldState(world).units.map((unit) => normalizeString(unit.id)).filter(Boolean));
   const generatedPolities = [];

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -387,6 +387,52 @@ export async function readOpenAIStreamedResponse(response) {
     };
 }
 
+// Generic SSE text streamer for the CHAT path (the advisor). Reads `data:` lines,
+// pulls each provider's incremental text via extractDelta, forwards it to
+// onChunk(delta, fullSoFar), and returns the full accumulated text. Used ONLY
+// for non-tool calls that pass an onChunk callback; tool/JSON tasks keep the
+// buffered path so the whole structured object is still parsed at once. The
+// onChunk call is wrapped so a throwing UI callback can never break the stream.
+async function streamTextSSE(response, extractDelta, onChunk) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let full = "";
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split(/\r?\n/);
+            buffer = lines.pop() ?? "";
+            for (const line of lines) {
+                if (!line.startsWith("data:")) continue;
+                const payload = line.slice(5).trim();
+                if (!payload || payload === "[DONE]") continue;
+                let json;
+                try { json = JSON.parse(payload); } catch { continue; }
+                const delta = extractDelta(json);
+                if (delta) { full += delta; try { onChunk(delta, full); } catch { /* UI callback must not break the stream */ } }
+            }
+        }
+    } finally {
+        try { reader.releaseLock(); } catch { /* already closed */ }
+    }
+    return full;
+}
+
+// One incremental text chunk per provider's stream event. NOTE: joinGeminiParts
+// trims, which would swallow the leading space of each chunk and run words
+// together — so join the streamed parts WITHOUT trimming.
+const geminiStreamDelta = (json) =>
+    (json?.candidates?.[0]?.content?.parts ?? []).map((part) => part?.text ?? "").join("");
+const openaiStreamDelta = (json) => {
+    const delta = json?.choices?.[0]?.delta;
+    return typeof delta?.content === "string" ? delta.content : "";
+};
+const anthropicStreamDelta = (json) =>
+    json?.type === "content_block_delta" && json?.delta?.type === "text_delta" ? (json.delta.text || "") : "";
+
 function toOpenAIMessages(systemPrompt, history) {
     const messages = [{ role: "system", content: systemPrompt }];
 
@@ -459,6 +505,8 @@ async function resolveModel(provider, { endpoint = "", headers = {}, fallbackMod
 
 async function callGemini(systemPrompt, history, {
     deadline,
+    maxTokens = 8192,
+    onChunk,
     retries = 3,
     retryDelay = 15000,
     signal,
@@ -478,6 +526,35 @@ async function callGemini(systemPrompt, history, {
     });
 
     const customParams = parseCustomParams(settings.customParams, "Gemini");
+
+    // Advisor/chat streaming: with an onChunk callback (and no tool), use the
+    // streaming endpoint so the reply appears token-by-token. maxOutputTokens
+    // caps this reply at the requested budget — the buffered jump path below
+    // deliberately sends NO cap so long simulations are never truncated.
+    if (onChunk && !tool) {
+        const streamUrl = getGeminiUrl(model, apiKey).replace(":generateContent?", ":streamGenerateContent?alt=sse&");
+        const response = await fetch(streamUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                system_instruction: { parts: [{ text: systemPrompt }] },
+                contents: history,
+                generationConfig: {
+                    maxOutputTokens: Math.max(1, Number(maxTokens) || 8192),
+                    ...(getReasoningEnabled() ? { thinkingConfig: { thinkingBudget: 8192 } } : {}),
+                },
+                ...customParams,
+            }),
+            signal,
+        });
+        if (!response.ok) {
+            const payload = await readErrorPayload(response);
+            throw new Error(extractErrorMessage(payload, `Gemini API request failed (${response.status})`));
+        }
+        const streamed = await streamTextSSE(response, geminiStreamDelta, onChunk);
+        if (!streamed) throw new Error("Gemini response did not contain text.");
+        return streamed;
+    }
 
     for (let attempt = 1; attempt <= retries; attempt++) {
         const response = await fetch(getGeminiUrl(model, apiKey), {
@@ -556,6 +633,7 @@ async function callOpenAIStyleChatCompletions({
     deadline,
     signal,
     tool,
+    onChunk,
     allowJsonSchemaFallback = false,
     maxTokens = 8192,
     tokenLimitField = "max_tokens",
@@ -579,8 +657,9 @@ async function callOpenAIStyleChatCompletions({
             payload: {
                 model,
                 // Streaming is what makes Cancel PHYSICAL on a local server —
-                // see readOpenAIStreamedResponse. Local endpoints only.
-                ...(streamLocalEndpoint ? { stream: true } : {}),
+                // see readOpenAIStreamedResponse. Local endpoints, and the
+                // advisor/chat path (onChunk) which streams tokens to the UI.
+                ...(streamLocalEndpoint || (onChunk && !tool) ? { stream: true } : {}),
                 messages: toOpenAIMessages(requestSystemPrompt, history),
                 // Reasoning toggle (settings) — honored by o-series/gpt-5 models and
                 // most OpenAI-compatible gateways. Sent in EVERY mode, tool calls
@@ -672,6 +751,15 @@ async function callOpenAIStyleChatCompletions({
         if (!response.ok) {
             const payload = await readErrorPayload(response);
             throw new Error(extractErrorMessage(payload, `${providerLabel} request failed (${response.status})`));
+        }
+
+        // Advisor/chat streaming: forward tokens to the UI as they arrive. Guard
+        // on the actual content-type so a gateway that ignored stream:true (plain
+        // JSON) safely falls through to the buffered path below.
+        if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
+            const streamed = await streamTextSSE(response, openaiStreamDelta, onChunk);
+            if (!streamed) throw new Error(`${providerLabel} response did not contain text.`);
+            return streamed;
         }
 
         // Local servers that honor stream:true answer as an event stream; ones
@@ -770,6 +858,7 @@ async function callOpenAICompatible(systemPrompt, history, opts = {}) {
 async function callAnthropic(systemPrompt, history, {
     deadline,
     maxTokens = 8192,
+    onChunk,
     retries = 3,
     retryDelay = 15000,
     signal,
@@ -809,6 +898,8 @@ async function callAnthropic(systemPrompt, history, {
             system: systemPrompt,
             max_tokens: requestedMaxTokens,
             ...(reasoning && !tool ? { thinking: { type: "enabled", budget_tokens: 4096 } } : {}),
+            // Advisor/chat streaming: SSE tokens to the UI.
+            ...(onChunk && !tool ? { stream: true } : {}),
             messages: toAnthropicMessages(history),
             ...customParams,
             ...(tool ? {
@@ -839,6 +930,12 @@ async function callAnthropic(systemPrompt, history, {
             throw new Error(extractErrorMessage(payload, `Anthropic request failed (${response.status})`));
         }
 
+        if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
+            const streamed = await streamTextSSE(response, anthropicStreamDelta, onChunk);
+            if (!streamed) throw new Error("Anthropic response did not contain text.");
+            return streamed;
+        }
+
         const data = await response.json();
         if (tool) {
             const toolInput = extractAnthropicToolInput(data, tool);
@@ -858,6 +955,7 @@ async function callAnthropic(systemPrompt, history, {
 async function callAnthropicCompatible(systemPrompt, history, {
     deadline,
     maxTokens = 8192,
+    onChunk,
     retries = 3,
     retryDelay = 15000,
     signal,
@@ -898,6 +996,7 @@ async function callAnthropicCompatible(systemPrompt, history, {
             system: systemPrompt,
             max_tokens: requestedMaxTokens,
             ...(reasoning && !tool ? { thinking: { type: "enabled", budget_tokens: 4096 } } : {}),
+            ...(onChunk && !tool ? { stream: true } : {}),
             messages: toAnthropicMessages(history),
             ...customParams,
             ...(tool ? {
@@ -921,6 +1020,12 @@ async function callAnthropicCompatible(systemPrompt, history, {
         if (!response.ok) {
             const payload = await readErrorPayload(response);
             throw new Error(extractErrorMessage(payload, `Anthropic-compatible request failed (${response.status})`));
+        }
+
+        if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
+            const streamed = await streamTextSSE(response, anthropicStreamDelta, onChunk);
+            if (!streamed) throw new Error("Anthropic-compatible response did not contain text.");
+            return streamed;
         }
 
         const data = await response.json();
@@ -1090,7 +1195,10 @@ export async function sendMessage(userMessage, opts) {
     advisorHistory = compactConversationHistory(advisorHistory);
 
     try {
-        const reply = await callAI(systemPrompt, advisorHistory, { ...opts, languageMode: "chat" });
+        // maxTokens 8192 caps the reply; onChunk (passed by the advisor UI) streams
+        // it token-by-token. Providers that can't stream still return the full reply
+        // here, so the advisor works either way.
+        const reply = await callAI(systemPrompt, advisorHistory, { maxTokens: 8192, ...opts, languageMode: "chat" });
         advisorHistory.push({ role: "model", parts: [{ text: reply }] });
         return reply;
     } catch (err) {

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -20,7 +20,7 @@ import {
 // Supports Gemini, OpenAI, Anthropic, and OpenAI-compatible endpoints
 // Usage: import { sendMessage, sendDiplomaticMessage, startChat, startDiplomaticChat, loadHistory, loadDiplomaticHistory, buildDiplomaticSystemPrompt } from './main.jsx'
 
-const GEMINI_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview";
+const GEMINI_DEFAULT_MODEL = "gemini-3.6-flash-lite";
 const ANTHROPIC_DEFAULT_MODEL = "claude-haiku-4-5";
 const OPENAI_API_ENDPOINT = "https://api.openai.com/v1";
 const ANTHROPIC_API_ENDPOINT = "https://api.anthropic.com/v1";

--- a/src/Game/AI/providerConfig.js
+++ b/src/Game/AI/providerConfig.js
@@ -42,7 +42,7 @@ export const PROVIDER_OPTIONS = [
 const PROVIDER_SETTINGS = {
     gemini: {
         apiKey: { storageKey: "gemini_api_key", defaultValue: "" },
-        model: { storageKey: "gemini_model", defaultValue: "gemini-3.1-flash-lite-preview" },
+        model: { storageKey: "gemini_model", defaultValue: "gemini-3.6-flash-lite" },
         customParams: { storageKey: "gemini_custom_params", defaultValue: "" },
     },
     openai: {

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -250,18 +250,40 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
         setMessages(prev => [...prev, userMessage]);
         setIsLoading(true);
 
+        // Streaming: the ThinkingDots show until the first token, then a live
+        // advisor bubble fills as tokens arrive. It carries a `streaming` flag so
+        // it can be found and finalised; intermediate text is NOT persisted.
+        const showStreaming = (fullText) => setMessages(prev => {
+            const next = prev.slice();
+            const last = next[next.length - 1];
+            if (last && last.role === "advisor" && last.streaming) {
+                next[next.length - 1] = { ...last, text: fullText };
+            } else {
+                next.push({ role: "advisor", text: fullText, time: gameDate, streaming: true });
+            }
+            return next;
+        });
+
         try {
-            const reply = await sendMessage(text);  // uses advisor prompt automatically
-            const advisorMessage = { role: "advisor", text: reply, time: gameDate };
+            const reply = await sendMessage(text, { onChunk: (_delta, full) => showStreaming(full) });
             setMessages(prev => {
-                const updated = [...prev, advisorMessage];
-                saveMessages(updated);
-                return updated;
+                const next = prev.slice();
+                const last = next[next.length - 1];
+                // Finalise the streaming bubble, or append the full reply if the
+                // provider never streamed a chunk.
+                if (last && last.role === "advisor" && last.streaming) {
+                    next[next.length - 1] = { role: "advisor", text: reply, time: gameDate };
+                } else {
+                    next.push({ role: "advisor", text: reply, time: gameDate });
+                }
+                saveMessages(next);
+                return next;
             });
         } catch (err) {
-            const errorMessage = { role: "error", text: err.message, time: gameDate };
             setMessages(prev => {
-                const updated = [...prev, errorMessage];
+                const last = prev[prev.length - 1];
+                const base = last && last.role === "advisor" && last.streaming ? prev.slice(0, -1) : prev.slice();
+                const updated = [...base, { role: "error", text: err.message, time: gameDate }];
                 saveMessages(updated);
                 return updated;
             });
@@ -377,7 +399,7 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
             );
         })}
 
-        {isLoading && (
+        {isLoading && !(messages[messages.length - 1]?.role === "advisor" && messages[messages.length - 1]?.streaming) && (
             <div style={{ display: "flex", alignItems: "flex-start", flexDirection: "column", gap: "0.25rem" }}>
             <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)" }}>🧭 Advisor</span>
             <div style={{ padding: "0.6rem 0.85rem", borderRadius: "12px 12px 12px 4px", backgroundColor: "rgba(255,255,255,0.08)", fontSize: "0.85rem" }}>

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -452,7 +452,7 @@ const ProviderSettingsPanel = ({ provider, settings, onSettingChange }) => {
             label="Model"
             value={settings.geminiModel ?? ""}
             onChange={(value) => onSettingChange("geminiModel", value)}
-            placeholder="gemini-3.1-flash-lite-preview"
+            placeholder="gemini-3.6-flash-lite"
             helperText="Leave blank to use the built-in Gemini default."
             />
             <SettingsInput


### PR DESCRIPTION
Three AI changes folded into one PR per channel (was #465/#466/#467, #468/#469/#470, #471/#472/#473). Five files, one commit per fix.

### 1. Conquests move the map (+ single 8192 request budget) — `gameplay.js`
Fixes "two turns of invasions and not a single province transferred." A call-time `[Map Truth]` directive (reaches frozen-prompt saves) requires capture narration to ship `regionTransfers`, and a strict-attempt reluctance guard bounces a turn that narrates a capture with zero transfers back with corrective feedback (salvage attempt always passes, so it can't lose a turn). Also: every `runJsonTask` now requests one 8192 budget (Gemini ignores it; capped providers drop 16384→8192).

### 2. Advisor streams replies + 8192 cap — `main.jsx`, `advisor.jsx`
The advisor now streams token-by-token (`streamTextSSE` + per-provider extractors; Gemini `streamGenerateContent`, OpenAI/Anthropic `stream:true`, guarded on real event-stream so non-streaming providers fall back cleanly). `sendMessage` requests `maxTokens: 8192` — on Gemini that caps only the streaming advisor call, jumps stay uncapped. Diplomacy chat untouched.

### 3. Default Gemini model → `gemini-3.5-flash-lite` — `providerConfig.js`, `main.jsx`, `settings.jsx`
Pre-filled value, no-model fallback, and empty-field placeholder. Only affects new installs / users who never set their own model.

### Verified
Map-truth guard 12/12, SSE streamer + extractors 7/7 (both against the real reported payloads); all files esbuild clean. The advisor's live token-by-token render is best confirmed in-app with a key.
