### PR TITLE
Advisor: drag the panel's left edge to resize it

### DIFF
--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -184,7 +184,7 @@ const TabButton = ({ icon, label, active, onClick }) => (
     </button>
 );
 
-const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
+const AdvisorPanel = ({ isAdvisorOpen, onClose, width, onResize }) => {
     const [messages, setMessages]   = useState([]);
     const [input, setInput]         = useState("");
     const [isLoading, setIsLoading] = useState(false);
@@ -193,6 +193,30 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
     const [hasBootstrapped, setHasBootstrapped] = useState(false);
     const [activeTab, setActiveTab] = useState("advisor");
     const inputRef = useRef(null);
+    const [isResizing, setIsResizing] = useState(false);
+    const [handleHover, setHandleHover] = useState(false);
+
+    // Drag the drawer's left edge to resize it. The panel is docked right, so the
+    // new width is simply (viewport width − pointer x); the parent (main.jsx) clamps
+    // and persists it. Pointer capture keeps the drag alive if the cursor leaves the
+    // 10px handle. Works for mouse, touch and pen.
+    const handleResizeStart = React.useCallback((e) => {
+        if (typeof onResize !== "function") return;
+        e.preventDefault();
+        const target = e.currentTarget;
+        try { target.setPointerCapture(e.pointerId); } catch { /* not fatal */ }
+        setIsResizing(true);
+        const onMove = (ev) => onResize(window.innerWidth - ev.clientX);
+        const onUp = () => {
+            setIsResizing(false);
+            target.removeEventListener("pointermove", onMove);
+            target.removeEventListener("pointerup", onUp);
+            target.removeEventListener("pointercancel", onUp);
+        };
+        target.addEventListener("pointermove", onMove);
+        target.addEventListener("pointerup", onUp);
+        target.addEventListener("pointercancel", onUp);
+    }, [onResize]);
     // A reply already in the chat language must skip the UI translator, which
     // would render it back into the interface language.
     const chatDiffers = chatLanguageDiffersFromUi();
@@ -315,7 +339,7 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
             // Full height now the in-game top bar is gone — it used to stop 64px
             // (the old BAR_HEIGHT) short of the top to clear it. Anchored bottom: 0
             // above, so height: 100vh reaches the top edge.
-            width: ADVISOR_PANEL_WIDTH, height: "100vh",
+            width: typeof width === "number" ? `${width}px` : ADVISOR_PANEL_WIDTH, height: "100vh",
             backgroundColor: "rgba(17, 24, 39, 0.95)", backdropFilter: "blur(8px)",
             // Above every HUD button/panel (toolbar 9999, forces 10000,
             // library panels 10031) so nothing covers the open drawer on
@@ -326,6 +350,28 @@ const AdvisorPanel = ({ isAdvisorOpen, onClose }) => {
             display: "flex", flexDirection: "column",
             color: "white", fontFamily: "sans-serif", overflow: "hidden",
         }}>
+        {/* Drag the left edge to resize the drawer (main.jsx clamps + persists). */}
+        {typeof onResize === "function" && (
+            <div
+                onPointerDown={handleResizeStart}
+                onPointerEnter={() => setHandleHover(true)}
+                onPointerLeave={() => setHandleHover(false)}
+                title="Drag to resize"
+                style={{
+                    position: "absolute", left: 0, top: 0, bottom: 0, width: "10px",
+                    cursor: "ew-resize", zIndex: 30, touchAction: "none",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                }}
+            >
+                <div style={{
+                    width: "3px", height: "42px", borderRadius: "2px",
+                    backgroundColor: isResizing
+                        ? "rgba(96,165,250,0.95)"
+                        : handleHover ? "rgba(255,255,255,0.5)" : "rgba(255,255,255,0.22)",
+                    transition: "background-color 0.15s",
+                }} />
+            </div>
+        )}
         {/* Header: tabs to flip between the advisor chat and national stats. */}
         <div style={{ alignItems: "center", borderBottom: "1px solid rgba(255,255,255,0.1)", display: "flex", padding: "0 0.75rem 0 0.35rem" }}>
         <TabButton icon="🧭" label="Advisor" active={activeTab === "advisor"} onClick={() => setActiveTab("advisor")} />

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -15,7 +15,22 @@ import {
   persistProviderSetting,
 } from "../AI/providerConfig.js";
 
-const ADVISOR_PANEL_WIDTH = "min(20rem, calc(100vw - 1rem))";
+// The advisor drawer is user-resizable — drag its left edge (see advisor.jsx).
+// Width is kept in px so the drag maps 1:1 to the pointer, persisted in
+// localStorage, and clamped to a readable min and the current viewport.
+const ADVISOR_MIN_WIDTH = 280;
+const ADVISOR_DEFAULT_WIDTH = 320; // 20rem, the old fixed width
+const clampAdvisorWidth = (px) => {
+  const max = (typeof window !== "undefined" ? window.innerWidth : 1280) - 16;
+  return Math.round(Math.min(Math.max(px, Math.min(ADVISOR_MIN_WIDTH, max)), max));
+};
+const readAdvisorWidth = () => {
+  try {
+    const saved = Number(localStorage.getItem("oh-advisor-width"));
+    if (Number.isFinite(saved) && saved > 0) return clampAdvisorWidth(saved);
+  } catch { /* private-mode storage — fall through to default */ }
+  return clampAdvisorWidth(ADVISOR_DEFAULT_WIDTH);
+};
 const baseStyle = {
   position: "fixed",
   backgroundColor: "rgba(17, 24, 39, 0.9)",
@@ -121,6 +136,7 @@ const Main = ({
   const [isCheatsOpen, setIsCheatsOpen] = useState(false);
   const [shouldLoadCheats, setShouldLoadCheats] = useState(false);
   const [isAdvisorOpen, setIsAdvisorOpen] = useState(false);
+  const [advisorWidth, setAdvisorWidth] = useState(readAdvisorWidth);
   const [isForcesOpen, setIsForcesOpen] = useState(false);
   const [activeBottomPanel, setActiveBottomPanel] = useState(null);
   const [shouldLoadAdvisor, setShouldLoadAdvisor] = useState(false);
@@ -218,7 +234,23 @@ const Main = ({
     setIsAdvisorOpen(true);
   }, []);
 
-  const rightShift = isAdvisorOpen ? `calc(${ADVISOR_PANEL_WIDTH} + 0.5rem)` : "0.5rem";
+  // Called on every pointermove while the user drags the advisor's edge.
+  const handleAdvisorResize = useCallback((px) => {
+    setAdvisorWidth(() => {
+      const w = clampAdvisorWidth(px);
+      try { localStorage.setItem("oh-advisor-width", String(w)); } catch { /* ignore */ }
+      return w;
+    });
+  }, []);
+
+  // Keep the saved width valid if the window shrinks below it.
+  useEffect(() => {
+    const onResize = () => setAdvisorWidth((w) => clampAdvisorWidth(w));
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const rightShift = isAdvisorOpen ? `calc(${advisorWidth}px + 0.5rem)` : "0.5rem";
   const toggleBottomPanel = useCallback((panelName) => {
     setActiveBottomPanel((currentPanel) => (
       currentPanel === panelName ? null : panelName
@@ -257,7 +289,7 @@ const Main = ({
       />
       <Suspense fallback={null}>
         {shouldLoadAdvisor && (
-          <LazyAdvisorPanel isAdvisorOpen={isAdvisorOpen} onClose={() => setIsAdvisorOpen(false)} />
+          <LazyAdvisorPanel isAdvisorOpen={isAdvisorOpen} onClose={() => setIsAdvisorOpen(false)} width={advisorWidth} onResize={handleAdvisorResize} />
         )}
       </Suspense>
       <Suspense fallback={null}>


### PR DESCRIPTION
The advisor / stats drawer was a fixed width. Now you can **drag its left edge to resize it**.

- A thin resize handle on the drawer's left edge (a subtle grip that brightens on hover / while dragging), using pointer events so it works with **mouse, touch and pen**.
- The width is lifted into `main.jsx` as state, **clamped to [280px, viewport−16px]** and **persisted in `localStorage`** (`oh-advisor-width`), re-clamped if the window shrinks.
- The `rightShift` that offsets the date widget / other panel / advisor button reads the live width, so those HUD controls **track the drawer** as it grows/shrinks.

**Verified by booting the dev app + a synthetic pointer drag:** the panel goes 320→460px as dragged, **clamps at the viewport max and the 280px min**, the new width **persists to localStorage**, and the HUD controls shift with it. No new console errors.

Note: applied onto the current (i18n-bearing) `advisor.jsx`/`main.jsx` — confirmed zero i18n/RTL lines were touched (the work-repo copy of those files was stale, so the edits were re-applied on the upstream version).