### PR TITLE
web: move account/sync widget out from under the date + jump controls

### DIFF
--- a/src/runtime/web/accountWidget.js
+++ b/src/runtime/web/accountWidget.js
@@ -7,7 +7,7 @@ import { accountConfigured, isSignedIn, getEmail, signOut, signInWithGoogle, goo
 import { syncNow, startSync, stopSync } from "./sync.js";
 
 const css = `
-.oh-acct{position:fixed;top:10px;right:10px;z-index:99998;font:13px/1.4 system-ui,sans-serif}
+.oh-acct{position:fixed;top:4.25rem;right:10px;z-index:9997;font:13px/1.4 system-ui,sans-serif}
 .oh-acct-btn{display:flex;align-items:center;gap:6px;background:rgba(15,17,23,.82);color:#e6e8ee;border:1px solid rgba(255,255,255,.14);border-radius:999px;padding:5px 11px;cursor:pointer;backdrop-filter:blur(6px);max-width:220px}
 .oh-acct-btn:hover{border-color:rgba(255,255,255,.3)}
 .oh-acct-dot{width:8px;height:8px;border-radius:50%;background:#6b7280;flex:0 0 auto}


### PR DESCRIPTION
The web-build account/sync widget (email + "Syncing…" status) was pinned to `top:10px; right:10px; z-index:99998` — the exact top-right corner the **date widget** and its **« / » / jump** controls occupy — so it sat on top of the date and covered the skip-forward button.

That top-right column is also the date widget's dropdown-panel zone (up to 26 rem wide). So the fix drops the account widget just **below the date bar** (`top:0.5rem` + `height:3.5rem` = 4 rem → `top:4.25rem`) and lowers its z-index to **9997** — under the date widget (9999) and its panels (9998).

Result: it's visible during normal play, **never covers the date or skip button**, and tucks *under* a panel when one opens instead of over it. Web build only; one line, nothing else moves.

Worth an eyeball on openhistoria.com/play once merged — I could not reproduce the signed-in widget locally (it only mounts when the account URL is configured), so this is a reasoned CSS reposition rather than a live-verified one.