### PR TITLE
Crash resilience: cap MapLibre tile cache; game-view error boundary (beta)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import UI from "./Game/GameUI/main.jsx";
 // Lazy so OpenLayers is only fetched when the editor is actually opened.
 const MapEditor = lazy(() => import("./Editor/MapEditor.jsx"));
 import StartupScreen from "./runtime/StartupScreen.jsx";
+import ErrorBoundary from "./runtime/ErrorBoundary.jsx";
 import {
   STARTUP_TIME_BUDGET_MS,
   createInitialStartupState,
@@ -203,7 +204,15 @@ function App() {
       </Suspense>
     );
   }
-  return <GameApp />;
+  // Wrap the game view (not the editor route, which has its own Suspense fallback)
+  // so a render/lifecycle throw in the map, UI or panels shows a recoverable Reload
+  // screen instead of unmounting to a blank page. Wrapping <GameApp/> at this level
+  // (rather than inside GameApp's return) also catches GameApp's own render throws.
+  return (
+    <ErrorBoundary>
+      <GameApp />
+    </ErrorBoundary>
+  );
 }
 
 export default App;

--- a/src/Game/Map/World.jsx
+++ b/src/Game/Map/World.jsx
@@ -304,6 +304,16 @@ function World({ mapRef, projection, terrainEnabled, onInitialIdle }) {
         collectResourceTiming={false}
         crossSourceCollisions={false}
         renderWorldCopies
+        // Cap MapLibre's per-source out-of-view tile-retention cache. Left unset it
+        // sizes dynamically to ~(ceil(w/tileSize)+1)*(ceil(h/tileSize)+1)*5 tiles PER
+        // source — ~270 at 1080p but ~800 at a 3840x2160 desktop viewport, and
+        // renderWorldCopies feeds successive wrapped world-copy tiles into it as you
+        // pan E/W, so retained GPU textures climb until the tab OOMs. 256 caps the 4K
+        // case ~3x while barely trimming 1080p, and is a no-op on phone-sized viewports
+        // (dynamic size there is well under 256). In-view tiles live in a separate
+        // structure and are never evicted by this, so it never re-fetches what's on
+        // screen. Orthogonal to applyDynamicPixelRatio (which bounds framebuffer pixels).
+        maxTileCacheSize={256}
         projection={mapProjection}
         terrain={terrain}
         mapStyle={worldStyle}

--- a/src/runtime/ErrorBoundary.jsx
+++ b/src/runtime/ErrorBoundary.jsx
@@ -1,0 +1,115 @@
+/*! Open Historia — React error boundary (recoverable render-crash fallback) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+import React from "react";
+
+// Catches render/lifecycle/constructor throws in the map, game UI and panels so a
+// crash shows a recoverable fallback (with a Reload) instead of React unmounting the
+// whole tree to a blank white page. Caveat: an error boundary only catches errors
+// thrown by its DESCENDANTS during render — not in its own render, not in event
+// handlers, and not in async/promise/rAF code (much of the map runs in effects, not
+// render). It is wrapped around <GameApp/> in App.jsx so it also covers GameApp's
+// own render.
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Render crash caught by ErrorBoundary:", error, info?.componentStack);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div style={styles.shell} role="alert">
+        <div style={styles.card}>
+          <div style={styles.title}>Something went wrong</div>
+          <div style={styles.body}>
+            The world view hit an unexpected error and had to stop. Your saved games
+            are safe — reloading usually recovers.
+          </div>
+          {error?.message ? <pre style={styles.detail}>{String(error.message)}</pre> : null}
+          <button type="button" style={styles.button} onClick={this.handleReload}>
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+// Inline styles so the fallback renders even if the stylesheet failed to load;
+// mirrors the loading screen's dark/gold palette. Fixed + very high z-index so it
+// covers the map and all in-game overlays.
+const styles = {
+  shell: {
+    position: "fixed",
+    inset: 0,
+    zIndex: 100000,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "6vw",
+    background: "#050403",
+    color: "#f2e8cc",
+    fontFamily: "Georgia, 'EB Garamond', serif",
+  },
+  card: {
+    maxWidth: "30rem",
+    width: "100%",
+    textAlign: "center",
+    display: "flex",
+    flexDirection: "column",
+    gap: "1rem",
+  },
+  title: {
+    fontSize: "clamp(1.3rem, 3vw, 1.8rem)",
+    fontWeight: 700,
+    letterSpacing: "0.04em",
+    color: "#f0cc40",
+  },
+  body: {
+    fontSize: "0.95rem",
+    lineHeight: 1.5,
+    color: "rgba(215,190,140,0.85)",
+  },
+  detail: {
+    maxHeight: "8rem",
+    overflow: "auto",
+    textAlign: "left",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: "0.75rem",
+    color: "rgba(230,185,120,0.7)",
+    background: "rgba(255,255,255,0.04)",
+    border: "1px solid rgba(210,165,55,0.25)",
+    borderRadius: "6px",
+    padding: "0.6rem 0.75rem",
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+  },
+  button: {
+    alignSelf: "center",
+    marginTop: "0.4rem",
+    padding: "0.6rem 1.6rem",
+    fontSize: "0.9rem",
+    fontWeight: 600,
+    letterSpacing: "0.08em",
+    color: "#050403",
+    background: "linear-gradient(90deg, #d4a820, #ffe370)",
+    border: "none",
+    borderRadius: "6px",
+    cursor: "pointer",
+  },
+};
+
+export default ErrorBoundary;


### PR DESCRIPTION
Two of the desktop-website stability fixes from the crash investigation (the menu-lag cover fix ships separately after re-keying).

**1. `maxTileCacheSize={256}` on the `<Map>`.** Left unset, MapLibre sizes its per-source out-of-view tile cache to the viewport — ~270 tiles/source at 1080p but ~800 at a 3840×2160 desktop, and with `renderWorldCopies` on, panning E/W pours wrapped world-copy tiles in until the tab OOMs. 256 caps the 4K case ~3×, is a **no-op on phone viewports** (dynamic size there is well under 256), and never evicts in-view tiles (no re-fetch of what is on screen). This is the "desktop crashes but phone is fine" driver.

**2. A React error boundary around `<GameApp/>`** (new `src/runtime/ErrorBoundary.jsx`). There were **zero** error boundaries; a render/lifecycle throw in the map, UI or panels unmounted the whole tree to a blank white page. Now it shows a recoverable dark/gold "Something went wrong" + **Reload** screen. Wrapped at the `App()` level (not inside `GameApp`) so it also catches `GameApp`’s own render throws; the editor route keeps its own Suspense fallback.

**Deliberately NOT included: a hand-rolled WebGL-context-loss handler.** MapLibre v5.19 already `preventDefault()`s on `webglcontextlost`, snapshots the style, and rebuilds every GL resource on `webglcontextrestored`; the game has no `type:"custom"` layers, so a hand-rolled handler would only fight MapLibre’s own recovery. (Caveat: MapLibre recovers only when the browser fires `webglcontextrestored`, which is not guaranteed on a hard GPU reset — a passive log/offer-reload listener is the only safe future addition.)

**Verification:** booted the dev app — normal path mounts the map canvas with the boundary as a transparent pass-through; a forced child throw rendered the fallback with a working Reload button, then reverted cleanly. `maxTileCacheSize` forwarding confirmed against `@vis.gl/react-maplibre` + `maplibre-gl` v5. Design + edits were adversarially verified before implementing. Headless WebGL can’t composite the map, so a quick eyeball on real 4K hardware is worth it, but the change is low-blast-radius and inert on small viewports.