### PR TITLE
CI: add Build Android APK (Beta) workflow

### DIFF
--- a/.github/workflows/android-apk-beta.yml
+++ b/.github/workflows/android-apk-beta.yml
@@ -1,0 +1,77 @@
+# Open Historia — Android APK BETA (embedded node server) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE).
+name: Build Android APK (Beta)
+
+# Builds the EXPERIMENTAL embedded-node-server app from the `alpha` branch and
+# publishes it to a SEPARATE, isolated "android-beta" pre-release. The stable
+# `android` release and every installed stable app are left untouched — beta
+# testers download pax-historia.apk from the android-beta release by hand.
+# Run it from the Actions tab (Run workflow).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  apk:
+    runs-on: ubuntu-latest
+    steps:
+      # Always build the node-server code, which lives on `alpha`, regardless of
+      # which branch this workflow is dispatched from.
+      - uses: actions/checkout@v4
+        with:
+          ref: alpha
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Stamp the build number
+        run: sed -i "s/__APP_BUILD__/${{ github.run_number }}/" mobile/www/index.html
+
+      - name: Point the beta app's self-update at the android-beta release
+        # So the beta polls android-beta, not the stable android release — it never
+        # nags a tester to "update" back to the stable app.
+        run: sed -i 's#releases/tags/android"#releases/tags/android-beta"#' mobile/www/index.html
+
+      - name: Build the game + assemble the embedded server
+        run: |
+          npm ci
+          npm run build
+          node scripts/build-mobile-server.mjs
+
+      - name: Build the APK
+        run: |
+          cd mobile
+          npm ci
+          npx cap sync android
+          cd android
+          chmod +x gradlew
+          ./gradlew assembleDebug --no-daemon
+
+      - name: Collect
+        run: cp mobile/android/app/build/outputs/apk/debug/app-debug.apk pax-historia.apk
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pax-historia-apk-beta
+          path: pax-historia.apk
+
+      - name: Publish to the isolated "android-beta" pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NOTES="Open Historia for Android — BETA (experimental in-app server).
+
+          This build runs the game server INSIDE the app (nodejs-mobile) instead of needing Termux or a separate machine. It is unfinished and may fail to start or crash — please report what happens. Download pax-historia.apk below and open it to install (allow installs from your browser when Android asks). On first launch it starts the built-in server and downloads the world map (~200 MB). This is separate from the stable app and its updates.
+
+          Build: ${{ github.run_number }}"
+          gh release create android-beta --title "Android app — Beta (in-app server)" --prerelease --notes "$NOTES" 2>/dev/null \
+            || gh release edit android-beta --prerelease --notes "$NOTES"
+          gh release upload android-beta pax-historia.apk --clobber


### PR DESCRIPTION
Adds a `workflow_dispatch` job that builds the embedded-node-server app from `alpha` and publishes `pax-historia.apk` to a separate, isolated `android-beta` pre-release. Stable app untouched. Needs to live on `main` to be dispatchable.