### PR TITLE
CI(beta apk): stage nodejs-project under assets/www for the Cordova plugin

### DIFF
--- a/.github/workflows/android-apk-beta.yml
+++ b/.github/workflows/android-apk-beta.yml
@@ -51,6 +51,12 @@ jobs:
           cd mobile
           npm ci
           npx cap sync android
+          # nodejs-mobile-cordova is a Cordova plugin: its gradle looks for the node
+          # project under the Cordova www assets folder (assets/www/nodejs-project),
+          # which Capacitor never creates — it copies webDir to assets/public. Drop
+          # the assembled server there so the plugin can bundle it into the APK.
+          mkdir -p android/app/src/main/assets/www
+          cp -r nodejs-project android/app/src/main/assets/www/nodejs-project
           cd android
           chmod +x gradlew
           ./gradlew assembleDebug --no-daemon


### PR DESCRIPTION
Fixes the 'couldn't find the www folder' gradle error — copies the assembled nodejs-project into assets/www/nodejs-project after cap sync (Cordova plugin expects the Cordova layout; Capacitor uses assets/public).