### PR TITLE
Editor: keep code-shaped country names verbatim; fix edited-region shade (alpha)

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -72,6 +72,13 @@ const resolveOwnerRef = (value, world) => {
 
   const lower = raw.toLowerCase();
   const overrides = world?.polityOverrides;
+  // A polity the map editor marked `verbatim` was named by a human whose text
+  // collides with a GADM code ("USA"); honour it literally rather than
+  // canonicalising it to the code's country. Nothing else sets this flag, so
+  // legacy and model-written owners are untouched. See resolveOwnerName in
+  // ownerMigration.js for the full note.
+  const verbatimPolity = overrides?.[raw];
+  if (verbatimPolity?.verbatim) return String(verbatimPolity.name ?? raw).trim() || raw;
   if (overrides && typeof overrides === "object") {
     for (const [key, polity] of Object.entries(overrides)) {
       const name = String(polity?.name ?? key).trim();

--- a/server/ownerMigration.js
+++ b/server/ownerMigration.js
@@ -39,6 +39,15 @@ export const resolveOwnerName = (token, ctx = {}) => {
 
   const { polityOverrides, countryNameOverrides, registry, features, ownershipOverrides } = ctx;
 
+  // 0. A polity the map editor marked `verbatim`. The author typed this exact name
+  //    and it happens to collide with a GADM code ("USA", "RUS"); take it literally
+  //    so the editor never "corrects" it to the code's country ("United States").
+  //    Only the editor sets this flag, and only for a name a human actually typed —
+  //    legacy code owners, disputed placeholders (Z01), and model output carry no
+  //    such flag, so every existing resolution below is unchanged.
+  const verbatimPolity = polityOverrides?.[raw];
+  if (verbatimPolity?.verbatim) return str(verbatimPolity.name) || raw;
+
   // 1. The scenario's own polity. Catches ROM → "Roman Empire", SOV → "Soviet Union".
   //
   //    The `name !== token` guard is load-bearing. default/world.json carries 9

--- a/server/ownerMigration.test.js
+++ b/server/ownerMigration.test.js
@@ -128,6 +128,31 @@ test("the name !== token guard: a self-named degenerate must not win", () => {
   assert.equal(resolveOwnerName("Z01", ctx), "India");
 });
 
+test("a verbatim polity is taken literally even when its token is a registry code", () => {
+  // The map editor lets an author name a country "RUS". Rule 3 would canonicalise it
+  // to "Russia"; the editor marks such a collision `verbatim` so the typed name is
+  // kept. This is rule 0 — it must beat the registry.
+  const flagged = DEFAULT_LIKE();
+  flagged.world.polityOverrides.RUS = { name: "RUS", aliases: [], color: "#112233", note: "", verbatim: true };
+  assert.equal(resolveOwnerName("RUS", ctxOf(flagged)), "RUS");
+  // The flag is the ONLY thing that changes: the same token unflagged still resolves
+  // to the registry country, so legacy and model-written codes are untouched.
+  assert.equal(resolveOwnerName("RUS", ctxOf(DEFAULT_LIKE())), "Russia");
+});
+
+test("a verbatim owner survives migration with its polity intact", () => {
+  const f = DEFAULT_LIKE();
+  f.world.regionOwnershipOverrides["FRA.1_1"] = "FRA";
+  f.world.polityOverrides.FRA = { name: "FRA", aliases: [], color: "#112233", note: "", verbatim: true };
+  const renames = buildOwnerRenameMap(ctxOf(f));
+  const migrated = migrateWorld(f.world, renames, () => {});
+  // The owner is NOT rewritten to "France", and its polity is NOT dropped as a
+  // degenerate self-name — the two failure modes the flag exists to prevent.
+  assert.equal(migrated.regionOwnershipOverrides["FRA.1_1"], "FRA");
+  assert.equal(migrated.polityOverrides.FRA?.name, "FRA");
+  assert.equal(migrated.polityOverrides.FRA?.verbatim, true);
+});
+
 test("rule 2 is the only thing that saves a legacy label", () => {
   const f = DEFAULT_LIKE();
   f.meta.countryNameOverrides = { THA: "Siam" }; // wwii-1939's hand-authored label

--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -960,7 +960,14 @@ const OlMap = ({
       added.push(draw, new Snap({ source })); // Snap last so it sees events first
     } else if (activeTool === "modify") {
       const modify = new Modify({ source });
-      modify.on("modifyend", notifyRegions);
+      modify.on("modifyend", (e) => {
+        // Dragging a vertex changes the region's geometry, so the stock GADM tile
+        // no longer describes it: mark it edited so the exporter ships this shape
+        // and the game renders it from the GeoJSON instead of the original tile
+        // (which would otherwise paint the old shape over it — a darker seam).
+        for (const f of e.features?.getArray?.() ?? []) f.set("edited", true);
+        notifyRegions();
+      });
       added.push(modify, new Snap({ source }));
     } else if (activeTool === "move") {
       const translate = new Translate({ layers: [layer], hitTolerance: 2 });

--- a/src/Editor/exportPreset.js
+++ b/src/Editor/exportPreset.js
@@ -69,6 +69,12 @@ const normalizeRegionsForGame = (regionsFC) => {
         // No `country`: owner IS the country's name.
         typeId: props.typeId ? String(props.typeId) : "land",
         ...(claimants.length ? { claimants } : {}),
+        // A GADM region the editor reshaped (draw-carve, vertex edit). Its true
+        // geometry now lives in THIS GeoJSON, not the stock tiles — which still
+        // hold the original shape. The game reads this to render the region from
+        // the GeoJSON at every zoom and keep it OUT of the stock-tile fill, so the
+        // reshaped area isn't painted twice and shaded too dark (see Nations.jsx).
+        ...(props.edited ? { edited: true } : {}),
       },
     });
   }
@@ -180,19 +186,20 @@ export const buildGameSeed = (doc, regionsFC, palette = {}, { playerCountry } = 
     colors[owner] = rgb;
 
     // A polity entry exists to tell the game and the model about a country the
-    // stock world has never heard of. That test used to be /^[A-Z]{2,3}$/ — "is
-    // this owner shaped like a GADM code?" — which worked only while owners WERE
-    // codes. Against names it inverts: "Russia" isn't code-shaped, so every real
-    // country would get a spurious polity, while a map-maker who names a country
-    // "USA" or "UAE" still trips the regex and gets NO entry, leaving the model
-    // with no idea their country exists. Ask the real question instead: does the
-    // stock world already know this name?
-    // Also skip an owner that is a known CODE, not just a known name. A document
-    // authored before the rename still owns regions by "MNG", and emitting
-    // {"MNG": {name: "MNG"}} for it is actively harmful: a self-naming polity
-    // shadows the registry in every write-path resolver, so that token can never
-    // become "Mongolia" again. Say nothing and let the registry name it.
-    if (!STOCK_COUNTRY_NAMES.has(owner) && !COUNTRY_NAMES[owner]) {
+    // stock world has never heard of. The test is simply "does the stock world
+    // already know this NAME?": "Russia" is stock and needs no entry, while any
+    // name a map-maker invents does — including one shaped like a GADM code.
+    //
+    // A name that COLLIDES with a code ("USA", "RUS") is the subtle case. It used to
+    // be excluded here (`&& !COUNTRY_NAMES[owner]`) to stop a legacy document's "MNG"
+    // from self-naming a polity that pins it away from "Mongolia" forever. But that
+    // also meant a map-maker who deliberately named a country "USA" got NO entry and
+    // watched it silently canonicalised to "United States" on export. A legacy doc no
+    // longer reaches here still wearing a code — documentMigration turns "MNG" into
+    // "Mongolia" on open — so the only code-shaped owner left at export IS one a human
+    // typed. Emit it, and mark it `verbatim` so the owner resolvers keep it literally
+    // instead of resolving the code (see resolveOwnerName in server/ownerMigration.js).
+    if (!STOCK_COUNTRY_NAMES.has(owner)) {
       polityOverrides[owner] = {
         // No `code`: the key IS the identifier now. `name` mirrors the key because
         // readers expect the field, not because they can differ.
@@ -200,6 +207,9 @@ export const buildGameSeed = (doc, regionsFC, palette = {}, { playerCountry } = 
         aliases: [],
         color: `#${rgb.map((n) => n.toString(16).padStart(2, "0")).join("")}`,
         note: "",
+        // Only a real code-collision needs protecting; a plain invented name
+        // ("Freedonia") already resolves to itself with or without the flag.
+        ...(COUNTRY_NAMES[owner] ? { verbatim: true } : {}),
       };
     }
   }

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -200,6 +200,15 @@ const CUSTOM_FILL_COLOR = ["get", "_fillColor"];
 // zoom, on top — the tiles don't know those shapes.
 const CUSTOM_GEOMETRY_FILTER = ["==", ["index-of", ".", ["get", "id"]], -1];
 const GADM_GEOMETRY_FILTER = [">=", ["index-of", ".", ["get", "id"]], 0];
+// A feature whose geometry lives ONLY in the GeoJSON: author-drawn ("reg_...", no
+// dot) OR a GADM region the editor reshaped (dotted id, but `edited`). Both must
+// render from the GeoJSON at every zoom AND be kept out of the stock tiles, whose
+// geometry is the ORIGINAL shape — painting both stacks two 0.72 fills and darkens
+// the reshaped area. A plain unedited GADM region carries no `edited`, so
+// ["==", ["get","edited"], true] is false for it and these fall back exactly to the
+// dot test — stock and author-only maps render identically to before.
+const AUTHORED_GEOMETRY_FILTER = ["any", CUSTOM_GEOMETRY_FILTER, ["==", ["get", "edited"], true]];
+const STOCK_GEOMETRY_FILTER = ["all", GADM_GEOMETRY_FILTER, ["!=", ["get", "edited"], true]];
 // Crossfade band: seed geometry was extracted at tile-zoom 5, so hand off to
 // the tiles just past that.
 const FAR_FILL_FADE = ["interpolate", ["linear"], ["zoom"], 5.5, 0.72, 6.5, 0];
@@ -933,20 +942,39 @@ const WorldMap = ({ isGlobe = false }) => {
   // GADM regions on custom maps paint the STOCK vector tiles (sharp geometry at
   // every zoom — the coarse seed polygons left sliver gaps up close). Only
   // author-drawn shapes still render from the GeoJSON, on top.
+  // Dotted (GADM) ids the editor reshaped: their true geometry is the GeoJSON's, so
+  // the stock tiles — which still carry the ORIGINAL shape — must not paint them, or
+  // the reshaped area fills twice and reads a shade too dark. Empty on stock and
+  // author-only maps, where every change below is a no-op.
+  const editedStockIds = useMemo(() => {
+    if (!customActive) return [];
+    const ids = [];
+    for (const f of customRegionData?.features ?? []) {
+      const props = f.properties || {};
+      if (props.edited && String(props.id ?? "").includes(".")) ids.push(String(props.id));
+    }
+    return ids;
+  }, [customActive, customRegionData]);
+
   const stockRegionsFillPaint = useMemo(() => {
     if (!customActive) return { "fill-opacity": 0 };
     const stops = [];
     for (const [regionId, owner] of ownerByRegionId) {
       if (!regionId.includes(".")) continue; // drawn regions aren't in the tiles
+      if (editedStockIds.includes(regionId)) continue; // reshaped — the GeoJSON owns it
       stops.push(regionId, owner ? ownerColorCss(owner) : NEUTRAL_LAND_COLOR);
     }
     if (!stops.length) return { "fill-opacity": 0 };
     return {
       "fill-color": ["match", ["get", "GID_1"], ...stops, NEUTRAL_LAND_COLOR],
-      // Fades in as the seed-geometry far layer fades out.
-      "fill-opacity": TILE_FILL_FADE,
+      // Fades in as the seed-geometry far layer fades out — but never for a reshaped
+      // region: its tile still holds the original shape, so painting it here would
+      // double-fill the edited area over the GeoJSON that now owns it.
+      "fill-opacity": editedStockIds.length
+        ? ["case", ["in", ["get", "GID_1"], ["literal", editedStockIds]], 0, TILE_FILL_FADE]
+        : TILE_FILL_FADE,
     };
-  }, [customActive, ownerByRegionId, colorMap, ownerColorCss]);
+  }, [customActive, ownerByRegionId, colorMap, ownerColorCss, editedStockIds]);
 
   // Stock country fills/borders render ONLY once the world is known to be a
   // stock world. Gating on the customRegions FLAG (not customActive, which
@@ -1071,7 +1099,11 @@ const WorldMap = ({ isGlobe = false }) => {
             id="regions-disputed"
             type="fill"
             source-layer="regions"
-            filter={["in", ["get", "GID_1"], ["literal", disputedTileStops.filter((_, i) => i % 2 === 0)]]}
+            filter={editedStockIds.length
+              ? ["all",
+                ["in", ["get", "GID_1"], ["literal", disputedTileStops.filter((_, i) => i % 2 === 0)]],
+                ["!", ["in", ["get", "GID_1"], ["literal", editedStockIds]]]]
+              : ["in", ["get", "GID_1"], ["literal", disputedTileStops.filter((_, i) => i % 2 === 0)]]}
             paint={{
               "fill-pattern": ["match", ["get", "GID_1"], ...disputedTileStops, disputedTileStops[1]],
               "fill-opacity": customActive && worldKnown ? TILE_FILL_FADE : 0,
@@ -1082,6 +1114,7 @@ const WorldMap = ({ isGlobe = false }) => {
           id="regions-outline"
           type="line"
           source-layer="regions"
+          filter={editedStockIds.length ? ["!", ["in", ["get", "GID_1"], ["literal", editedStockIds]]] : undefined}
           paint={regionsOutlinePaint}
         />
       </Source>
@@ -1100,7 +1133,7 @@ const WorldMap = ({ isGlobe = false }) => {
           id="custom-regions-fill-far"
           type="fill"
           maxzoom={7}
-          filter={GADM_GEOMETRY_FILTER}
+          filter={STOCK_GEOMETRY_FILTER}
           paint={{ "fill-color": CUSTOM_FILL_COLOR, "fill-opacity": customActive ? FAR_FILL_FADE : 0 }}
         />
         {/* Far hairlines from the SAME seed geometry as the far fills, so
@@ -1110,7 +1143,7 @@ const WorldMap = ({ isGlobe = false }) => {
           id="custom-regions-hairline-far"
           type="line"
           maxzoom={7}
-          filter={GADM_GEOMETRY_FILTER}
+          filter={STOCK_GEOMETRY_FILTER}
           paint={{
             "line-color": "#000",
             "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.3, 6.5, 0.6],
@@ -1127,25 +1160,25 @@ const WorldMap = ({ isGlobe = false }) => {
           id="custom-regions-disputed-far"
           type="fill"
           maxzoom={7}
-          filter={["all", GADM_GEOMETRY_FILTER, ["has", "_stripes"]]}
+          filter={["all", STOCK_GEOMETRY_FILTER, ["has", "_stripes"]]}
           paint={{ "fill-pattern": ["get", "_stripes"], "fill-opacity": customActive ? FAR_FILL_FADE : 0 }}
         />
         <Layer
           id="custom-regions-fill"
           type="fill"
-          filter={CUSTOM_GEOMETRY_FILTER}
+          filter={AUTHORED_GEOMETRY_FILTER}
           paint={{ "fill-color": CUSTOM_FILL_COLOR, "fill-opacity": 0.72 }}
         />
         <Layer
           id="custom-regions-disputed"
           type="fill"
-          filter={["all", CUSTOM_GEOMETRY_FILTER, ["has", "_stripes"]]}
+          filter={["all", AUTHORED_GEOMETRY_FILTER, ["has", "_stripes"]]}
           paint={{ "fill-pattern": ["get", "_stripes"], "fill-opacity": customActive ? 0.72 : 0 }}
         />
         <Layer
           id="custom-regions-outline"
           type="line"
-          filter={CUSTOM_GEOMETRY_FILTER}
+          filter={AUTHORED_GEOMETRY_FILTER}
           paint={{
             "line-color": "#000",
             "line-width": [

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -1114,7 +1114,7 @@ const WorldMap = ({ isGlobe = false }) => {
           id="regions-outline"
           type="line"
           source-layer="regions"
-          filter={editedStockIds.length ? ["!", ["in", ["get", "GID_1"], ["literal", editedStockIds]]] : undefined}
+          filter={editedStockIds.length ? ["!", ["in", ["get", "GID_1"], ["literal", editedStockIds]]] : ["all"]}
           paint={regionsOutlinePaint}
         />
       </Source>

--- a/src/runtime/web/models.js
+++ b/src/runtime/web/models.js
@@ -90,6 +90,12 @@ export const resolveOwnerRef = (value, world) => {
 
   const lower = raw.toLowerCase();
   const overrides = world?.polityOverrides;
+  // A polity the map editor marked `verbatim` was named by a human whose text
+  // collides with a GADM code ("USA"); honour it literally rather than
+  // canonicalising it to the code's country. Nothing else sets this flag, so
+  // legacy and model-written owners are untouched. Mirrors server/libraryStore.js.
+  const verbatimPolity = overrides?.[raw];
+  if (verbatimPolity?.verbatim) return String(verbatimPolity.name ?? raw).trim() || raw;
   if (overrides && typeof overrides === "object") {
     for (const [key, polity] of Object.entries(overrides)) {
       const name = String(polity?.name ?? key).trim();


### PR DESCRIPTION
Alpha of the triplet (main #480). Content-identical.

**1. "USA" is no longer auto-corrected to "United States."** Author-typed names that collide with a GADM code are marked `verbatim` and both owner resolvers honour that literally. Nothing else sets the flag, so legacy codes, Z01 placeholders and model output are unchanged (two new tests).

**2. Cut/edited regions no longer render a darker shade when zoomed in far.** Above z6.5 the stock tiles repainted an edited region's original shape over the reshaped GeoJSON (0.72 + 0.72 → darker). The export now carries an `edited` flag; the game renders edited GADM regions from the GeoJSON at every zoom and excludes them from the stock fill/outline. Gated on the flag — no existing scenario carries it, so stock/author-only maps are byte-identical. Vertex edits are flagged too (previously not shipped to the game).

Verification: 14/14 owner tests; style parses clean on boot. Edited-region visual not pixel-confirmable in headless WebGL — worth an eyeball on a real edited map (inert on everything existing).