### PR TITLE
docs: comprehensive developer documentation (docs/) + Prompt-Making Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# Open Historia — Developer Documentation
+
+Open Historia is an AI-driven, map-based alternate-history strategy game: players run a world of owned regions on an interactive map and advance it turn-by-turn, with a language model narrating events and applying concrete changes back to the world state. The same codebase ships as three variants from one source tree — a Node/Express server build, a browser-only web build (openhistoria.com), and a Capacitor Android app with an embedded server — gated by the compile-time `VITE_OH_WEB` flag. These docs are organized by subsystem: the map and in-game UI, the world/turn model, the AI pipeline, the standalone map editor, the backend and data layers, the web/mobile targets, and the delivery/release topology. Every page is a standalone reference; this index groups them and links each with a one-line summary.
+
+## Start here
+
+New to the codebase? Read **[Architecture Overview](architecture.md)** first — it covers the tech stack, the three build variants and the `VITE_OH_WEB` flag, the boot sequence, the directory map, and the frontend↔`/api`↔storage data flow that every other page builds on. From there, follow the group that matches what you're working on.
+
+> **Editing AI prompts?** The **[Prompt-Making Guide](ai-prompts.md)** is the canonical reference — every placeholder/variable, all 13 tasks plus the advisor/leader roots, end-to-end prompt assembly, the override/frozen-prompt model, and recipes for adding a variable or a task. Start there before touching any prompt text.
+
+## Contents
+
+### Getting Started
+- [Architecture Overview](architecture.md) — Tech stack, the three build variants and the `VITE_OH_WEB` flag, boot sequence, directory map, and the frontend↔`/api`↔storage data flow.
+- [Contributing & Conventions](conventions.md) — Repo/remote layout, release-channel workflow, PR-only process, commit/attribution and comment style, local dev, `node --test`, and frozen identifiers.
+
+### Game
+- [Game Map & Rendering](game-map.md) — In-game MapLibre rendering: region/country layers, owner colouring, disputed stripes, labels, cities/markers/units, the decorative globe, and `world.json` data flow.
+- [In-Game UI (HUD, Panels & Buttons)](game-ui.md) — Complete HUD/panels/buttons reference: shell, z-index ladder, main menu, and every panel with its state/props and map/AI/server data flow.
+- [World State & Turn Model](world-state.md) — The `world.json`/`game.json` schema, normalizers, AI impact application, the 5s poll, units peer-poll, country tags, and games-vs-scenarios storage.
+
+### AI & Prompts
+- [AI System Overview](ai-overview.md) — Transport/provider dispatch, key/relay security, streaming vs buffered, token caps, and the `runJsonTask` strict/salvage task pipeline.
+- [Prompt-Making Guide](ai-prompts.md) — The reference for authoring and editing AI prompts: every variable, all tasks, end-to-end assembly, and the override/frozen-prompt model.
+- [AI Return Schemas & Validation](ai-schemas.md) — AI JSON return schemas, the two-layer validator, and the `runJsonTask` strict/salvage retry discipline.
+
+### Editor
+- [Map Editor](map-editor.md) — The OpenLayers map editor: tools, region/owner/flag/tag editing, tier-1/tier-2 game-seed export, and how edits reach the game.
+
+### Backend & Data
+- [Server & API](server.md) — The Node/Express game server: routes, data-dir layout, asset serving, owner migration, and portability.
+- [Map Data & Assets](assets-and-data.md) — Map-data & asset handling from GitHub-Release download through server override resolution to the browser caching/warming model.
+- [Runtime Services](runtime-services.md) — Library/scenario/game stores, the country-name resolver, i18n/translator, and tags/labels/community-flags/map-settings services.
+
+### Web & Mobile
+- [Web Build (openhistoria.com)](web-build.md) — The browser-only `VITE_OH_WEB` build: fetch-interceptor fake backend, IndexedDB stores, PMTiles Worker-proxy/content-node trust chain, magic-link/Google accounts + E2E sync.
+- [Android App (Embedded Server)](mobile.md) — The Capacitor + nodejs-mobile Android app: boot shell, first-run map fetch, self-update, the `android` release channel, and build pipeline.
+
+### Delivery
+- [Delivery, Deploy & Releases](delivery-and-deploy.md) — Full CI/release/deploy topology: build scripts, main/beta/alpha channels + PR-triplet, the release assets, the four workflows, `build:site`, the admin-panel deploy engine, and the Workers.

--- a/docs/ai-overview.md
+++ b/docs/ai-overview.md
@@ -1,0 +1,258 @@
+# AI System Overview
+
+Open Historia drives every generative feature — the strategy advisor, leader diplomacy, timeline simulation, catalysts, stat sheets, and the game‑master console — through a single browser‑side AI layer under `src/Game/AI/`. The player's own API key talks **directly** to their chosen provider from the browser; there is no Open Historia backend in the loop except an optional same‑origin relay that only exists when the page is served from a machine the player controls. Two entry points sit on top of the transport: `callAI` for free‑form chat, and `runJsonTask` for schema‑validated structured "tasks" that mutate world state.
+
+This page documents the plumbing. For the prompt templates and how they are assembled, see [AI prompts](ai-prompts.md); for the JSON tool/response schemas and per‑field meaning, see [AI schemas](ai-schemas.md); for what the applied changes touch, see [World state](world-state.md).
+
+---
+
+## Module map
+
+| File | Responsibility |
+|------|----------------|
+| `src/Game/AI/main.jsx` | Transport. `callAI` dispatch, per‑provider callers, `providerFetch`/relay, streaming reassembly, advisor + diplomatic chat (`sendMessage`, `sendDiplomaticMessage`). |
+| `src/Game/AI/providerConfig.js` | Provider registry, per‑provider storage keys/defaults, `getStoredProvider`, `getProviderSettings`, reasoning toggle. |
+| `src/Game/AI/gameplay.js` | `runJsonTask` task runner + every gameplay task (jumps, catalysts, actions, GM, stat sheets, consolidation, idle diplomacy), validation/salvage, and applying results to world state. |
+| `src/Game/AI/gameplaySchemas.js` | JSON Schemas, tool definitions, `getGameplayTool`, `validateGameplayPayload`. See [AI schemas](ai-schemas.md). |
+| `src/Game/AI/gameplayPrompts.js`, `promptContext.js`, `defaultPrompts.json`, `gameplayPrompts.js` | Prompt pack normalization + template rendering. See [AI prompts](ai-prompts.md). |
+
+---
+
+## Supported providers
+
+Defined in `PROVIDER_OPTIONS` at `src/Game/AI/providerConfig.js:4`. The selected provider is stored under the `api_provider` localStorage key and resolved by `getStoredProvider()` (`providerConfig.js:132`); `normalizeProvider` maps the legacy value `"custom"` → `"openai-compatible"` and falls back to `DEFAULT_PROVIDER` (`"gemini"`) for anything unknown.
+
+| `value` | Label | Group | Caller (`main.jsx`) | Endpoint | Transport | Model discovery |
+|---------|-------|-------|---------------------|----------|-----------|-----------------|
+| `gemini` | Gemini | Native APIs | `callGemini` (`main.jsx:460`) | `generativelanguage.googleapis.com/v1beta` (hard‑coded, key in query) | **direct only** (`fetch`) | no |
+| `openai` | OpenAI | Native APIs | `callOpenAI` → `callOpenAIStyleChatCompletions` (`main.jsx:702`) | `https://api.openai.com/v1` | `providerFetch` (direct, relay if local) | yes |
+| `anthropic` | Anthropic | Native APIs | `callAnthropic` (`main.jsx:770`) | `https://api.anthropic.com/v1` | **direct only** (`fetch`, browser‑access opt‑in header) | no |
+| `openai-compatible` | OpenAI Compatible | Gateways & self‑hosted | `callOpenAICompatible` (`main.jsx:736`) | user `endpoint` (default `http://localhost:11434/v1`) | `providerFetch` | yes |
+| `anthropic-compatible` | Anthropic Compatible | Gateways & self‑hosted | `callAnthropicCompatible` (`main.jsx:858`) | user `endpoint` | `providerFetch` | no |
+
+`callAI` (`main.jsx:942`) is the single switch over `getStoredProvider()`; `gemini` is the `default` branch. Before dispatch it appends a language directive (`languageDirective()`, [i18n](i18n.md)) so replies come back in the player's language at the source.
+
+"OpenAI Compatible" is the catch‑all for Ollama, LM Studio, OpenRouter, vLLM, and other gateways speaking `/chat/completions`. "Anthropic Compatible" is a self‑hosted proxy speaking the Anthropic Messages API. Both share their native sibling's caller body but read a different settings namespace and are relay‑capable.
+
+---
+
+## Configuration & storage keys
+
+All AI config lives in **browser `localStorage`** — never on a server. `PROVIDER_SETTINGS` (`providerConfig.js:42`) maps each provider's fields to their storage keys. Read via `getProviderSettings(provider)` (`providerConfig.js:157`), which always returns `{ provider, apiKey, endpoint, model, customParams }` (missing fields resolve to `""`).
+
+| Provider | apiKey key | model key (default) | endpoint key (default) | customParams key |
+|----------|-----------|---------------------|------------------------|------------------|
+| `gemini` | `gemini_api_key` | `gemini_model` (`gemini-3.1-flash-lite-preview`) | — | `gemini_custom_params` |
+| `openai` | `openai_api_key` | `openai_model` (`""` → discovery) | — (fixed) | `openai_custom_params` |
+| `anthropic` | `anthropic_api_key` | `anthropic_model` (`claude-haiku-4-5`) | — (fixed) | `anthropic_custom_params` |
+| `openai-compatible` | `openai_compatible_api_key` | `openai_compatible_model` (`""`) | `openai_compatible_endpoint` (`http://localhost:11434/v1`) | `openai_compatible_custom_params` |
+| `anthropic-compatible` | `anthropic_compatible_api_key` | `anthropic_compatible_model` (`claude-haiku-4-5`) | `anthropic_compatible_endpoint` (`""`) | `anthropic_compatible_custom_params` |
+
+Notes:
+- **Legacy keys**: `openai-compatible` `endpoint`/`model` fall back to the pre‑rename `custom_api_endpoint`/`custom_api_model` keys (`readStoredValue`, `providerConfig.js:109`).
+- **Settings‑form binding**: the settings UI reads/writes via `FORM_FIELD_MAP` (`providerConfig.js:85`), `loadProviderSettingsFormState()`, and `persistProviderSetting()`.
+- **Default model constants** live in `main.jsx` too: `GEMINI_DEFAULT_MODEL` (`main.jsx:23`), `ANTHROPIC_DEFAULT_MODEL` (`main.jsx:24`), used as `resolveModel` fallbacks.
+
+### `customParams` — the request‑body escape hatch
+
+Each provider has a free‑text `customParams` field: a JSON object shallow‑merged **last** into the outgoing request body (`parseCustomParams`, `main.jsx:105`). It lets a player set body fields the UI doesn't expose (reasoning budgets, sampling params) and can override a built‑in key. Invalid JSON is warned and ignored — never fatal to a turn. A nested built‑in object (e.g. Gemini `generationConfig`) must be supplied whole to override any of its keys. For Anthropic, a `max_tokens` inside `customParams` is lifted into the token‑cap `Math.max` and then deleted so it can't fight the floor (`main.jsx:803`, `main.jsx:892`).
+
+### Reasoning toggle
+
+A single global toggle (`ai_reasoning_enabled` key) is read by `getReasoningEnabled()` (`providerConfig.js:174`). **On by default** — only an explicit `"0"` disables it, so a fresh install gets model reasoning without opting in. `callAI` honors it in every provider mode:
+
+| Provider mode | Reasoning knob when ON | Source |
+|---------------|------------------------|--------|
+| Gemini | `generationConfig.thinkingConfig.thinkingBudget: 8192` | `main.jsx:490` |
+| OpenAI / compatible | `reasoning_effort: "medium"` (sent in every mode incl. tool calls) | `main.jsx:594` |
+| OpenAI compatible, local | additionally `enable_thinking: true` (Qwen3/Seed‑OSS local template key) | `main.jsx:601` |
+| Anthropic / compatible | `thinking: { type: "enabled", budget_tokens: 4096 }` (only when **not** a tool call), `max_tokens` raised to fit | `main.jsx:811`, `main.jsx:900` |
+
+If a provider rejects `tools` + `reasoning_effort` together (documented 400/422), the OpenAI‑style caller retries once with reasoning stripped (`disableToolReasoning`, `main.jsx:637`), then sends `reasoning_effort: "none"` in tool mode.
+
+---
+
+## Where the key goes: direct calls, origin, and the relay
+
+The whole security model is in the comment block at `main.jsx:225`. AI calls go **straight from the browser to the provider** so the player's key only ever reaches the provider — never an Open Historia server or a community node. Direct is always tried first.
+
+- **`PAGE_IS_LOCAL`** (`main.jsx:250`, from `isLocallyServed()`): true when the page is served from a machine the player controls — `localhost`/`127.0.0.1`/`::1`/`*.local` or the LAN private ranges `10.*`, `192.168.*`, `172.16–31.*`. The LAN ranges cover the Android client, which loads the UI from a local server on the home network.
+- **`providerFetch(url, options)`** (`main.jsx:303`): tries `directFetch`; on a CORS/network `TypeError` (not an abort) **and** only when `PAGE_IS_LOCAL`, it remembers the origin in `relayOnlyOrigins` and retries through the same‑origin `/api/ai/relay` (`relayFetch`, `main.jsx:284`). A remembered origin skips the doomed direct attempt on later calls.
+- On a **hosted website** there is no relay: every call is direct‑only and the key is never handed to anything but the provider. If a hosted page tries to reach a **local** backend (Ollama/LM Studio) and the browser rejects it, `providerFetch` throws an actionable error telling the user to set `OLLAMA_ORIGINS`/enable CORS (`main.jsx:321`).
+- **Who uses the relay**: only the `providerFetch` callers — `openai`, `openai-compatible`, `anthropic-compatible`, and model discovery (`GET /models`). **Native Gemini and native Anthropic bypass `providerFetch` entirely** (plain `fetch`), because both explicitly allow browser calls (Anthropic via the `anthropic-dangerous-direct-browser-access: true` header, `main.jsx:795`). They are therefore always direct, relay or not.
+
+`isLocalEndpoint(url)` (`main.jsx:269`) is the per‑endpoint sibling of `PAGE_IS_LOCAL`; it also gates local streaming (below).
+
+---
+
+## Model resolution
+
+`resolveModel(provider, opts)` (`main.jsx:413`) picks the model for a call:
+
+1. A configured `model` in settings wins (Gemini strips a `models/` prefix).
+2. Else the caller's `fallbackModel` (Gemini/Anthropic native/compatible defaults).
+3. Else, if `providerSupportsModelDiscovery(provider)` (only `openai` and `openai-compatible`, `providerConfig.js:141`), `GET {endpoint}/models` and pick a likely chat model via `pickLikelyChatModel` (`main.jsx:122`) against `CHAT_MODEL_HINTS`/`NON_CHAT_MODEL_HINTS` (`main.jsx:28`). The discovered id is persisted back with `setProviderField`.
+4. Else throw a "go to settings and enter a model/endpoint" error.
+
+---
+
+## Request flow: UI action → provider → applied world change
+
+Two shapes of call sit on the transport.
+
+### A. Structured gameplay task (the map‑changing path)
+
+```
+UI control (e.g. "Jump forward", GM console, "Suggest actions")
+  → gameplay.js exported fn (simulateTimelineJump / applyGameMasterCommand / …)
+     → readGameStateBundle() + buildTemplateVariables()      [read world/events/actions/chats]
+     → runJsonTask(taskKey, { userMessage, variables, validatePayload, fallback, … })
+        → renderTemplate(promptPack.tasks[taskKey], vars) + difficulty/agency/map-truth/reputation directives
+        → tool = getGameplayTool(taskKey)
+        → callAI(systemPrompt, [{role:user, parts:[{text:userMessage}]}], { tool, maxTokens:8192, deadline, signal })
+           → per-provider caller → providerFetch/fetch → provider
+        → parse (toolInput ?? extractJsonPayload) → validateGameplayPayload(schema) → validatePayload(strict|salvage)
+        → up to 2 output attempts; else deterministic fallback() (or throw / propagate abort)
+  → applySimulationResult() / applyEventImpactsToWorld() → writeWorldState/… + rollback snapshot
+```
+
+Every task entry point wraps itself in `beginSimulation()`/`endSimulation()` (`gameplay.js:628`) — a busy lock so the idle‑diplomacy drip never writes chat state mid‑jump.
+
+### B. Free‑form chat (advisor / diplomacy)
+
+`sendMessage` (`main.jsx:1084`) and `sendDiplomaticMessage` (`main.jsx:1138`) build a system prompt, push the user turn onto a module‑level history (`advisorHistory` / `diplomaticHistory`, compacted by `compactConversationHistory` at `main.jsx:1070`), call `callAI` **without a `tool`** (plain text reply), and append the reply. On error the pushed user turn is popped so history isn't corrupted. `startChat`/`loadHistory`/`startDiplomaticChat`/`loadDiplomaticHistory` manage those histories. Diplomatic replies may carry a trailing `REACTION:<emoji>` line parsed off by `parseReaction` (`main.jsx:1130`).
+
+---
+
+## Transport internals per provider
+
+`callAI` (`main.jsx:942`) → one of five callers. Shared retry/abort machinery:
+
+- **Retries**: `retries = 3`, `retryDelay = 15000` ms. Retried on `429`/`503` (Gemini treats `429` as fatal "quota exhausted", `main.jsx:509`). Guarded by `canRetryBeforeDeadline(deadline, retryDelay)` (`main.jsx:67`) so a retry that would overrun the deadline is not attempted.
+- **Abort**: an `AbortSignal` (`signal`) propagates from `runJsonTask`'s controller through the caller to `fetch`/relay. An `AbortError` never triggers the relay fallback and never falls back to canned events (see [Cancellation](#cancellation--timeouts)).
+- **Errors**: `readErrorPayload`/`extractErrorMessage` (`main.jsx:78`) surface the provider's own message.
+
+### Structured output modes (per provider)
+
+`callAI` passes `tool` (a `{ name, description, schema }` from `getGameplayTool`) for structured tasks. Each provider forces exactly that one tool:
+
+| Provider | Forcing mechanism | Extractor |
+|----------|-------------------|-----------|
+| Gemini | `tools.functionDeclarations` + `toolConfig.functionCallingConfig.mode: "ANY"`, `allowedFunctionNames:[tool.name]`; schema stripped of `additionalProperties`/`$schema` via `toGeminiSchema` | `extractGeminiToolInput` (`main.jsx:148`) |
+| OpenAI / compatible | `tools:[{type:"function",…}]` + `tool_choice: "required"` (string form — llama.cpp servers reject the object form, `main.jsx:611`) | `extractOpenAIToolInput` (`main.jsx:176`) |
+| Anthropic / compatible | `tools:[{name,…,input_schema}]` + `tool_choice:{type:"tool",name}` | `extractAnthropicToolInput` (`main.jsx:205`) |
+
+The OpenAI‑style caller runs a **`structuredMode` state machine** (`main.jsx:563`): `tool` → on 400/422, either strip reasoning, or (only when `allowJsonSchemaFallback`, i.e. **compatible only**) fall through `json_schema` → `json_object` → `text_json` (schema inlined into the system prompt). Native OpenAI keeps `allowJsonSchemaFallback: false` (`main.jsx:730`) and stays in tool mode. Each caller returns either a plain string (chat) or `{ rawText, toolInput }` (structured).
+
+### Streaming vs buffered
+
+Cloud providers use a **buffered** path (`await response.json()`). **Streaming is used only for local OpenAI‑compatible endpoints**, and only to make Cancel physical:
+
+- `streamLocalEndpoint = isLocalEndpoint(endpoint)` (`main.jsx:575`). When true, `stream: true` is added to the body (`main.jsx:583`). Local inference servers (llama.cpp, LM Studio, Ollama) only notice a dead socket on their next token write; without streaming a cancelled non‑streaming request keeps generating the whole completion. Streaming makes the next token write fail, stopping inference within a token or two.
+- The response is branched on the **actual** `content-type`, not on what was asked: `text/event-stream` → `readOpenAIStreamedResponse` (`main.jsx:343`), else `response.json()` (`main.jsx:681`). `readOpenAIStreamedResponse` reassembles SSE `data:` deltas (content + `tool_calls` arguments + `finish_reason`) back into a normal chat‑completions object so the existing extractors work unchanged.
+- Anthropic‑compatible does **not** stream even when local; Gemini and native Anthropic never stream.
+
+### maxTokens / token‑cap semantics
+
+`runJsonTask` always passes `maxTokens: 8192` (`gameplay.js:455`) — one request budget for every task. What each provider does with it:
+
+| Provider | Body field | Value actually sent | Notes |
+|----------|-----------|---------------------|-------|
+| Gemini | *(none)* | not sent | Gemini ignores the cap entirely; no `maxOutputTokens` unless supplied via `customParams`. |
+| OpenAI | `max_completion_tokens` | `Math.max(8192, maxTokens)` | `tokenLimitField: "max_completion_tokens"` (`main.jsx:731`). |
+| OpenAI compatible | `max_tokens` | `Math.max(8192, maxTokens)` | `tokenLimitField: "max_tokens"` (`main.jsx:765`). |
+| Anthropic | `max_tokens` (required) | `Math.max(8192, maxTokens, customParams.max_tokens)` | raised further when extended thinking is on so `max_tokens` exceeds the 4096 thinking budget (`main.jsx:803`). |
+| Anthropic compatible | `max_tokens` | same as Anthropic | `main.jsx:892`. |
+
+So `maxTokens` is a **per‑response output ceiling only for providers that take one**, floored at 8192; capped providers are floored, Gemini ignores it. This is why jump tasks stopped requesting 16384 — it only raised the ceiling on capped providers and changed nothing on Gemini.
+
+---
+
+## The task runner: `runJsonTask`
+
+`runJsonTask(taskKey, { fallback, signal, timeoutMs, userMessage, validatePayload, variables })` (`gameplay.js:382`) is the structured‑generation core. Steps:
+
+1. **Prompt assembly**: `renderTemplate(prompts.tasks[taskKey], { …variables, …helpers })`, then append call‑time directives: `difficultyDirective` for all tasks; `[Player Agency]` + `[Map Truth]` for `jumpForward`/`autoJumpForward` (`gameplay.js:411`); `[International Reputation]` for `actions`/jumps/catalyst tasks (`gameplay.js:425`). These are appended **at call time** because each save carries its own frozen copy of the prompts — a `defaultPrompts.json` edit never reaches existing campaigns.
+2. **Deadline/abort wiring**: an internal `AbortController` is aborted by (a) the external `signal` (player Cancel) or (b) a `timeoutMs` timer (`gameplay.js:441`). `timeoutMs` default is 120000 ms; jumps pass `0` (no deadline) unless the "Limit AI generation" map setting opts into a 5‑minute bound (`gameplay.js:1888`).
+3. **Two output attempts** (`gameplay.js:447`): call `callAI` with the task `tool` and `maxTokens: 8192`; parse `response.toolInput ?? extractJsonPayload(rawText)`; run `validateGameplayPayload(taskKey, parsed)` (schema) then the caller's `validatePayload`. On attempt‑1 failure it pushes the model's answer + a corrective instruction into `history` and retries once. A model that used a tool is told to "call it again"; a prose model is told to "respond with ONLY the corrected JSON".
+4. **Outcome**: valid → `{ generation:{source:"ai"}, payload }`. Both attempts fail → deterministic `fallback()` with `generation.source:"fallback"` and the `failureReason`. No `fallback` → throw. A user **abort** is re‑thrown, never falling back (`gameplay.js:513`).
+
+### `extractJsonPayload` — tolerant parsing
+
+`extractJsonPayload` (`gameplay.js:284`) is what makes small/local models usable without tool support: strips `<think>…</think>` blocks, tries a lenient parse (`lenientJsonParse` repairs smart quotes and trailing commas, `gameplay.js:230`), then any ```` ``` ```` fenced block, then every balanced top‑level `{…}`/`[…]` via a string‑aware scan (`balancedJsonCandidates`, `gameplay.js:243`), objects preferred over stray arrays. Repairs are attempted **only after** a strict parse fails, so well‑formed output is untouched.
+
+---
+
+## Task catalog
+
+`taskKey` → schema (`GAMEPLAY_SCHEMAS`, `gameplaySchemas.js:621`) → tool (`GAMEPLAY_TOOLS`, `gameplaySchemas.js:717`). Exported callers in `gameplay.js`:
+
+| taskKey | Tool name | Exported fn (`gameplay.js`) | Purpose / applied to |
+|---------|-----------|-----------------------------|----------------------|
+| `jumpForward` | `submit_jump_result` | `simulateTimelineJump({mode:"jump"})` (`:1852`) | Advance to a target date; events + impacts + catalyst → world state. |
+| `autoJumpForward` | `submit_jump_result` | `simulateAutoJump` (`:1946`) | Advance to the next notable moment. |
+| `actions` | `submit_actions` | `generateActionSuggestions` (`:1430`) | Strategic suggestion topics for the player. |
+| `descriptionToAction` | `submit_description_to_action` | `refinePlayerAction` (`:1597`) | Freeform intent → structured action/chat. |
+| `nextSpeaker` | `submit_next_speaker` | `chooseNextDiplomaticSpeaker` (`:1630`) | Pick next chat participant. |
+| `eventConsolidator` | `submit_event_consolidation` | `consolidateRecentHistory` / auto `compactHistoryIfNeeded` (`:1662`, `:554`) | Compress old events/chats into a continuity summary. |
+| `catalystCreation` | `submit_catalyst_creation` | `createCatalyst` (`:1670`) | Open an interactive decision scene. |
+| `catalystExecutor` | `submit_catalyst_execution` | `advanceActiveCatalyst` (`:1701`) | Resolve a catalyst choice. |
+| `catalystSummary` | `submit_catalyst_summary` | (within catalyst resolution, `:1775`) | Final event from a resolved catalyst. |
+| `gameMaster` | `submit_game_master` | `applyGameMasterCommand` (`:1949`) | GM console: apply free‑text world/map edits. |
+| `countryStatSheet` | `submit_country_stat_sheet` | `generateCountryStatSheet` / `generateCountryStats` (`:1580`, `:1551`) | National statistics sheet. |
+| `idleDiplomacy` | `submit_idle_diplomacy` | `maybeSendIdleDiplomacy` (`:2128`) | Optional unprompted diplomatic note. |
+| `pregameHistory` | `submit_pregame_history` | `maybeGeneratePregameHistory` (`:2050`) | Backstory events before the start date. |
+
+---
+
+## Strict / salvage validation discipline
+
+Two validation layers run on a parsed payload; the second is where the strict/salvage contract lives.
+
+1. **Schema** — `validateGameplayPayload(taskKey, parsed)` (`gameplaySchemas.js:852`) checks the payload against `GAMEPLAY_SCHEMAS[taskKey]` with a hand‑rolled validator (types, `enum`, `minLength`/`minItems`/`maxItems`, `required`, `additionalProperties:false`). See [AI schemas](ai-schemas.md).
+
+2. **Semantic `validatePayload(candidate, { attempt, finalAttempt })`** — the caller‑supplied validator. The **`finalAttempt` flag comes from `runJsonTask` itself** (`gameplay.js:474`), never from counting invocations — a schema failure on attempt 1 skips this validator, which would otherwise make attempt 2 look "first" and leak strict feedback out as the fallback reason (a real field report). The contract:
+
+   - **Attempt 1 (`strict = !finalAttempt`)**: shape problems return a **corrective error string**, which `runJsonTask` feeds back to the model as its one retry — the model usually fixes its own answer.
+   - **Attempt 2 (final)**: a finished generation is **never rejected into the canned fallback** over cosmetics. Instead the payload is **salvaged in place**: dates clamped, unresolvable ops dropped, invalid entries pruned.
+
+   The jump validator (`gameplay.js:1897`) shows all three: strict event‑count check → `validateTimelineDates` (strict) vs `clampTimelineDates` (salvage, `gameplay.js:187`) → `validateGeneratedWorldChanges` with `strictTransfers: strict`.
+
+   `validateGeneratedWorldChanges` (`gameplay.js:1002`) is the map‑integrity gate:
+   - **Region transfers**: `resolveRegionTransfers` (`gameplay.js:831`) canonicalizes each `regionId` — the prompt asks for a region's plain **name**, which must be resolved to a real map id (e.g. `DEU.2_1`) via the region catalog, owner‑aware for repeated names. Strict: unresolved names **fail** with the losing owner's real region list (`buildTransferFeedback`, `gameplay.js:940`) so the retry has the vocabulary; final: unresolved transfers are dropped (a phantom key never reaches world state).
+   - **Reluctance guard** (strict only): an event whose text uses capture language (`CAPTURE_LANGUAGE`, `gameplay.js:994`) while the whole payload ships **zero** `regionTransfers` fails once — narration and the map must never disagree.
+   - **Unit ops / marker ops / created chats / outreach**: each validated per entry; strict returns a path‑anchored error, salvage drops the bad entry (stale `unitId`, blank marker name, unresolvable chat participants) and keeps the turn.
+
+---
+
+## Applying world changes
+
+Once a payload is accepted (region ids already canonicalized in place), the exported task functions write it back:
+
+- **Jumps**: `applySimulationResult` (`gameplay.js:1305`) normalizes events, advances `gameDate`/`round`, resolves planned actions to `resolved`, runs `applyEventImpactsToWorld` (from `runtime/gameState.js` — region ownership, polity changes, units, markers, colors), builds chats from `impacts.createdChats` + top‑level `diplomaticOutreach` via `buildGeneratedChat` (`gameplay.js:762`), optionally consolidates history, writes all state slices, and captures a rollback snapshot (`loadRollbackSnapshots`/`rollBackToSnapshot`, `gameplay.js:1278`).
+- **GM command**: `applyGameMasterCommand` (`gameplay.js:1949`) turns the payload into a single GM event and applies its impacts the same way.
+- The `generation` object (`{ source: "ai" | "fallback", fallbackReason }`) rides along into `simulationHistory` so the UI can show whether a turn was AI‑ or fallback‑generated.
+
+See [World state](world-state.md) for the shape of what these writers touch, and [Game state persistence](game-state.md) for the read/write bundle helpers.
+
+---
+
+## Cancellation & timeouts
+
+- **Player Cancel** passes an `AbortSignal` into `simulateTimelineJump`/etc → `runJsonTask` → `callAI` → `fetch`/relay. A deliberate cancel is re‑thrown as an `AbortError` and **does not** write state or fall back to canned events (`gameplay.js:513`).
+- **Timeout** (`timeoutMs`) aborts the same controller but **does** use the deterministic fallback, because a slow model shouldn't leave the turn with nothing. Jumps default to no timeout (wait as long as the model needs); the "Limit AI generation" setting imposes 5 minutes.
+- **Conversational** `callAI` callers accept an `opts.signal` too (advisor/diplomacy Stop button); on abort the just‑pushed history entry is popped.
+
+---
+
+## Quick reference: key exports
+
+| Symbol | File | Role |
+|--------|------|------|
+| `callAI(systemPrompt, history, opts)` | `main.jsx:942` | Provider dispatch; returns string (chat) or `{rawText,toolInput}` (structured). |
+| `sendMessage`, `sendDiplomaticMessage` | `main.jsx:1084`, `:1138` | Advisor / leader chat turns. |
+| `readOpenAIStreamedResponse` | `main.jsx:343` | SSE → chat‑completions reassembly (local streaming). |
+| `getStoredProvider`, `getProviderSettings`, `getReasoningEnabled` | `providerConfig.js:132`, `:157`, `:174` | Read selected provider / its settings / reasoning toggle. |
+| `runJsonTask(taskKey, opts)` | `gameplay.js:382` | Structured task runner (2 attempts, validate/salvage, fallback). |
+| `simulateTimelineJump`, `applyGameMasterCommand`, `generateActionSuggestions`, … | `gameplay.js` | Task entry points (see [catalog](#task-catalog)). |
+| `getGameplayTool`, `validateGameplayPayload` | `gameplaySchemas.js:733`, `:852` | taskKey → tool, payload schema check. See [AI schemas](ai-schemas.md). |

--- a/docs/ai-prompts.md
+++ b/docs/ai-prompts.md
@@ -1,0 +1,352 @@
+# Prompt-Making Guide
+
+Every LLM call the game makes is a template in `src/Game/AI/defaultPrompts.json` filled with runtime game state, then hardened by call-time directives, then validated against a JSON Schema tool. This page is the single reference for anyone editing prompts: it enumerates every `${PLACEHOLDER}`, every template variable and where it is computed, every AI task and its output schema, exactly how a final prompt is assembled, how prompts are overridden per scenario, and how to add a new variable or task. When in doubt, the code paths are all in `src/Game/AI/` and `src/runtime/`.
+
+---
+
+## 1. File map — where everything lives
+
+| Concern | File | Notes |
+|---|---|---|
+| Task + root prompt text; `${PLACEHOLDER}`→`${var}` helper map | `src/Game/AI/defaultPrompts.json` | Built-in defaults, bundled with the app |
+| Prompt-pack normalization, editor section list, task-key list | `src/Game/AI/gameplayPrompts.js` | `normalizePromptPack`, `serializePromptPack`, `PROMPT_SECTION_DEFINITIONS` |
+| Context builders (world summary, histories, units, cities) | `src/Game/AI/promptContext.js` | `buildPromptContext`, `buildWorldSummary`, `renderTemplate`, `resolveHelperValues` |
+| Task runner, call-time directives, validators, fallbacks, task entry points | `src/Game/AI/gameplay.js` | `runJsonTask`, `buildTemplateVariables`, `simulateTimelineJump`, etc. |
+| JSON Schemas + tools + payload validator | `src/Game/AI/gameplaySchemas.js` | `GAMEPLAY_SCHEMAS`, `GAMEPLAY_TOOLS`, `validateGameplayPayload` |
+| Provider dispatch, `callAI`, advisor/leader assembly | `src/Game/AI/main.jsx` | `callAI`, `buildAdvisorSystemPrompt`, `buildDiplomaticSystemPrompt` |
+| Language directive (appended to *every* call) | `src/runtime/i18n.js` | `languageDirective` at line 137 |
+| Difficulty directive (appended to task + leader prompts) | `src/runtime/difficulty.js` | `difficultyDirective` at line 73 |
+| Where the active game's prompt overrides are read from | `src/runtime/assets.js:268` | `JSON_URLS.prompts = /api/runtime/json/prompts` |
+| Per-scenario prompt editor UI ("Prompts" tab) | `src/Game/GameUI/libraryBar.jsx` | `handlePromptChange`, `serializePromptPack` on save |
+
+See [World state](world-state.md) for the `world.json` shapes (`regionOwnershipOverrides`, `polityOverrides`, `units`, `markers`, `activeCatalyst`, `consolidatedHistory`, `simulationHistory`) that the context builders read.
+
+---
+
+## 2. The three prompt "kinds" and how they are stored
+
+`defaultPrompts.json` has exactly three top-level buckets:
+
+| Kind | JSON key | Contains | Rendered by |
+|---|---|---|---|
+| Root: **advisor** | `advisor` (string) | Chief-advisor side-panel chat | `buildAdvisorSystemPrompt` (`main.jsx:1012`) |
+| Root: **leader** | `leader` (string) | AI diplomacy — polities replying in a chat | `buildDiplomaticSystemPrompt` (`main.jsx:1036`) |
+| **tasks** | `tasks.<key>` (strings) | 13 structured JSON tasks (below) | `runJsonTask` (`gameplay.js:382`) |
+| Helper map | `helpers` (object) | `${PLACEHOLDER}` → `${templateVar}` indirection | `resolveHelperValues` (`promptContext.js:23`) |
+
+### Override / storage model
+
+- The bundled `defaultPrompts.json` is the fallback. The **active game** may ship its own `prompts` asset, served at `JSON_URLS.prompts` (`/api/runtime/json/prompts`). Both `runJsonTask` (via `loadPromptCatalog`, `gameplay.js:310`) and the advisor/leader path (via `ensurePromptsLoaded`, `main.jsx:969`) read it.
+- `normalizePromptPack` (`gameplayPrompts.js:232`) merges **per key with fallback**: for every task key in `PROMPT_TASK_KEYS`, an override is used only if it is a non-blank string, else the default. Same for `advisor`, `leader`, and each `helpers` entry. A partial override (one task) leaves all others at default.
+- Scenarios persist overrides under `details.data.prompts`. The library "Prompts" editor writes them: root sections write `prompts[key]`, task sections write `prompts.tasks[key]`, helpers write `prompts.helpers[key]` (`libraryBar.jsx:1426`), and `serializePromptPack` flattens on save (`gameplayPrompts.js:255`).
+- `PROMPT_SECTION_DEFINITIONS` (`gameplayPrompts.js:15`) drives the editor UI: one entry per editable section with a `label`, `type` (`root` | `task`), and a **declared** `helpers` list. Note two mismatches with the runtime: `idleDiplomacy` is a real task but has **no editor section** (not user-editable in the UI, still overridable via `prompts.tasks.idleDiplomacy`), and the declared helper lists are hints — some listed placeholders (e.g. `CONSOLIDATED_HISTORY`, `PLAYER_POLITY_REPUTATION_CONTEXT`) are **not** referenced by the current default text.
+
+### ⚠️ Frozen-prompt caveat (read this before adding a rule to defaultPrompts.json)
+
+**Existing campaigns carry a frozen copy of the task prompts.** A game created before your edit keeps whatever prompt text it was seeded with; editing `defaultPrompts.json` only affects games that read the default (no override) or new scenarios. This is *the* reason several critical rules are **appended at call time in `runJsonTask`** instead of living in the JSON (see §6): Player Agency, Map Truth, and International Reputation reach old games only because they are concatenated onto the system prompt every call. If a rule must apply retroactively to all campaigns, append it in code, not in `defaultPrompts.json`.
+
+---
+
+## 3. How a final prompt is assembled, end to end
+
+### 3a. Task path (`runJsonTask`, `gameplay.js:382`)
+
+Order of concatenation onto the system prompt:
+
+1. **Load pack** — `loadPromptCatalog()` → `normalizePromptPack(readJson(JSON_URLS.prompts))` (per-key override or default).
+2. **Resolve helpers** — `helperValues = resolveHelperValues(prompts.helpers, variables)` (`promptContext.js:23`). Two passes so a helper that references another helper resolves.
+3. **Render task text** — `systemPrompt = renderTemplate(prompts.tasks[taskKey], { ...variables, ...helperValues })` (`gameplay.js:392`). `renderTemplate` (`promptContext.js:17`) replaces `${key}` with `variables[key]` (missing/`null` → empty string). Both uppercase `${PLACEHOLDER}` keys (from `helperValues`) and lowercase `${var}` keys (from `variables`) are in scope.
+4. **+ Difficulty directive** — `\n\n${difficultyDirective(game.difficulty)}` for every task (`gameplay.js:400`).
+5. **+ Player Agency** and **+ Map Truth** — only `jumpForward`, `autoJumpForward` (`gameplay.js:411`–`420`).
+6. **+ International Reputation** — only `actions`, `jumpForward`, `autoJumpForward`, `catalystCreation`, `catalystExecutor` (`gameplay.js:425`).
+7. **Call `callAI(systemPrompt, [{role:"user", parts:[{text: userMessage}]}], { tool, maxTokens: 8192, ... })`.** Inside `callAI` (`main.jsx:942`): **+ Language directive** `\n\n${languageDirective()}` when the UI language ≠ English.
+8. **Provider layer** (`main.jsx`): native tool-use providers (Anthropic/OpenAI/Gemini) pass `tool.schema` as a tool; the JSON-schema fallback path appends `\n\nReturn only one JSON object matching this JSON Schema…\n${JSON.stringify(tool.schema)}` (`main.jsx:573`). `maxTokens` is floored at 8192 by capped providers; Gemini ignores it.
+
+So the final task system prompt is:
+
+```
+<rendered task text>
+\n\n<difficulty directive>
+[\n\n[Player Agency]…\n\n[Map Truth]…]        (jump tasks only)
+[\n\n[International Reputation]…]              (5 tasks only)
+\n\n<language directive>                        (non-English only)
+[\n\n Return only one JSON object … <schema>]  (json-schema fallback providers only)
+```
+
+Retry (`gameplay.js:447`): each task gets **two output attempts**. On attempt-1 failure the model's raw answer plus a corrective user turn are appended to `history`, and attempt 2 runs against the same system prompt. `validatePayload` receives `{ attempt, finalAttempt }`; `finalAttempt` (attempt 2) switches validators from *strict* (return a corrective string) to *salvage* (repair in place). If both attempts fail, the deterministic `fallback()` runs (or, for tasks with no fallback, it throws). A user `signal` abort propagates and cancels rather than falling back.
+
+### 3b. Advisor / leader path (`main.jsx`)
+
+These do **not** go through `runJsonTask` or `buildTemplateVariables`; they build variables directly from `buildPromptContext` (`buildPromptVariables`, `main.jsx:989`, with `eventLimit: 16`).
+
+- **Advisor** (`buildAdvisorSystemPrompt`, `main.jsx:1012`): `renderTemplate(promptPack.advisor, { ...variables, ...helperValues })` → `callAI` (language directive only). No difficulty, no schema (free-form text reply). Called by `sendMessage` (`main.jsx:1084`) with a rolling `advisorHistory`.
+- **Leader** (`buildDiplomaticSystemPrompt`, `main.jsx:1036`): `renderTemplate(promptPack.leader, …)` **+ `\n\n${difficultyDirective}`** (`main.jsx:1063`). Then `sendDiplomaticMessage` (`main.jsx:1138`) appends a per-turn user instruction telling the model to speak as one specific polity and optionally emit a trailing `REACTION:<emoji>` line (`main.jsx:1144`), which `parseReaction` strips. `callAI` adds the language directive.
+
+Because the advisor/leader path skips `buildTemplateVariables`, `playerPolityReputationContext` is empty and the military-feasibility doctrine (§5) is **not** appended to their unit text.
+
+---
+
+## 4. Placeholder → variable helper map
+
+`defaultPrompts.json` → `helpers`. Task/root text uses the uppercase `${PLACEHOLDER}`; the helper maps it to a lowercase `${var}` computed in `buildPromptContext`. "Used by" lists the prompts whose **default text** actually contains the placeholder.
+
+| `${PLACEHOLDER}` | → template var | Inserts | Used by (default text) |
+|---|---|---|---|
+| `PLAYER_POLITY` | `playerPolity` | Player polity name (`game.country`) | nearly all |
+| `PLAYER_POLITY_REGIONS` | `playerPolityRegions` | Comma list of regions the player owns, or the LANDLESS notice | advisor |
+| `PLAYER_POLITY_BATTALION_SUMMARIES` | `playerBattalionSummaries` | Player + world unit lines (no feasibility doctrine) | advisor |
+| `PLAYER_POLITY_REPUTATION_CONTEXT` | `playerPolityReputationContext` | "International reputation: N/100 (band)." | *(none — injected via the [International Reputation] directive, not the placeholder)* |
+| `PLAYER_ACTIONS_THIS_ROUND` | `plannedActions` | Planned (unresolved) actions | advisor, actions, jumpForward, autoJumpForward, catalystCreation, gameMaster, descriptionToAction |
+| `PLAYER_EVERY_ACTION` / `PLAYER_EVERY_ACTION_NOT_PREVIOUS` | `allActions` | All actions incl. resolved | advisor, jumpForward, autoJumpForward |
+| `GRAND_MAP_DESCRIPTION` | `worldSummary` | Full world snapshot (see §5 `worldSummary`) | advisor, countryStatSheet |
+| `GRAND_MAP_DESCRIPTION_NO_CITY` | `worldSummaryNoCity` | **Identical string** to `worldSummary` (name is historical) | leader, actions, jumpForward, autoJumpForward, descriptionToAction, gameMaster, pregameHistory |
+| `CURRENT_UNITS` | `unitsSummary` | Deployed units **+ conditional military-feasibility doctrine** | jumpForward, autoJumpForward |
+| `CURRENT_MAP_STRUCTURES` | `markersSummary` | `world.markers` structures with coords | jumpForward, autoJumpForward |
+| `CITY_COORDINATES` | `citiesSummary` | City coordinate catalog (custom era set or stock significant slice) | jumpForward, autoJumpForward |
+| `NUMBER_OF_REGIONS` | `numberOfRegions` | Count of regions in the map catalog | jumpForward, autoJumpForward, gameMaster |
+| `WORLD_BEFORE_ROUND_ONE_TEXT` | `worldBeforeRoundOne` | Scenario "World Before Round One" briefing | advisor, leader, actions, jumpForward, autoJumpForward, catalyst×3, descriptionToAction, gameMaster, pregameHistory |
+| `HISTORICAL_PRESET_SIMULATION_RULES` | `simulationRules` | Scenario simulation rules | advisor, leader, countryStatSheet, actions, jump×2, catalyst×3, descriptionToAction, gameMaster, pregameHistory |
+| `ALL_EVENTS_WITH_CONSOLIDATION` | `recentEventsLong` | STORY SO FAR (consolidated) + RECENT EVENTS | leader, jumpForward |
+| `ALL_EVENTS_WITH_CONSOLIDATION_CATALYSTS` | `recentEventsLong` | Same value as above | advisor, actions, autoJumpForward, catalystCreation, catalystExecutor |
+| `CONSOLIDATED_HISTORY` | `consolidatedHistory` | Just the consolidated "STORY SO FAR" | *(declared in editor sections; not in current default text)* |
+| `PREVIOUS_ROUND_EVENTS` | `recentEvents` | Recent unconsolidated events (short window) | countryStatSheet, catalystCreation |
+| `NON_CONSOLIDATED_ROUNDS_WITH_DATES` | `recentRoundsWithDates` | `from → to` date pairs from `simulationHistory` | advisor, leader, actions, jumpForward, autoJumpForward |
+| `CHATS_NON_CONSOLIDATED_ROUNDS` | `chatHistoryLong` | Detailed multi-chat transcript | advisor, leader, actions, jumpForward, autoJumpForward |
+| `CHAT_PARTICIPANTS` | `chatParticipants` | Names of the current chat's participants | leader, nextSpeaker |
+| `THIS_CHAT_HISTORY` | `chatHistory` | The current chat's message lines | leader, nextSpeaker |
+| `THIS_CHATS_MOST_RECENT_SPEAKER` | `lastSpeaker` | Name of the last speaker (to exclude) | nextSpeaker |
+| `RESPONDING_POLITY_NAME` | `respondingPolityName` | Which polity the leader model should voice | leader |
+| `ALL_ADVISOR_MESSAGES` | `advisorMessages` | Prior advisor↔player transcript | advisor |
+| `ORIGIN_ROUND_DATE` | `date` | Current game date (`game.gameDate`, raw ISO/text) | leader, countryStatSheet, nextSpeaker, eventConsolidator, gameMaster, descriptionToAction |
+| `ORIGIN_ROUND_GRAMMATICAL_DATE` | `dateReadable` | Current date formatted "D MMMM YYYY" | advisor, actions, jumpForward |
+| `STARTING_ROUND_DATE` | `startDate` | Campaign start date (`game.startDate`) | advisor, jumpForward, autoJumpForward, pregameHistory |
+| `TARGET_ROUND_DATE` | `targetDate` | Jump target date (ISO) | jumpForward, autoJumpForward |
+| `TARGET_ROUND_GRAMMATICAL_DATE` | `targetDateReadable` | Target date formatted readable | jumpForward |
+| `CURRENT_ROUND_NUMBER` | `round` | Current round number | jumpForward |
+| `DIFFICULTY_DESCRIPTION_CHATS` | `difficultyGuidanceChats` | Difficulty guidance, "chats" flavor | leader |
+| `DIFFICULTY_DESCRIPTION_JUMP_FORWARD` | `difficultyGuidanceJumpForward` | Difficulty guidance, "jump" flavor | jumpForward, autoJumpForward |
+| `DESCRIPTION_ACTION_TEXT` | `actionInput` | Raw player freeform text to convert | descriptionToAction |
+| `EVENTS_TO_CONSOLIDATE` | `eventsToConsolidate` | Event batch to compress | eventConsolidator |
+| `CHATS_TO_CONSOLIDATE` | `chatsToConsolidate` | Chat batch to compress | eventConsolidator |
+| `GAME_MASTER_PLAYER_REQUEST` | `gameMasterRequest` | Raw GM/cheat request text | gameMaster |
+| `RUNNING_CATALYST_DATE` | `catalystDate` | Catalyst date (= current date) | catalystCreation, catalystExecutor, catalystSummary |
+| `RUNNING_CATALYST_PERCENT` | `catalystPercent` | Catalyst progress %, `min(100, history.length*50)` | catalystExecutor |
+| `CATALYST_PREMISE_DESCRIPTION` | `catalystPremise` | The catalyst's premise text | catalystExecutor, catalystSummary |
+| `CATALYST_SIMULATION_HISTORY` | `catalystHistory` | Choice→summary log so far | catalystExecutor, catalystSummary |
+
+Lowercase variables referenced **directly** by task text (no helper alias): `${language}` (all tasks), and in `idleDiplomacy` — `${playerPolity}`, `${dateReadable}`, `${worldSummary}`, `${recentEvents}`, `${chatSummary}`; in `catalystExecutor` — `${catalystChoice}`.
+
+---
+
+## 5. Template variable reference (the full map)
+
+Every key on the object returned by `buildPromptContext` (`promptContext.js:379`, return block 413–462), plus the two keys `buildTemplateVariables` (`gameplay.js:367`) adds/overrides. This is the master set available to `renderTemplate`.
+
+| Variable | Inserts | Computed at |
+|---|---|---|
+| `playerPolity` | `game.country` or "Unknown polity" | `promptContext.js:447` |
+| `playerPolityRegions` | Player's owned-region names, "No player polity…", "No explicit… override list", or the LANDLESS block | `buildPlayerPolityRegionsText` `promptContext.js:293` (LANDLESS text 287) |
+| `playerBattalionSummaries` | `buildUnitsSummaryText(world)` (up to 60 units, coords/type/owner/strength/status) | `promptContext.js:447` / builder `195` |
+| `unitsSummary` | Same unit text; **`buildTemplateVariables` appends `buildMilitaryFeasibilityText`** (era-reach/type/distance doctrine) only when units exist or the actions text matches the military regex | `promptContext.js:458`; override `gameplay.js:372`; feasibility builder `319` |
+| `playerPolityReputationContext` | "International reputation: N/100 (poor/mixed/well-regarded)." from `world.internationalReputation[player]`, else last viewed stat sheet, else 50 | `buildPlayerPolityReputationText` `gameplay.js:348` (added `371`) |
+| `worldSummary` | Multi-section snapshot: player line + tags, round, date, language, difficulty, world-before-round-one, simulation rules, up-to-24 territorial overrides, up-to-16 polity overrides (incl. `note` lore), up-to-40 country tag lines, active-catalyst line | `buildWorldSummary` `promptContext.js:317` |
+| `worldSummaryNoCity` | **Identical** to `worldSummary` | `promptContext.js:461` |
+| `citiesSummary` | City coordinate lines: custom-city scenarios use the era geojson (tier/pop sorted, ≤200); otherwise the stock significant slice (capitals + pop ≥ 2M, cached) | `buildCityCatalogText` `promptContext.js:239` |
+| `markersSummary` | `world.markers` structures (≤60) with kind/owner/coords/note | `buildMarkersSummaryText` `promptContext.js:211` |
+| `numberOfRegions` | `String(regionCatalog.length)` | `promptContext.js:444` |
+| `recentEvents` | Unconsolidated event history, `eventLimit` window (10 default; 16 on advisor/leader path) | `buildEventHistoryText` `promptContext.js:48` |
+| `recentEventsLong` | `buildCampaignHistoryText`: "STORY SO FAR" (consolidated) + "RECENT EVENTS" (≤`longEventLimit`, 24) | `promptContext.js:450` / builder `95` |
+| `consolidatedHistory` | `buildConsolidatedHistoryText(world)` — the `consolidatedHistory[]` summaries | `promptContext.js:433` / builder `86` |
+| `recentRoundsWithDates` | `from → to` date pairs from `world.simulationHistory` (≤8) | `buildRecentRoundsWithDates` `promptContext.js:187` |
+| `chatHistory` | Current chat's `speaker: text` lines, or "No chat history." | `promptContext.js:428` |
+| `chatHistoryLong` | `buildDetailedChatHistoryText(unconsolidatedChats, {limit: chatLimit})` | `promptContext.js:429` / builder `114` |
+| `chatSummary` | One-line-per-chat last-message summary | `buildChatSummaryText` `promptContext.js:431` / builder `103` |
+| `chatParticipants` | Current chat's participant names, comma-joined | `promptContext.js:430` (overridden with a bulleted list in `buildDiplomaticSystemPrompt`, `main.jsx:1058`) |
+| `chatsToConsolidate` | Explicit batch, else detailed transcript (≤12 chats, ≤50 msgs) | `promptContext.js:432` |
+| `chat` | `JSON.stringify(unconsolidatedChats)` | `promptContext.js:427` |
+| `lastSpeaker` | Current chat's last speaker name | `promptContext.js:442` |
+| `respondingPolityName` | Option override, else first non-player participant | `promptContext.js:452` |
+| `advisorMessages` | `buildAdvisorHistoryText(bundle.advisor, {limit: advisorLimit=18})` | `promptContext.js:416` / builder `127` |
+| `actions` | `formatActionsForPrompt(bundle.actions)` (title + display text) | `promptContext.js:415` / builder `156` |
+| `plannedActions` | `buildActionHistoryText(bundle.actions)` (planned only) | `promptContext.js:445` / builder `140` |
+| `allActions` | `buildActionHistoryText(…, {includeResolved:true})` | `promptContext.js:417` |
+| `actionInput` | The `actionInput` option (raw player text) | `promptContext.js:414` |
+| `date` | `game.gameDate` (raw) | `promptContext.js:434` |
+| `dateReadable` | `formatDateReadable(date)` → "D MMMM YYYY" (dayjs); raw text if unparseable | `promptContext.js:435` / builder `165` |
+| `startDate` | `game.startDate` | `promptContext.js:456` |
+| `round` | `String(game.round || 1)` | `promptContext.js:453` |
+| `targetDate` | `targetDate` option or `date` | `promptContext.js:457` |
+| `targetDateReadable` | `formatDateReadable(target)` | `promptContext.js:457` |
+| `language` | `world.language ‖ game.language ‖ "English"` | `promptContext.js:441` |
+| `difficulty` | `game.difficulty || "standard"` | `promptContext.js:436` |
+| `difficultyGuidanceChats` | `buildDifficultyGuidance(difficulty, "chats")` | `promptContext.js:437` / builder `170` |
+| `difficultyGuidanceJumpForward` | `buildDifficultyGuidance(difficulty, "jump")` | `promptContext.js:438` |
+| `simulationRules` | `world.simulationRules` or "No extra simulation rules were provided." | `promptContext.js:454` |
+| `worldBeforeRoundOne` | `world.startingTimelineText` or "No pre-game world briefing…" | `promptContext.js:459` |
+| `numberOfRegions` | (above) | `promptContext.js:444` |
+| `eventsToConsolidate` | Explicit batch, else `buildEventHistoryText(events, {limit:12})` | `promptContext.js:439` |
+| `gameMasterRequest` | The `gameMasterRequest` option | `promptContext.js:440` |
+| `catalystDate` | `= date` | `promptContext.js:420` |
+| `catalystPercent` | `min(100, activeCatalyst.history.length*50)%`, else "0%" | `promptContext.js:422` |
+| `catalystPremise` | `catalystPremise` option | `promptContext.js:425` |
+| `catalystHistory` | `catalystHistory` option (choice→summary log) | `promptContext.js:423` |
+| `catalystChoice` | `catalystChoice` option (the just-chosen option) | `promptContext.js:418` |
+| `catalystOpening` | `catalystOpening` option | `promptContext.js:419` |
+
+`buildPromptContext` accepts an options bag (`promptContext.js:379`): `actionInput`, `advisorLimit`, `catalystChoice/History/Opening/Premise`, `chat`, `chatLimit`, `chatsToConsolidate`, `eventLimit`, `eventsToConsolidate`, `gameMasterRequest`, `longEventLimit`, `respondingPolityName`, `targetDate`. Each task's entry point passes the ones it needs (e.g. `simulateTimelineJump` passes `targetDate`; `advanceActiveCatalyst` passes `catalystChoice/History/Premise/Opening`).
+
+---
+
+## 6. Call-time appended directives
+
+Concatenated onto the system prompt in `runJsonTask` / `callAI` **after** the template renders. They exist in code (not `defaultPrompts.json`) so they reach frozen-prompt campaigns (§2).
+
+| Directive | Applies to | Source |
+|---|---|---|
+| **Difficulty** — one of 6 blurbs steering success rates | every task (via `readGameData`); leader (via `buildDiplomaticSystemPrompt`) | `gameplay.js:400`, `main.jsx:1063`; text in `difficulty.js` |
+| **[Player Agency]** — never commit the player to treaties/wars they did not order; surface offers as open chats/events | `jumpForward`, `autoJumpForward` | `gameplay.js:411` |
+| **[Map Truth]** — capture/annex/cede language *requires* matching `impacts.regionTransfers`; resolving the player's own ordered offensives is allowed | `jumpForward`, `autoJumpForward` | `gameplay.js:420` |
+| **[International Reputation]** — how the world regards the player biases behavior; record changes via `polityChanges.reputation` (0–100) | `actions`, `jumpForward`, `autoJumpForward`, `catalystCreation`, `catalystExecutor` | `gameplay.js:425` |
+| **Language** — write all human-readable text in the UI language; keep JSON keys/ISO codes/dates unchanged | every `callAI` call (advisor, leader, all tasks, intel briefing) when language ≠ `en` | `callAI` `main.jsx:945`; text `i18n.js:137` |
+| **Military feasibility** — era-reach/unit-type/distance doctrine; folded into `${CURRENT_UNITS}` not appended separately | conditional: only when units exist or actions text matches the military regex | `buildMilitaryFeasibilityText` `gameplay.js:319`, injected `372` |
+| **Leader turn instruction** — "speak only as `<polity>`… optionally append `REACTION:<emoji>`" (a user-role turn, not system) | leader only | `main.jsx:1144` |
+
+Difficulty text (`difficulty.js`): `very-easy`, `easy`, `medium` (default; `"standard"`/empty normalize to medium), `hard`, `very-hard`, `impossible`. `buildDifficultyGuidance` (`promptContext.js:170`) is a *separate* softer paragraph used inside the jump/chat prompt bodies via `DIFFICULTY_DESCRIPTION_*`.
+
+---
+
+## 7. AI tasks
+
+Each subsection: purpose · default prompt location · entry point · key inputs · output tool/schema · validation & fallback. All schemas are in `gameplaySchemas.js`; the tool name is what the model calls. Task text lives at `defaultPrompts.json` `tasks.<key>`.
+
+### 7.1 `jumpForward` — manual time skip
+- **Purpose:** Simulate every event between the origin date and a player-chosen target date; move the map, units, structures, diplomacy.
+- **Prompt:** `tasks.jumpForward`. **Entry:** `simulateTimelineJump({days, mode:"jump", signal})` `gameplay.js:1852`.
+- **Inputs:** full state bundle; `targetDate`; event-count band from `eventCountRangeForDays(days)` (`1834`) with a floor of one event per queued action; duration label; `${CURRENT_UNITS/MAP_STRUCTURES/CITY_COORDINATES}`.
+- **Tool/schema:** `submit_jump_result` / `JUMP_FORWARD_SCHEMA` (`gameplaySchemas.js:399`). Payload: `events[]` (each `date/title/description` + `impacts`), `stopDate`, `summary`, `clearActions`, nullable `catalyst`, top-level `diplomaticOutreach[]`.
+- **Validation:** `validatePayload` (`gameplay.js:1897`) — strict on attempt 1 / salvage on final: event-count range, `validateTimelineDates` (`125`) then `clampTimelineDates` (`187`) on salvage, then `validateGeneratedWorldChanges` (`1002`) resolving region names → ids (`resolveRegionTransfers` `831`) with a corrective owner-region list (`buildTransferFeedback` `940`) and the **capture-reluctance guard** (`CAPTURE_LANGUAGE` `994`, guard `1020`). **Fallback:** `fallbackJumpSimulation` (`1142`). Timeout: unbounded unless the "Limit AI generation" map setting is on (then 5 min); `signal` aborts cleanly.
+- **Applied by:** `applySimulationResult` (`1305`) — appends events, bumps round/date, resolves planned actions, applies impacts, opens generated chats, writes a `simulationHistory` entry, snapshots for rollback.
+
+### 7.2 `autoJumpForward` — auto skip to the next notable event
+- **Purpose:** Same engine, but **stop early** at the first strategically notable / player-relevant / catalyst-worthy event and set it `notable:true`.
+- **Prompt:** `tasks.autoJumpForward`. **Entry:** `simulateAutoJump({days=365, signal})` → `simulateTimelineJump(mode:"auto")` `gameplay.js:1946`.
+- **Tool/schema:** `submit_jump_result` / `AUTO_JUMP_FORWARD_SCHEMA` (= `JUMP_FORWARD_SCHEMA`, `gameplaySchemas.js:429`).
+- **Validation:** same validator; in `auto` mode `stopDate` may be any date after origin and ≤ target (`validateTimelineDates` `153`); the event-count range is not strictly enforced.
+
+### 7.3 `actions` — strategic action suggestions
+- **Purpose:** Produce 6–9 "Topics of Concern," each with 2–5 concrete actions (kind `action`, or `chat` for outreach).
+- **Prompt:** `tasks.actions`. **Entry:** `generateActionSuggestions({force})` `gameplay.js:1430`.
+- **Tool/schema:** `submit_actions` / `ACTIONS_SCHEMA` (`gameplaySchemas.js:369`): `topics[] { title, description, actions[] { title, text, kind, invitees, chatStarter } }`.
+- **Validation/fallback:** accepts array/`topics`/`suggestions` shapes; empty → `fallbackActionSuggestions` (`678`, from `DEFAULT_SUGGESTION_TOPICS`). Result stored on `world.actionSuggestions`.
+
+### 7.4 `descriptionToAction` — freeform text → structured command
+- **Purpose:** Turn the player's raw sentence into one action (or a chat invitation), ~50% longer, tone-matched, ≤650 chars.
+- **Prompt:** `tasks.descriptionToAction`. **Entry:** `refinePlayerAction(rawInput, {persist})` `gameplay.js:1597` (passes `actionInput`).
+- **Tool/schema:** `submit_description_to_action` / `DESCRIPTION_TO_ACTION_SCHEMA` (`483`): `{ title, text, kind, invitees[], chatStarter }`.
+- **Fallback:** `fallbackDescriptionToAction` (`708`) — heuristic chat detection via `CHAT_HINT_PATTERNS` (`46`) and `inferInviteeNames`.
+
+### 7.5 `nextSpeaker` — pick the next diplomat
+- **Purpose:** Choose which participant speaks next in an open chat (never the last speaker).
+- **Prompt:** `tasks.nextSpeaker`. **Entry:** `chooseNextDiplomaticSpeaker({chat, excludeSpeaker})` `gameplay.js:1630`.
+- **Tool/schema:** `submit_next_speaker` / `NEXT_SPEAKER_SCHEMA` (`497`): `{ nextSpeaker }`.
+- **Fallback:** `fallbackNextSpeaker` (`740`) — mentioned polity, else first non-excluded participant. (The chosen polity's actual reply is generated by the **leader** root prompt, §7.14.)
+
+### 7.6 `eventConsolidator` — compress history
+- **Purpose:** Fold a batch of events + closed chats into one continuity summary (~≤360 words) so old detail leaves the context window without losing map/diplomacy facts.
+- **Prompt:** `tasks.eventConsolidator`. **Entries:** `consolidateHistoryBatch` (`535`, auto-run by `compactHistoryIfNeeded` `554` after jumps) and `consolidateRecentHistory({limit})` (`1662`).
+- **Tool/schema:** `submit_event_consolidation` / `EVENT_CONSOLIDATOR_SCHEMA` (`507`): `{ summary }`.
+- **Fallback:** concatenate raw event lines + `buildChatSummaryText`. Triggers: `CONSOLIDATION_*` thresholds (`gameplay.js:530`).
+
+### 7.7 `catalystCreation` — open a branching scene
+- **Purpose:** Design an immersive interactive "catalyst" scene with an opening and 2–5 choices.
+- **Prompt:** `tasks.catalystCreation`. **Entry:** `createCatalyst({force})` `gameplay.js:1670`.
+- **Tool/schema:** `submit_catalyst_creation` / `CATALYST_CREATION_SCHEMA` (= `catalystSchema`, `gameplaySchemas.js:346`): `{ title, premise, opening, choices[2..5] }`. Written to `world.activeCatalyst`.
+
+### 7.8 `catalystExecutor` — advance a scene
+- **Purpose:** React to the player's chosen option, advance the scene, add to a progress bar, and offer next choices (or resolve).
+- **Prompt:** `tasks.catalystExecutor` (uses `${catalystChoice}` and `${RUNNING_CATALYST_PERCENT}`). **Entry:** `advanceActiveCatalyst(choiceText)` `gameplay.js:1701`.
+- **Tool/schema:** `submit_catalyst_execution` / `CATALYST_EXECUTOR_SCHEMA` (`519`): `{ summary, resolved, nextChoices[] }`. Validator (`926`) enforces: empty `nextChoices` when resolved, ≥2 distinct otherwise.
+
+### 7.9 `catalystSummary` — resolved scene → one event
+- **Purpose:** When a catalyst resolves, condense it into a single campaign event.
+- **Prompt:** `tasks.catalystSummary`. **Entry:** the resolution branch of `advanceActiveCatalyst` (`gameplay.js:1775`), then `applySimulationResult` with `mode:"catalyst"`.
+- **Tool/schema:** `submit_catalyst_summary` / `CATALYST_SUMMARY_SCHEMA` (`539`): `{ title, description, importance }`.
+- ⚠️ **Caveat:** the default `catalystSummary` string contains a large stray **"Game Master" / "Master Cheat Assistant"** block pasted mid-prompt (legacy content). The task still returns the `{title,description,importance}` shape; the real GM task is the separate `gameMaster` key (§7.11). If you rewrite this prompt, delete the embedded GM text.
+
+### 7.10 `pregameHistory` — backstory generator
+- **Purpose:** On the first open of a fresh game with a "World Before Round One" briefing, write 4–10 dated events **strictly before** the start date. Runs once (the `simulationHistory` entry doubles as the done-marker); events carry **no impacts** (world already reflects them); clock stays at start, round stays 1.
+- **Prompt:** `tasks.pregameHistory`. **Entry:** `maybeGeneratePregameHistory()` `gameplay.js:2050`.
+- **Tool/schema:** `submit_pregame_history` / `PREGAME_HISTORY_SCHEMA` (`448`): `{ events[1..12] { date,title,description,importance,kind }, summary }` — note the impact-free `pregameEventSchema` (`434`).
+- **Validation:** `validatePregameEvents` (`2013`) — strict/salvage: all dates before start, chronological; non-Gregorian scenarios skip date checks. No fallback (silent null on failure).
+
+### 7.11 `gameMaster` — direct map/state cheat
+- **Purpose:** Apply an explicit player/GM request to the map/world; never argue or refuse.
+- **Prompt:** `tasks.gameMaster`. **Entry:** `applyGameMasterCommand(requestText)` `gameplay.js:1949` (passes `gameMasterRequest`).
+- **Tool/schema:** `submit_game_master` / `GAME_MASTER_SCHEMA` (`551`): `{ summary, impacts { regionTransfers, polityChanges, markerOps } }`.
+- **Validation:** `validateGeneratedWorldChanges` (strict on attempt 1). **Fallback:** empty impacts + neutral summary. Wrapped as a "Game master intervention" event.
+
+### 7.12 `countryStatSheet` — structured national stats
+- **Purpose:** Compile a full stat sheet for a selected polity for the Stats tab.
+- **Prompt:** `tasks.countryStatSheet`. **Entry:** `generateCountryStatSheet({code, name})` `gameplay.js:1580` (userMessage carries a `buildTargetDossier` (`1498`) + era slice).
+- **Tool/schema:** `submit_country_stat_sheet` / `COUNTRY_STAT_SHEET_SCHEMA` (`569`): `capital, continent, government, leader, stability(0–100), indices{sovereignty,foodAutonomy,energyAutonomy,economicIndependence,internalSecurity,internationalReputation}, economy{gdp,gdpGrowth,gdpPerCapita,currency,inflation,unemployment,publicDebt,budgetBalance}, gdpBreakdown{agriculture,industry,services}`.
+- **Validation:** all strings non-blank; all indices 0–100 integers; `agriculture+industry+services === 100` (`gameplaySchemas.js:940`). No fallback.
+
+### 7.13 `idleDiplomacy` — unprompted note drip
+- **Purpose:** Between jumps, on each real-minute tick, a small chance a single polity sends the player a short note; usually the answer is silence (`chat: null`).
+- **Prompt:** `tasks.idleDiplomacy` (uses lowercase `${playerPolity}`, `${dateReadable}`, `${worldSummary}`, `${recentEvents}`, `${chatSummary}`). **Entry:** `maybeSendIdleDiplomacy({chance})` `gameplay.js:2128` (1/20 default; suspended by the simulation busy-lock, `628`).
+- **Tool/schema:** `submit_idle_diplomacy` / `IDLE_DIPLOMACY_SCHEMA` (`468`): `{ chat: null | createdChat }`. No editor section; no canned fallback (silent). A note from a country the player already 1:1s with lands in that thread.
+
+### 7.14 Root prompt: `leader` — AI diplomacy
+- **Purpose:** Roleplay a single non-player polity replying in an ongoing chat; hard rule to **match the player's average message length** and tone; simulate a polity leaving.
+- **Prompt:** top-level `leader` string. **Assembly:** `buildDiplomaticSystemPrompt(countries, playerCountry)` (`main.jsx:1036`, `+difficultyDirective`) then `sendDiplomaticMessage(playerMessage, speakingAs, countries)` (`1138`) adds the per-turn instruction + optional `REACTION:<emoji>`. Free-form text (no tool/schema). `${RESPONDING_POLITY_NAME}` selects the voiced polity.
+
+### 7.15 Root prompt: `advisor` — chief advisor chat
+- **Purpose:** In-character strategic advice, ≤3000 chars, may append a `chart`-fenced Chart.js block. **Assembly:** `buildAdvisorSystemPrompt` (`main.jsx:1012`) + `sendMessage` (`1084`) with rolling `advisorHistory`; language directive only (no difficulty, no schema).
+
+### 7.16 Not in the prompt pack: `generateCountryStats` — intel briefing
+- **Purpose:** Free-text bulleted intelligence briefing on a polity. Builds its **own inline system prompt** (dossier + world snapshot + recent events) and calls `callAI` **directly** (no tool, no `runJsonTask`, so only the language directive is appended). Entry: `generateCountryStats({code, name})` `gameplay.js:1551`. Distinct from `countryStatSheet` (§7.12).
+
+---
+
+## 8. Impacts / output-shape reference
+
+Shared `impacts` object (`impactsSchema` `gameplaySchemas.js:282`) carried by jump/auto/gameMaster events. All entries are optional arrays; omit empties.
+
+| Field | Entry shape | Resolution / notes |
+|---|---|---|
+| `regionTransfers` | `{ regionId, regionName?, fromCode?, toCode, note? }` | `regionId` may be a plain name; `resolveRegionTransfers` (`gameplay.js:831`) maps name→id (owner-disambiguated). Unresolved → strict corrective feedback (attempt 1) or dropped (final). Required whenever event text claims a capture (Map Truth guard). |
+| `polityChanges` | `{ code, name?, color?, aliases?, reputation?(0–100), tags?, note? }` | `reputation` was recently added to the schema (`107`); without the schema entry, json-schema providers could never emit it. `tags` is the *complete* new trait list, not a delta. |
+| `createdChats` | `{ countries[≥1], title, openingMessage, speaker }` | Initiating polity speaks first, never the player. `validateChatOpener` (`979`) requires title + opening. Built into a real chat by `buildGeneratedChat` (`762`). |
+| `unitOps` | `spawn{unit{name,type∈enum,ownerCode,strength 1–1000,lng,lat,regionId?}}` · `move{unitId,toLng,toLat,regionId?,note?}` · `strength{unitId,strength 0–1000}` · `remove{unitId}` | `unitOpSchema` (`178`). Ops on unknown unit ids: strict error / salvage drop. `strength:0` or `remove` deletes the unit. |
+| `markerOps` | `build{marker{name,kind(free lowercase),ownerCode?,lng,lat,note?,foundedAt?}}` · `remove{name}` | `markerOpSchema` (`256`). Structures never move borders (no `regionTransfers`). |
+
+Jump payloads also carry a top-level `diplomaticOutreach[]` (same shape as `createdChats`, not tied to an event) and a nullable `catalyst`. The schema validator (`validateGameplayPayload` `852`) additionally enforces non-blank `stopDate`/event fields, "at least one event, summary, or meaningful catalyst," and distinct catalyst choices.
+
+---
+
+## 9. Recipes
+
+### Add a new template variable
+1. **Compute it** in `buildPromptContext`'s return object (`promptContext.js:413`) — e.g. `myThing: buildMyThing(bundle.world)`. Add a builder next to the others if non-trivial. (If it needs reputation/feasibility-style augmentation only for tasks, add it in `buildTemplateVariables` `gameplay.js:367` instead — but remember advisor/leader won't see those.)
+2. **Expose a placeholder** in `defaultPrompts.json` `helpers`: `"MY_THING": "${myThing}"`.
+3. **Reference it** in the task/root text as `${MY_THING}` (or the lowercase `${myThing}` directly).
+4. **(Optional) editor:** add `MY_THING` to the relevant section's `helpers` list in `PROMPT_SECTION_DEFINITIONS` (`gameplayPrompts.js:15`) so it shows in the Prompts editor hints.
+5. Nothing else — `renderTemplate` picks up any key present in the merged `{...variables, ...helperValues}` map.
+
+### Add a new task
+1. **Schema + tool:** define `MY_TASK_SCHEMA` and `MY_TASK_TOOL = makeTool("submit_my_task", …)` in `gameplaySchemas.js`; register both in `GAMEPLAY_SCHEMAS` (`621`) and `GAMEPLAY_TOOLS` (`717`) under the new key; add any task-specific checks to `validateGameplayPayload` (`852`).
+2. **Prompt text:** add `tasks.myTask` to `defaultPrompts.json` ending with the JSON output contract. It is auto-picked-up: `PROMPT_TASK_KEYS = Object.keys(tasks)` and `normalizePromptPack` iterate it (`gameplayPrompts.js:230`, `246`).
+3. **Entry point:** in `gameplay.js`, build variables (`buildTemplateVariables(bundle, {…})`) and call `runJsonTask("myTask", { userMessage, variables, fallback?, validatePayload?, timeoutMs? })`. Wrap state-writing tasks in `beginSimulation()/endSimulation()`.
+4. **Call-time directives:** if the rule must apply to existing games, add the task key to the relevant `if ([...].includes(taskKey))` blocks in `runJsonTask` (`gameplay.js:411`/`425`) rather than only in the JSON (frozen-prompt caveat, §2).
+5. **(Optional) editor:** add a `PROMPT_SECTION_DEFINITIONS` entry (`type:"task"`) so it is user-editable per scenario.
+
+---
+
+## 10. Gotchas
+
+- **`worldSummary` and `worldSummaryNoCity` are the same string** — the "no city" name is historical; city coordinates are a separate `citiesSummary`/`${CITY_COORDINATES}`.
+- **Two output attempts per task**, then a deterministic fallback (or throw). `finalAttempt` comes from `runJsonTask`, never from counting validator calls — attempt-1 schema failures skip `validatePayload` entirely (`gameplay.js:464` comment).
+- **Reputation and military-feasibility reach only the task path** (`buildTemplateVariables`). Advisor/leader use `buildPromptContext` directly and never see them.
+- **`catalystSummary` contains stray embedded "Game Master" text** (§7.9) — the actual GM task is `gameMaster`.
+- **`idleDiplomacy` and the intel `generateCountryStats` briefing are invisible to the Prompts editor** — the former has no `PROMPT_SECTION_DEFINITIONS` entry; the latter is an inline prompt not in `defaultPrompts.json`.
+- **Editing `defaultPrompts.json` does not retroactively change existing campaigns** — they carry frozen prompt copies; use call-time appends for universal rules.

--- a/docs/ai-schemas.md
+++ b/docs/ai-schemas.md
@@ -1,0 +1,417 @@
+# AI Return Schemas & Validation
+
+Every AI gameplay task in Open Historia hands the model a JSON Schema (as a provider "tool") and gets back a JSON object it must trust before mutating the world. This page documents the schemas the model must return (`src/Game/AI/gameplaySchemas.js`), the hand-rolled two-layer validator that gates every response, and the strict-vs-salvage retry discipline in `runJsonTask` (`src/Game/AI/gameplay.js`) that decides whether a bad answer earns a corrective retry or gets repaired in place. If you are adding a field the model should emit, read the [`additionalProperties: false` trap](#the-additionalpropertiesfalse-trap) first — it is the single most common way a new feature silently does nothing.
+
+Related pages: [World state](world-state.md) (what these payloads mutate), [AI providers](ai-providers.md) (how the schema becomes a tool call in `main.jsx`), [Gameplay orchestration](ai-gameplay.md) (the task callers), [Gameplay prompts](gameplay-prompts.md) (the templates rendered alongside each schema).
+
+---
+
+## 1. The big picture: two files, two validation layers
+
+| Concern | File | What it holds |
+|---|---|---|
+| Schema definitions + generic validator | `src/Game/AI/gameplaySchemas.js` | `GAMEPLAY_SCHEMAS`, `GAMEPLAY_TOOLS`, `validateGameplayPayload` |
+| Task orchestration + world-aware validator | `src/Game/AI/gameplay.js` | `runJsonTask`, `validateGeneratedWorldChanges`, timeline/pregame validators, JSON recovery |
+| Provider wire format | `src/Game/AI/main.jsx` | `callAI` — turns a `tool` into Gemini/OpenAI/Anthropic tool calls, extracts `toolInput` |
+
+A response passes through **two independent validation layers** before it is accepted (`gameplay.js:461-477`):
+
+1. **Layer 1 — schema + generic invariants** (`validateGameplayPayload`, always runs). Structural: types, required keys, `additionalProperties`, ranges, plus per-task rules like the gdpBreakdown sum and distinct-choice checks. Pure function of the payload; knows nothing about the current game.
+2. **Layer 2 — the `validatePayload` callback** (optional, world-aware). Only some callers supply it (`jumpForward`, `autoJumpForward`, `gameMaster`, `pregameHistory`, `idleDiplomacy`). It gets `{ attempt, finalAttempt }` and can consult live world state — e.g. `validateGeneratedWorldChanges` resolves region names against the real map. This is where strict-vs-salvage lives.
+
+Both layers return a string error (`""` means valid). A non-empty error on attempt 1 becomes the corrective feedback the model sees on its one retry.
+
+---
+
+## 2. Task registry: schema, tool, and task key
+
+Each task is identified by a **task key**. `GAMEPLAY_SCHEMAS` maps the key to its schema; `GAMEPLAY_TOOLS` maps it to a `{ name, description, schema }` tool object built by `makeTool` (`gameplaySchemas.js:637`). `getGameplayTool(taskKey)` (`:733`) is what `runJsonTask` calls to get the provider tool; `validateGameplayPayload(taskKey, value)` (`:852`) is what validates the result.
+
+| Task key | Schema export | Tool name (provider function name) | Called from |
+|---|---|---|---|
+| `actions` | `ACTIONS_SCHEMA` | `submit_actions` | `generateActions` |
+| `jumpForward` | `JUMP_FORWARD_SCHEMA` | `submit_jump_result` | `simulateTimelineJump` |
+| `autoJumpForward` | `AUTO_JUMP_FORWARD_SCHEMA` (**= `JUMP_FORWARD_SCHEMA`**, `:429`) | `submit_jump_result` | `simulateAutoJump` |
+| `descriptionToAction` | `DESCRIPTION_TO_ACTION_SCHEMA` | `submit_description_to_action` | freeform-intent → command |
+| `nextSpeaker` | `NEXT_SPEAKER_SCHEMA` | `submit_next_speaker` | diplomatic chat turn order |
+| `eventConsolidator` | `EVENT_CONSOLIDATOR_SCHEMA` | `submit_event_consolidation` | `consolidateHistoryBatch` |
+| `catalystCreation` | `CATALYST_CREATION_SCHEMA` (**= `catalystSchema`**, `:517`) | `submit_catalyst_creation` | catalyst scene creation |
+| `catalystExecutor` | `CATALYST_EXECUTOR_SCHEMA` | `submit_catalyst_execution` | advance a catalyst |
+| `catalystSummary` | `CATALYST_SUMMARY_SCHEMA` | `submit_catalyst_summary` | resolved catalyst → event |
+| `gameMaster` | `GAME_MASTER_SCHEMA` | `submit_game_master` | `applyGameMasterCommand` |
+| `countryStatSheet` | `COUNTRY_STAT_SHEET_SCHEMA` | `submit_country_stat_sheet` | national stat sheet |
+| `idleDiplomacy` | `IDLE_DIPLOMACY_SCHEMA` | `submit_idle_diplomacy` | idle inbox drip |
+| `pregameHistory` | `PREGAME_HISTORY_SCHEMA` | `submit_pregame_history` | pre-game backstory |
+
+`getGameplayTool` returns `null` for an unknown key; `validateGameplayPayload` returns `{ valid: false, error: "Unknown gameplay task key: …" }` (`:854`).
+
+### How a schema becomes a tool call
+
+`callAI` (`main.jsx`) receives the `tool` and adapts it per provider (`main.jsx:494-627`):
+
+- **Gemini** — `tools: [{ functionDeclarations: [{ name, description, parameters: toGeminiSchema(schema) }] }]`, forced via `allowedFunctionNames`. `toGeminiSchema` **strips `additionalProperties` and `$schema`** recursively (`main.jsx:211-219`) — Gemini rejects those keys.
+- **OpenAI-compatible** — `tools: [{ type: "function", function: { name, description, parameters: schema } }]` in `tool` mode; falls back to `response_format: { type: "json_schema", … }` and then `{ type: "json_object" }` on 400/422 (`main.jsx:605-650`). The schema is sent **verbatim, including `additionalProperties: false`**.
+- **Anthropic** — native `tool_use`; `extractAnthropicToolInput` reads `block.input`.
+
+The parsed arguments come back as `response.toolInput`. `runJsonTask` prefers that; if the model answered in prose (local models with no tool support), it falls back to `extractJsonPayload(rawText)` (`gameplay.js:460`).
+
+---
+
+## 3. Shared building blocks
+
+Small factory helpers keep the schemas DRY (`gameplaySchemas.js:1-15`, `:562`):
+
+| Helper | Produces | Notes |
+|---|---|---|
+| `textSchema(desc)` | `{ type: "string", description }` | optional free text |
+| `nonEmptyTextSchema(desc)` | `textSchema` + `minLength: 1` | enforced by the validator's `minLength` check |
+| `stringArraySchema(desc)` | `{ type: "array", items: { type: "string" } }` | e.g. `aliases`, `tags`, `invitees` |
+| `percentageSchema(desc)` | `{ type: "integer", minimum: 0, maximum: 100 }` | all stat-sheet indices |
+
+Every object schema sets `additionalProperties: false`. Understand what that means before adding fields — see [§7](#7-the-additionalpropertiesfalse-trap).
+
+---
+
+## 4. Payload schemas — field tables
+
+Only fields listed in a schema's `properties` are legal; anything else is rejected. "Req?" is membership in the schema's `required` array. Sub-schemas are broken out so you can trace nesting.
+
+### 4.1 `impactsSchema` — structured world-state effects (`:282`)
+
+The heart of the map-mutating pipeline. Attached to events (`eventSchema.impacts`) and to `GAME_MASTER_SCHEMA.impacts`. "Include only effect arrays that are relevant." Consumed by `validateGeneratedWorldChanges` and then applied to [world state](world-state.md).
+
+| Field | Type | Meaning | Req? |
+|---|---|---|---|
+| `actionIds` | `string[]` | Player action ids this event resolves | no |
+| `createdChats` | `createdChatSchema[]` | Diplomatic chats the event opens toward the player | no |
+| `polityChanges` | `polityChangeSchema[]` | Polity metadata changes (name/color/reputation/tags…) | no |
+| `regionTransfers` | `regionTransferSchema[]` | **Map ownership changes.** Required by prompt whenever narration says territory changed hands — one entry per region | no |
+| `unitOps` | `unitOpSchema[]` | Military unit mutations | no |
+| `markerOps` | `markerOpSchema[]` | Structures built/destroyed on the map | no |
+
+### 4.2 `regionTransferSchema` (`:90`)
+
+| Field | Type | Meaning | Req? |
+|---|---|---|---|
+| `regionId` | string | Exact region id **or plain name** (engine resolves names → ids) | **yes** |
+| `regionName` | string | Human-readable name, when known | no |
+| `fromCode` | string | Previous owner polity code — lets the resolver locate the region | no |
+| `toCode` | string | New owner polity code | **yes** |
+| `note` | string | Brief reason | no |
+
+### 4.3 `polityChangeSchema` (`:107`)
+
+A creation/rename/recolor/metadata change. Only `code` is required; send other fields **only when they change**.
+
+| Field | Type | Meaning | Req? |
+|---|---|---|---|
+| `code` | string | Exact polity code | **yes** |
+| `name` | string | New name, only when it changes | no |
+| `color` | string | New six-digit hex color, only when it changes | no |
+| `aliases` | `string[]` | Alternative names | no |
+| `reputation` | number | International reputation 0–100, only when it changes (0 = pariah, 100 = universally trusted) | no |
+| `tags` | `string[]` | Complete new trait list (ideology/alignment/posture) — send the whole list, not a delta | no |
+| `note` | string | Brief reason | no |
+
+> `reputation` is the canonical example of the [`additionalProperties: false` trap](#7-the-additionalpropertiesfalse-trap): the prompt asked for it and `gameState` clamped/wrote it, but it was **absent from `properties`** — so a strict `json_schema` provider could never emit it and reputation silently never moved. Declaring it (`:119`) is what connected the feature.
+
+### 4.4 `unitOpSchema` — `anyOf` on `op` (`:178`)
+
+Not a single object: an `anyOf` of four shapes discriminated by `op`. Each branch is `additionalProperties: false`, so fields from one op leaking into another fail validation.
+
+| `op` | Required fields | Payload |
+|---|---|---|
+| `spawn` | `op`, `unit` | full `unitSchema` object |
+| `move` | `op`, `unitId`, `toLng`, `toLat` | + optional `regionId`, `note` |
+| `strength` | `op`, `unitId`, `strength` | `strength` integer 0–1000 |
+| `remove` | `op`, `unitId` | + optional `note` |
+
+`unitSchema` (`:136`) fields: `id`, `name`* (nonempty), `type`* (enum: `infantry|armor|air|naval|artillery|garrison`), `ownerCode`* (nonempty), `strength`* (integer 1–1000), `lng`* (−180..180), `lat`* (−90..90), `regionId`, `status` (enum `idle|moving|engaged|pending`), `note`. (\* = required.)
+
+### 4.5 `markerOpSchema` — `anyOf` on `op` (`:256`)
+
+| `op` | Required | Payload |
+|---|---|---|
+| `build` | `op`, `marker` | full `markerSchema` |
+| `remove` | `op`, `name` | + optional `markerId`, `note` |
+
+`markerSchema` (`:227`) fields: `id`, `name`* (nonempty), `kind`* (nonempty free-form lowercase noun — city/base/silo/embassy…), `ownerCode`, `lng`* (−180..180), `lat`* (−90..90), `note`, `foundedAt`.
+
+> **Note:** `validateGeneratedWorldChanges` (Layer 2) also accepts `op: "found"` as an alias of `build` and `op: "destroy"` as an alias of `remove` (`gameplay.js:1095`, `:1105`), and for a build reads coordinates from `operation.marker ?? operation`. The **schema itself only declares `build`/`remove`** — the aliases pass Layer 1 only because `unitOp`/`markerOp` schemas validate loosely (see the caveat in §6).
+
+### 4.6 `createdChatSchema` (`:57`)
+
+The initiating polity always speaks first — a blank untitled chat tells the player nothing.
+
+| Field | Type | Meaning | Req? |
+|---|---|---|---|
+| `id` | string | Stable chat id | no |
+| `title` | string (nonempty) | Purpose (e.g. "French mediation offer") | **yes** |
+| `countries` | array (`minItems: 1`) of `chatCountrySchema` | Participants | **yes** |
+| `messages` | `chatMessageSchema[]` | Messages the chat begins with | no |
+| `openingMessage` | string (nonempty) | Initiator's first message, in leader's voice; never the player | **yes** |
+| `speaker` | string (nonempty) | Name of the polity sending the opener; never the player | **yes** |
+| `linkedEventId` | string | Optional cause link | no |
+| `source`, `status` | string | Optional labels | no |
+
+`chatCountrySchema` (`:32`): `code`, `name`* (nonempty). `chatMessageSchema` (`:43`): `code`, `role`, `speaker`, `text`* (nonempty? — only `text` required), `time`.
+
+### 4.7 Jump payload — `JUMP_FORWARD_SCHEMA` (`:399`)
+
+Also used for `autoJumpForward`. This is the largest task.
+
+| Field | Type | Meaning | Req? |
+|---|---|---|---|
+| `events` | `eventSchema[]` | Dated events during the period | **yes** |
+| `stopDate` | string | Date the simulation stops | **yes** |
+| `summary` | string | Concise period summary | **yes** |
+| `clearActions` | boolean | Were queued player actions resolved | **yes** |
+| `catalyst` | `catalystSchema \| null` | Optional interactive scene | no |
+| `diplomaticOutreach` | `createdChatSchema[]` | Polities reaching out on their own initiative, not tied to any event | no |
+
+`eventSchema` (`:322`): `id`, `date`* , `title`* , `description`* , `importance`, `kind`, `notable` (bool), `playerRelated` (bool), `impacts` (`impactsSchema`).
+
+### 4.8 `catalystSchema` (`:346`) and executor/summary
+
+`CATALYST_CREATION_SCHEMA` is `catalystSchema` directly.
+
+| Schema | Fields (required*) |
+|---|---|
+| `catalystSchema` | `title`*, `premise`*, `opening`*, `choices`* (array, `minItems: 2`, `maxItems: 5`, nonempty items) |
+| `CATALYST_EXECUTOR_SCHEMA` (`:519`) | `summary`*, `resolved`* (bool), `nextChoices`* (array `maxItems: 5`, nonempty items) |
+| `CATALYST_SUMMARY_SCHEMA` (`:539`) | `title`*, `description`*, `importance`* |
+
+### 4.9 Small single-purpose schemas
+
+| Schema | Fields (required*) | Purpose |
+|---|---|---|
+| `ACTIONS_SCHEMA` (`:369`) | `topics`* (array `minItems:1`); each topic: `title`*, `description`*, `actions`* (array `minItems:1` of `actionSchema`) | Strategic topics + concrete actions |
+| `DESCRIPTION_TO_ACTION_SCHEMA` (`:483`) | `title`*, `text`*, `kind`*, `invitees`, `chatStarter` | Freeform intent → structured command |
+| `NEXT_SPEAKER_SCHEMA` (`:497`) | `nextSpeaker`* | Whose turn in a chat |
+| `EVENT_CONSOLIDATOR_SCHEMA` (`:507`) | `summary`* | Continuity-safe history summary |
+| `GAME_MASTER_SCHEMA` (`:551`) | `summary`*, `impacts`* | GM intervention + world effects |
+| `IDLE_DIPLOMACY_SCHEMA` (`:468`) | `chat`* (`null \| createdChatSchema`) | At most one idle note, or `null` for silence |
+| `PREGAME_HISTORY_SCHEMA` (`:448`) | `events`* (array `minItems:1`,`maxItems:12` of `pregameEventSchema`), `summary`* | Pre-game backstory |
+
+`actionSchema` (`:17`): `id`, `title`*, `text`*, `kind`, `invitees`, `chatStarter`. `pregameEventSchema` (`:434`): `date`*, `title`*, `description`*, `importance`, `kind` — **deliberately no `impacts`** (a backstory event is a record, not a change to apply, `:431`).
+
+### 4.10 `COUNTRY_STAT_SHEET_SCHEMA` (`:569`)
+
+A complete national statistics sheet. Every top-level object below is required; every nested field is required within its object.
+
+| Group | Fields | Type |
+|---|---|---|
+| top level | `capital`, `continent`, `government`, `leader` | nonempty string |
+| top level | `stability` | percentage (int 0–100) |
+| `indices` | `sovereignty`, `foodAutonomy`, `energyAutonomy`, `economicIndependence`, `internalSecurity`, `internationalReputation` | percentage each |
+| `economy` | `gdp`, `gdpGrowth`, `gdpPerCapita`, `currency`, `inflation`, `unemployment`, `publicDebt`, `budgetBalance` | nonempty string each |
+| `gdpBreakdown` | `agriculture`, `industry`, `services` | percentage each — **must sum to exactly 100** (see §5.3) |
+
+---
+
+## 5. Layer 1 validation — `validateGameplayPayload` (`:852`)
+
+Two stages inside one function: the generic schema walk, then per-task rules.
+
+### 5.1 `validateAgainstSchema` — the hand-rolled schema walker (`:744`)
+
+There is **no Ajv / JSON-Schema library** here; validation is a bespoke recursive walk supporting exactly the keywords the schemas use. If you use a JSON-Schema keyword this walker doesn't implement, it is silently ignored.
+
+| Keyword handled | Behavior | Line |
+|---|---|---|
+| `anyOf` | Passes if the value matches **any** candidate; else concatenates all sub-errors | `:745` |
+| `type` | `integer` = number AND `Number.isInteger`; missing `type` matches anything | `:751` |
+| finite check | `number`/`integer` must be `Number.isFinite` (rejects `NaN`/`Infinity`) | `:759` |
+| `minimum`/`maximum` | numeric bounds | `:763` |
+| `enum` | value must be in the list | `:771` |
+| `minLength` | string length (this is how `nonEmptyTextSchema`'s `minLength:1` is enforced) | `:775` |
+| `minItems`/`maxItems` | array length | `:780` |
+| `items` | recurse into each element | `:787` |
+| `required` | each key must be an own-property (via `hasOwnProperty`) | `:796` |
+| `additionalProperties: false` | any key not in `properties` → `"… is not allowed."` | `:805` |
+
+`valueType` (`:735`) distinguishes `null`/`array`/`object`/primitive so error messages are precise. `propertyPath` (`:741`) builds JSONPath-ish locations (`$.economy.gdp`, `$.events[3].date`) so retry feedback names the exact offending field.
+
+> **Caveat — nested `anyOf` schemas validate loosely.** `unitOpSchema` and `markerOpSchema` have `anyOf` at the top of the item but **no `type`** on the wrapper. The walker's `anyOf` branch tries each candidate and passes if any matches. Because the candidate objects use `additionalProperties: false`, a mostly-correct op usually matches one branch — but this is a weaker guarantee than a discriminated union. The real teeth for unit/marker ops are in Layer 2 (`validateGeneratedWorldChanges`), which is why alias ops like `found`/`destroy` slip past Layer 1.
+
+### 5.2 Per-task generic rules
+
+After the schema walk passes, `validateGameplayPayload` runs task-specific checks. These exist because the schema can't express cross-field constraints or non-blank-after-trim.
+
+| Task | Extra rule | Line |
+|---|---|---|
+| `jumpForward` / `autoJumpForward` | `stopDate` non-blank; every event's `date`/`title`/`description` non-blank after trim; **at least one of** events, non-empty summary, or a *meaningful* catalyst; if a catalyst is present its `choices` must be distinct | `:866` |
+| `pregameHistory` | every event's `date`/`title`/`description` non-blank; `summary` non-blank | `:892` |
+| `descriptionToAction`, `nextSpeaker`, `eventConsolidator`, `catalystCreation`, `catalystExecutor`, `catalystSummary`, `gameMaster` | a per-task list of top-level fields must be non-blank after trim (`requiredTextByTask`, `:906`) | `:915` |
+| `catalystCreation` | `choices` distinct (`validateDistinctChoices`) | `:921` |
+| `catalystExecutor` | `nextChoices` **must be empty when `resolved`**; must have **≥2** when unresolved; must be distinct | `:926` |
+| `countryStatSheet` | deep no-blank-strings (`findBlankString`); **gdpBreakdown sum = 100** | `:937` |
+| `actions` | each topic `title` non-blank; each action `title` AND `text` non-blank | `:946` |
+
+Helpers backing these:
+
+- **`hasMeaningfulCatalyst`** (`:819`) — a catalyst counts only if `title`/`premise`/`opening` has real text **or** `choices` is non-empty. Prevents an empty `{}` catalyst from satisfying the "at least one of" jump rule.
+- **`validateDistinctChoices`** (`:828`) — trims + lowercases each choice, flags the first blank, then rejects if the `Set` size differs from the array length (duplicate detection).
+- **`findBlankString`** (`:836`) — recurses the entire value (objects and arrays) and returns the JSONPath of the first whitespace-only string. Used by `countryStatSheet` so no field in the sheet ships blank. Note this is stricter than the schema's `nonEmptyTextSchema` (which only checks `minLength`, so `"   "` would pass the walker but fail here).
+
+### 5.3 The `gdpBreakdown` sum-to-100 rule (`:940`)
+
+```
+if (breakdown.agriculture + breakdown.industry + breakdown.services !== 100)
+  return { valid: false, error: "$.gdpBreakdown percentages must sum to 100." };
+```
+
+Each part is already a `percentageSchema` (int 0–100) by Layer 1, but three in-range integers can still sum to 97 or 110. This exact-equality check (`!== 100`, not a tolerance band) guarantees the three-slice pie the stat sheet renders is coherent. A model that emits `40/40/30` fails and, on attempt 1, is told to fix it.
+
+### 5.4 The capture-reluctance guard (Layer 2, `gameplay.js:1011-1032`)
+
+Not in `validateGameplayPayload` — it lives in `validateGeneratedWorldChanges`, which jump/GM tasks pass as their `validatePayload` callback. The recurring field report it fixes: "two turns of invasions and not a single province transferred."
+
+Logic (strict attempt only):
+
+1. Sum `regionTransfers` across all event `impacts` containers.
+2. If the total is **0**, scan every event's `title`+`description` against `CAPTURE_LANGUAGE` — a deliberately narrow, word-boundary-anchored regex of *capture verbs* (`captur*`, `seiz*`, `annex*`, `conquer*`, `occupy/ies/ied/ation`, `overran`, `liberat*`, `retak*`, `cede*`, `fell to`, `falls to`; `gameplay.js:994`).
+3. If any event narrates a capture but zero regions moved, return a corrective error telling the model to add `regionTransfers` to every capture event **or** strip the capture language.
+
+It is narrow by design: "preoccupied"/"occupational" never match, and defensive battles that move no borders (war verbs, not capture verbs) are a legitimate zero-transfer turn and never trip it. English-only heuristic; non-English games just skip the nudge. Because it is **strict-only**, it can never cost a finished turn on the final attempt.
+
+---
+
+## 6. `validateGeneratedWorldChanges` — the world-aware Layer 2 (`gameplay.js:1002`)
+
+Passed as `validatePayload` by `jumpForward`/`autoJumpForward` (`gameplay.js:1916`) and `gameMaster` (`:1965`). It both **validates and mutates in place** (canonicalizing region ids, dropping dead ops), so a payload is only accepted after it has passed through here clean. Signature: `(candidate, world, { strictTransfers })`. `strict = strictTransfers` and callers set it to `!finalAttempt`.
+
+| Check | Strict behavior (attempt 1) | Salvage behavior (final attempt) | Line |
+|---|---|---|---|
+| Region transfers unresolvable against the map | Return `buildTransferFeedback` — the losing owner's real region list so the model can resend with exact ids/names | Leave unresolved transfers for normalization to drop | `:1007` |
+| Capture narration + zero transfers | Corrective error (see §5.4) | Skipped entirely | `:1020` |
+| `createdChats` with no known participants | Reject | Drop the chat, keep the turn | `:1042` |
+| `createdChats` opener/title missing | Reject (`validateChatOpener`) | Skipped | `:1046` |
+| `unitOps.spawn` missing name/ownerCode | Reject | Drop the op | `:1059` |
+| `unitOps.spawn` duplicate id | Reject | `delete unit.id` so normalization mints a fresh one | `:1064` |
+| `unitOps` targeting a nonexistent `unitId` | Reject | Drop the op | `:1079` |
+| `markerOps.build` missing name / coords | Reject | Drop the op | `:1097` |
+| `markerOps.remove` missing name+id | Reject | Drop the op | `:1106` |
+| `diplomaticOutreach` with no known participants / bad opener | Reject | Drop the outreach | `:1126` |
+
+`buildTransferFeedback` (`:940`) caps at the first 3 unresolved transfers and lists up to 40 candidate regions each (`"Pomorskie (POL.11_1)"`) — small, targeted vocabulary so the model can fix "Pomerania" into a real id on the retry instead of losing the map change.
+
+---
+
+## 7. The `additionalProperties: false` trap
+
+**A field that is not declared in a schema's `properties` cannot round-trip — even if the prompt asks for it and the writer code handles it.** Two independent gates enforce this:
+
+1. **The provider.** In OpenAI `json_schema` mode (and strict tool modes), the schema — including `additionalProperties: false` — is sent verbatim and the provider constrains generation to it. The model literally cannot emit an undeclared key. (Gemini is the exception: `toGeminiSchema` strips `additionalProperties`, `main.jsx:216` — but you cannot rely on that, since other providers enforce it.)
+2. **The local validator.** Even if a model volunteers an extra key, `validateAgainstSchema` returns `"… is not allowed."` for any property missing from `properties` when `additionalProperties === false` (`gameplaySchemas.js:805`). The payload is rejected.
+
+The lived example is `reputation` on `polityChangeSchema`. The prompt requested it, `gameState` normalized/clamped/wrote it — but the field was missing from `properties`, so `additionalProperties: false` meant a strict provider **could never emit it** and international reputation silently never moved. The fix (`:117-123`) was simply to declare it. The in-code comment is worth reading before you touch any schema.
+
+**Checklist to make a new field emittable:**
+
+1. Add it to the relevant schema's `properties` (with a good `description` — the model reads it).
+2. Add it to `required` only if it must always be present (most impact fields are optional).
+3. Make sure the writer/normalizer in [world state](world-state.md) actually reads and applies it.
+4. If it needs a cross-field or non-blank rule the schema can't express, add it to `validateGameplayPayload` or the task's `validatePayload` callback.
+
+Skipping step 1 is the silent-no-op failure mode.
+
+---
+
+## 8. `runJsonTask` — the request/validate/retry harness (`gameplay.js:382`)
+
+Every AI gameplay call goes through this one function. It owns prompt assembly, the abort/timeout budget, the two-attempt loop, and the fallback.
+
+### 8.1 Options
+
+| Option | Meaning |
+|---|---|
+| `fallback` | Async function returning a deterministic payload when the AI can't produce a valid one. If absent, failure **throws** instead of falling back (`:519`). |
+| `signal` | External `AbortSignal` (player pressed Cancel) — propagated into `callAI` and the server relay (`:435`). |
+| `timeoutMs` | Default `120000`. `0`/non-finite **disables** the deadline (jumps use `0` unless "Limit AI generation" is on → 300000, `:1888`). |
+| `userMessage` | The single user turn seeding `history`. |
+| `validatePayload` | Optional Layer-2 callback `(candidate, { attempt, finalAttempt })`. |
+| `variables` | Template variables for the rendered system prompt. |
+
+### 8.2 Prompt assembly (before the loop)
+
+1. `loadPromptCatalog` + `renderTemplate` build the system prompt from the campaign's frozen prompt pack (`:390`).
+2. Append the **difficulty directive** from `readGameData().difficulty` (`:400`).
+3. For `jumpForward`/`autoJumpForward`: append **[Player Agency]** and **[Map Truth]** blocks at call time (`:411-421`) — done here, not in `defaultPrompts.json`, because existing campaigns carry frozen prompt copies, so a call-time append is the only way the rule reaches them.
+4. For `actions`/jumps/catalysts: append **[International Reputation]** context (`:425`).
+
+### 8.3 The two-attempt loop (`:447-502`)
+
+```
+for (outputAttempt = 1; outputAttempt <= 2; outputAttempt++):
+    response = callAI(systemPrompt, history, { deadline, maxTokens: 8192, signal, tool })
+    parsed   = response.toolInput ?? extractJsonPayload(rawText)          // §9
+    validation = parsed ? validateGameplayPayload(taskKey, parsed) : {invalid}   // Layer 1
+    if (validation.valid && validatePayload):
+        taskError = await validatePayload(parsed, { attempt: outputAttempt,
+                                                    finalAttempt: outputAttempt === 2 })   // Layer 2
+        if (taskError) validation = { valid:false, error: taskError }
+    if (validation.valid): return { generation:{source:"ai"}, payload: parsed }
+    if (outputAttempt === 1 && !aborted):
+        history.push(model turn = rawText)
+        history.push(user turn = "Your previous structured answer failed validation: <error> <retryInstruction>")
+        continue
+```
+
+Key details:
+
+- **`maxTokens: 8192`** is a per-response output ceiling only for capped providers; Gemini ignores it (`:450`). Jumps used to request 16384, which only raised the ceiling and did nothing useful.
+- **`retryInstruction` adapts to how the model answered** (`:493`): a model that used a tool is told to "Call `<tool>` again with corrected input"; a prose model (no tool support) is told to "Respond again with ONLY the corrected JSON object". Telling a tool-less local model to call a tool it can't see would waste the one retry.
+- Only **one retry** exists (attempt 1 → attempt 2). Spend it wisely — this is why strict validators front-load the most fixable errors.
+
+### 8.4 `finalAttempt` — the linchpin of strict vs salvage
+
+`finalAttempt` is `outputAttempt === 2`, computed **in `runJsonTask` from the real attempt counter** (`:474`), never from counting validator invocations. The comment at `:465-472` explains why this matters: if attempt 1 dies at the schema/parse layer, `validatePayload` never runs, so a self-counting validator would think attempt 2 was its "first" call, emit *strict* feedback meant for the model, and hand that string to the player as a fallback reason (a real field report: fallbacks that read "Resend the same response with…"). Sourcing `finalAttempt` from the loop counter is what keeps strict feedback pointed at the model and salvage pointed at the player.
+
+### 8.5 Strict vs salvage — the contract
+
+Every Layer-2 validator follows the same discipline. `strict = !finalAttempt`:
+
+- **Attempt 1 (strict):** return a **corrective error string** describing exactly what's wrong. This becomes the retry message; the model usually fixes its own answer. Shape problems (wrong event count, stray dates, unresolvable region names, bad ops) are all strict here.
+- **Attempt 2 (final = salvage):** **never reject a finished generation to the canned fallback over cosmetics.** Instead repair in place: `clampTimelineDates` pulls stray dates into the window (`gameplay.js:187`, `:1914`), unresolvable transfers/ops are dropped, duplicate unit ids are deleted so normalization re-mints them. A good story with sloppy dates beats canned events every time.
+
+The jump validator (`:1897-1917`) is the canonical example: `const strict = !finalAttempt;` gates the event-count check, then `validateTimelineDates` (strict → return error; salvage → `clampTimelineDates`), then `validateGeneratedWorldChanges(..., { strictTransfers: strict })`. `pregameHistory` (`validatePregameEvents`, `:2013`) and `idleDiplomacy` follow the identical pattern.
+
+### 8.6 Outcomes
+
+| Situation | Result |
+|---|---|
+| Valid payload (either attempt) | `{ generation: { source: "ai", fallbackReason: "" }, payload }` (`:480`) |
+| Player cancelled (`signal.aborted`) | **Throws** the abort reason — never silently falls back (`:513`) |
+| No `fallback` provided + failure | Throws `AI task "<key>" failed: <reason>` (`:520`) |
+| `fallback` provided + failure/timeout | Warns, returns `{ generation: { source: "fallback", fallbackReason }, payload: await fallback() }` (`:524`) |
+
+Callers read `generation.source`/`fallbackReason` to tell the player whether they got a real AI turn or the deterministic fallback.
+
+---
+
+## 9. JSON recovery — `extractJsonPayload` (`gameplay.js:284`)
+
+When a model answers in prose instead of a tool call, `runJsonTask` must dig the JSON out. The recovery ladder:
+
+1. **Strip think blocks** — `<think>…</think>` and a leading `…</think>` (reasoning models / Ollama templates prepend these) (`:287`).
+2. **`lenientJsonParse`** the whole text (`:230`): try `JSON.parse`; on failure repair the two slips small models make — curly `"smart"` quotes → `"`, and trailing commas before `}`/`]` — then reparse. Repairs run **only after** a strict parse fails, so well-formed output is never touched.
+3. **Any fenced block** — `` ```json ``, `` ```JSON ``, `` ```javascript ``, or bare `` ``` `` — parsed leniently (`:297`).
+4. **`balancedJsonCandidates`** (`:243`) — a string-aware brace/bracket walker that extracts every balanced top-level `{…}`/`[…]`, sorted objects-first so a stray inline array in the model's commentary can't shadow the real object payload. Each candidate is parsed leniently; first object wins.
+5. Returns `null` if nothing parses → Layer 1 reports `"Response did not contain parseable JSON or tool arguments."`
+
+This ladder is what lets local/self-hosted models without tool support still play; hosted providers normally return clean `toolInput` and skip it entirely.
+
+---
+
+## 10. Where to look when…
+
+| You want to… | Go to |
+|---|---|
+| Add/change a field the model returns | `gameplaySchemas.js` `properties` + [§7 trap](#7-the-additionalpropertiesfalse-trap) |
+| Add a whole new task | Add schema → `GAMEPLAY_SCHEMAS` + tool → `GAMEPLAY_TOOLS`, then a caller using `runJsonTask` |
+| Change what makes a payload invalid (generic) | `validateGameplayPayload` (`gameplaySchemas.js:852`) |
+| Change map/world-aware validation | `validateGeneratedWorldChanges` (`gameplay.js:1002`) |
+| Tune retry feedback wording | The corrective strings returned by the validators (they are shown to the model verbatim) |
+| Debug "the AI turn silently became a fallback" | `runJsonTask` `failureReason`, and check whether a strict error leaked (see `finalAttempt`, §8.4) |
+| Debug provider tool wiring | `callAI` in `main.jsx` ([AI providers](ai-providers.md)) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,250 @@
+# Architecture Overview
+
+Open Historia is a turn-based, AI-driven grand-strategy game that renders the whole Earth as an interactive map. The frontend is a single React 19 SPA (Vite build) that draws the world with MapLibre GL + PMTiles vector tiles and hosts an OpenLayers-based map editor behind a URL flag; the same client bundle runs against **three interchangeable `/api` backends** selected at compile time — a local Express server (desktop download), an in-browser IndexedDB fetch-interceptor (hosted website), and an embedded nodejs-mobile server (Android app). Everything the client needs it asks for through the same `/api/*` calls, so the three variants differ only in what answers those calls.
+
+This page is the map of the codebase. Each subsystem has its own page; follow the cross-links.
+
+---
+
+## 1. Tech stack
+
+| Concern | Choice | Where |
+|---|---|---|
+| UI framework | React 19 (+ `babel-plugin-react-compiler`) | `package.json`, `vite.config.ts:77` |
+| Bundler / dev server | Vite 7 | `vite.config.ts`, `package.json` scripts |
+| Map renderer | MapLibre GL 5 via `react-map-gl/maplibre` | `src/Game/Map/World.jsx:3` |
+| Vector tiles | PMTiles 4 (`pmtiles`, `ol-pmtiles`) — regions / countries / cities archives | `src/runtime/assets.js`, `src/runtime/preload.js` |
+| Map editor renderer | OpenLayers 10 (`ol`) — lazy-loaded, editor route only | `src/App.jsx:7`, `src/Editor/OlMap.jsx` |
+| Geometry / GIS | `@turf/*`, `d3-geo`, `polygon-clipping`, `shpjs`, `geotiff` | `package.json` deps |
+| Charts | Chart.js 4 (stats panel) | `src/Game/GameUI/stats.jsx` |
+| Desktop/mobile server | Express 5 | `server/server.js`, `mobile/nodejs-project/` |
+| Signing / trust | `@noble/ed25519` (content manifests, node directory) | `trust/`, `src/runtime/web/contentTrust.js` |
+| Bundled tools | Azgaar Fantasy Map Generator (vendored) | `fmg/`, `scripts/fetch-fmg.mjs` |
+| Basemap raster tiles | ESRI/ArcGIS Online (public, token-free) + terrarium DEM (AWS) | `src/runtime/assets.js:82` |
+
+The heavy map binaries (`regions.pmtiles` ~101 MB, `countries.pmtiles`, `cities.pmtiles`, plus editor seed geojson) are **never bundled** — see [Map assets & PMTiles](map-assets.md). They live in `public/assets/`, are gitignored, and are fetched from a GitHub "map-data" Release on first launch. A Vite plugin (`dropMapBinaries`, `vite.config.ts:43`) deletes them from every build output so Cloudflare Pages' 25 MiB/file limit is never hit.
+
+---
+
+## 2. The three build variants
+
+All three run the identical `src/` client. What changes is (a) the `VITE_OH_WEB` compile-time flag and (b) which process answers `/api/*`.
+
+| Variant | Build command | `/api` backend | Asset storage | Distribution |
+|---|---|---|---|---|
+| **Desktop download** ("Download for Windows/Mac/Linux") | `npm run build` → `dist/` | Local Express server `server/server.js` on `localhost:3000` | Files under `server/data/` (JSON manifests + binary assets) | Zip + launcher scripts (`Launch Open Historia.*`) |
+| **Web build** (the hosted website `openhistoria.com/play/`) | `npm run build:web` / `build:site` → `dist-web/` | **No server** — a `fetch()` interceptor answers `/api/*` from IndexedDB | IndexedDB in the browser; map tiles from the registry Worker / content nodes | Cloudflare Pages |
+| **Android app** | client from `dist/` inside APK; server via `npm run build:mobile-server` | Embedded Express (`server/server.js`) run in-process by **nodejs-mobile**, bound to `127.0.0.1` | Files in a writable sandbox dir (`OH_DATA_DIR`) | Capacitor APK (`mobile/`) |
+
+### How the compile-time flag selects the variant
+
+The whole web branch hinges on one boolean literal, injected by Vite's `define`:
+
+```
+'import.meta.env.VITE_OH_WEB': JSON.stringify(mode === 'web')   // vite.config.ts:75
+```
+
+- `vite build` (any mode ≠ `web`) → `VITE_OH_WEB` is `false`. Rollup dead-code-eliminates every `if (import.meta.env.VITE_OH_WEB)` branch **and the dynamically-imported web backend** (`src/runtime/web/*`), so the desktop/Android bundle never pulls in IndexedDB stores, accounts, or the web-only generated seed files. This is why a fresh desktop extract (which has never run a web build) still builds and boots.
+- `vite build --mode web` → `VITE_OH_WEB` is `true`, and Vite additionally loads `.env.web` (`VITE_OH_PMTILES_URL`, `VITE_OH_HUB_URL`, `VITE_OH_ACCOUNT_URL`, `VITE_OH_DIRECTORY_URL`, `VITE_OH_GOOGLE_CLIENT_ID`). See [Web build & accounts](web-build.md).
+
+The one place the flag is read at boot is `src/main.jsx:28` (below). Because the web backend is behind a **dynamic `import()`**, the desktop build never even references the module.
+
+**Relevant `package.json` scripts:**
+
+| Script | Effect |
+|---|---|
+| `dev` | `vite` — desktop client on `:5173`, proxying `/api` → `http://localhost:3000` (`vite.config.ts:87`) |
+| `dev:web` | seeds web defaults, then `vite --mode web` |
+| `build` | desktop client → `dist/` |
+| `build:web` | seeds, then `vite build --mode web --outDir dist-web` |
+| `build:site` | `build:web` with `--base /play/` + `scripts/assemble-site.mjs` (bolts the marketing `site/` around `/play/`) |
+| `build:mobile-server` | `scripts/build-mobile-server.mjs` — bundles `server/` into `mobile/nodejs-project/` |
+| `test` | `node --test server/**/*.test.js` (server unit tests only) |
+
+---
+
+## 3. Boot sequence
+
+### 3a. `src/main.jsx` — the fork
+
+`index.html` loads exactly one module, `/src/main.jsx`. It:
+
+1. `configureMapRuntime()` — sizes MapLibre worker count + parallel image requests from `navigator.hardwareConcurrency` (`src/runtime/assets.js:398`).
+2. Renders `<App/>` into `#root`, then `startTranslator()` (live UI translation when a non-English language is set — see [i18n & translation](i18n.md)) and registers the service worker (`public/sw.js`, production only).
+3. **The fork** (`src/main.jsx:28`):
+   - If `VITE_OH_WEB`: `import("./runtime/web/index.js").then(installWebBackend)` installs the IndexedDB `/api` interceptor **before** `mount()`, so no request escapes uninstalled.
+   - Else: `mount()` directly.
+
+### 3b. `src/App.jsx` — routing (game vs editor)
+
+`App()` reads URL params **once at render** (keeps hook order stable):
+
+| URL | Renders | Notes |
+|---|---|---|
+| `?editor=1` | `<MapEditor/>` (lazy, `src/App.jsx:7`) | OpenLayers only fetched here; wrapped in `<Suspense>`. See [Map editor](map-editor.md) |
+| anything else | `<ErrorBoundary><GameApp/></ErrorBoundary>` | `ErrorBoundary` (`src/runtime/ErrorBoundary.jsx`) shows a recoverable Reload screen on a render throw instead of a blank page |
+
+### 3c. `GameApp` — startup preload & first render
+
+`GameApp` (`src/App.jsx:36`) always mounts `<Map>` immediately (behind a black `WorldShell`), and swaps a `<StartupScreen>` overlay for the `<UI>` once ready. Readiness is a race between a time budget and two async signals:
+
+| State / ref | Meaning | Set by |
+|---|---|---|
+| `startupState` | progress %, current stage, per-task steps | `runStartupPreload` progress callback (`src/runtime/preload.js`) |
+| `preloadFinishedRef` | the 8 preload tasks finished/timed out | preload `.finally` |
+| `worldIdleRef` / `hasFirstWorldIdle` | MapLibre fired its **first** `onIdle` (first world frame settled) | `<Map onInitialIdle={handleFirstWorldIdle}>` → `World.jsx:226` |
+| `isReady` | show `<UI>`, hide `<StartupScreen>` | true when **(preload done AND first world idle)**, OR when `STARTUP_TIME_BUDGET_MS` (30 s) elapses |
+
+A `requestAnimationFrame` loop (`src/App.jsx:67`) ticks `elapsedMs` and flips `isReady` when either condition is met. The overlay's last 3% ("Finalizing first world render") is gated on `hasFirstWorldIdle` so the bar never sits at 100% while the map is still blank.
+
+Before the preload even starts, `ensureLibraryCatalog()` (`src/runtime/library.js:187`) loads the games/scenarios catalog so the active game's cache token is known. The **8 preload tasks** (`src/runtime/preload.js:82`) warm: runtime JSON state, ESRI + terrain textures, `countries.pmtiles`, the country index, country labels, `cities.pmtiles`, and `regions.pmtiles`. See [Startup preload](startup-preload.md).
+
+Both `<Map>` and `<UI>` are keyed on `activeGameId` (not the library token) so a scenario "Apply & Play" — which writes many assets and bumps the token repeatedly — remounts the map exactly **once** (`src/App.jsx:57`, `:169`).
+
+---
+
+## 4. Directory map
+
+### Repo root
+
+| Path | What lives there |
+|---|---|
+| `src/` | The React client (all three variants share this) |
+| `server/` | Express server + on-disk stores (desktop + embedded mobile backend) |
+| `scripts/` | Build/seed/signing/asset tooling (`.mjs`) — see below |
+| `public/` | Static assets served as-is: `assets/` (map binaries, gitignored), `lang/` shipped language packs, `sw.js`, signed `content-manifest.json` / `node-directory.json`, marketing HTML (`guides/`, `how-to-play/`, …) |
+| `site/` | Marketing homepage shell wrapped around `/play/` by `build:site` |
+| `mobile/` | Android app: Capacitor (`android/`, `www/`, `capacitor.config.json`) + `nodejs-project/` embedded server |
+| `node-content/` + `server/node.js` | Content-node server (hash-addressed, read-only) — see [Content nodes](content-nodes.md) |
+| `fmg/` | Vendored Azgaar Fantasy Map Generator (served at `/fmg` for the editor's Generate console) |
+| `trust/` | Ed25519 root key material + `pinned-key.js` for content/directory verification |
+| `tools/import-counter/` | Cloudflare Worker: self-hosted scenario-import counter |
+| `hub-templates/` | GitHub issue templates for the community scenario/basemap hub |
+| `dist/`, `dist-web/`, `dist-site/` | Build outputs (desktop, web, assembled site) |
+| `vite.config.ts`, `index.html`, `.env.web` | Build config + web-mode env |
+
+### `src/` layout
+
+| Path | Responsibility | Deep-dive |
+|---|---|---|
+| `src/main.jsx` | Entry: runtime config, mount, web/desktop fork | §3a |
+| `src/App.jsx` | Route split (game vs editor), startup race | §3b/3c |
+| `src/Game/Map/` | MapLibre map + layers: `World.jsx` (map shell + style), `Nations.jsx` (region fills/borders/labels), `Cities.jsx`, `Units.jsx` + `unitsController.js`/`unitCombat.js`, `MarkersLayer.jsx`, `GlobeEffects.jsx` + globe sun/star canvases, `useWorldState.js`, `useCustomBackground.js` | [Map rendering](map-rendering.md) |
+| `src/Game/GameUI/` | The HUD: `main.jsx` (shell), `libraryBar.jsx` (top bar + main menu), `time.jsx` (date/turn), `chat.jsx` (toolbar/inbox), `advisor.jsx`, `forces.jsx`, `settings.jsx`, `search.jsx`, `stats.jsx`, `scenarios.jsx`, `communityHub.jsx`, `actions.jsx`, `cheats.jsx`, `FactionCreator.jsx`, `CountryPickerMap.jsx`, `other.jsx` | [Game UI](game-ui.md) |
+| `src/Game/Selection/` | Click-target popups: `Regions.jsx`, `CountryPanel.jsx`, `Units.jsx`, `Features.jsx` | [Selection & popups](selection.md) |
+| `src/Game/AI/` | AI turn engine: `main.jsx` (provider chat), `gameplay.js`, `gameplayPrompts.js`, `gameplaySchemas.js`, `promptContext.js`, `providerConfig.js`, `defaultPrompts.json` | [AI system](ai-system.md) |
+| `src/runtime/` | Client "kernel": asset/endpoint layer, game/world state, library catalog, preload, i18n, startup UI | below |
+| `src/runtime/web/` | **Web-only** backend (dead-code-stripped from desktop): `index.js`, `router.js`, IndexedDB stores, accounts, sync, nodes, home page | [Web build & accounts](web-build.md) |
+| `src/Editor/` | OpenLayers map editor (author custom maps) | [Map editor](map-editor.md) |
+
+### `src/runtime/` (the client kernel)
+
+| File | Role |
+|---|---|
+| `assets.js` | The asset/endpoint hub: defines `JSON_URLS`, `PMTILES_ARCHIVES`, ESRI basemaps, MapLibre `pmtiles`/`ohbase` protocols, `readJson`/`writeJson`/`warm*`, per-token cache sweeping. §5 |
+| `library.js` | React store (`useSyncExternalStore`) for games/scenarios; wraps `/api/library`, `/api/games`, `/api/scenarios`; wires the active cache token + country-name overrides into `assets.js` |
+| `gameState.js` | `GAME_DEFAULTS` + `WORLD_DEFAULTS`; read/write of the per-game `game.json` and `world.json` runtime state | [World state](world-state.md) |
+| `preload.js` | The 8 startup warm tasks + progress model. §3c |
+| `StartupScreen.jsx` / `ErrorBoundary.jsx` | Loading overlay; render-error recovery |
+| `countryLabels.js`, `countryFlags.js`, `countryTags.js`, `countryNames`/`polityNames.js` | Country label/flag/tag/name resolution from `countries.pmtiles` + overrides |
+| `communityBasemaps.js`, `communityFlags.js`, `basemapLibrary.js`, `flagLibrary.js` | Community/basemap/flag catalogs |
+| `mapSettings.js`, `difficulty.js`, `scenarios.js` | Map display settings, difficulty directives, scenario helpers |
+| `translator.js`, `i18n.js` | Live UI translation + language directives |
+| `generated/` | Build-time generated tables (country names, etc.) |
+
+### `scripts/` and `server/` (quick index)
+
+| `scripts/*.mjs` | Purpose |
+|---|---|
+| `fetch-map-assets.mjs` / `map-assets.json` | Pull map binaries from the map-data Release |
+| `seed-web-defaults.mjs` | Generate web-build seed data (default scenario) |
+| `build-mobile-server.mjs` | Bundle `server/` into the APK's nodejs-project |
+| `extract-regions.mjs` / `extract-cities.mjs` / `build-default-map.mjs` | Build the PMTiles/geojson map data |
+| `build-content-manifest.mjs` / `sign-release.mjs` / `gen-signing-key.mjs` | Content-node manifest signing (Ed25519) |
+| `generate-country-*.mjs`, `generate-lang-packs.mjs`, `fetch-fmg.mjs`, `populate-node.mjs`, `node-updater.mjs` | Data/tooling generation |
+
+| `server/*.js` | Purpose |
+|---|---|
+| `server.js` | The Express app: all `/api/*` routes, CORS, CSRF guard, static SPA serve, AI relay, hub proxy, shutdown |
+| `libraryStore.js` | Games + scenarios store (catalog, assets, runtime JSON, import/export) — the on-disk heart |
+| `mapEditorStore.js`, `basemapStore.js`, `flagStore.js` | Editor docs, basemaps, "My flags" stores |
+| `dataDir.js` | Resolves the single writable `DATA_DIR` (`OH_DATA_DIR` or `server/data`) |
+| `security.js` | Cross-origin write policy, hub URL allowlist, byte-range parsing |
+| `ownerMigration.js`, `trust.js`, `country-names.json` | Owner code→name migration, trust helpers, data |
+| `node.js` | Standalone content-node server (separate process) |
+
+---
+
+## 5. Data flow: frontend ↔ `/api` ↔ stored assets
+
+The client **never** talks to storage directly. Every state read/write is a same-origin `/api/*` call built in `src/runtime/`. A backend answers it. This indirection is exactly what lets the same client run on Express, IndexedDB, or nodejs-mobile.
+
+### The runtime asset endpoints
+
+`setRuntimeAssetEndpoints({ token })` (`src/runtime/assets.js:204`) rebuilds every URL whenever the active library token changes, stamping `?v=<token>` for cache-busting and **sweeping the previous generation's caches** (a ~190 MB-per-switch GeoJSON leak fix — see [World state](world-state.md) and the RAM audit notes). The two endpoint families:
+
+| Family | URL | Backed by | Payload |
+|---|---|---|---|
+| Runtime **JSON** state | `/api/runtime/json/:key` (GET/PUT) | `readRuntimeJsonAsset`/`writeRuntimeJsonAsset` in `libraryStore.js` | Per-game/scenario state: `game`, `world`, `events`, `chat`, `advisor`, `actions`, `colors`, `flags`, `tags`, `prompts`, `snapshots`, `regionsGeojson`, `citiesGeojson`, `backgroundData` (`assets.js:260`) |
+| Runtime **binary** tiles | `/api/runtime/pmtiles/:key` (GET/HEAD, range) | `resolveRuntimeBinaryAsset` → `streamBinaryFile` | `regions` / `countries` / `cities` PMTiles archives (or a scenario override) |
+
+`game` vs `world`: `game.json` holds the player-facing scenario meta (`GAME_DEFAULTS` — country, difficulty, dates, round), `world.json` holds the mutable simulation (`WORLD_DEFAULTS` — units, markers, catalyst, reputation, region ownership/claimants, tags, label styling, history). Both are `gameState.js`.
+
+### The `/api` surface (`server/server.js`)
+
+| Route group | Methods | Store |
+|---|---|---|
+| `/api/library` | GET | Combined catalog (games + scenarios + active/selected ids + token) |
+| `/api/games`, `/api/games/:id`, `/api/games/active`, `/api/games/:id/assets/:key` | GET/POST/PUT/DELETE | `libraryStore.js` games |
+| `/api/scenarios`, `/api/scenarios/:id`, `/api/scenarios/selected`, `/api/scenarios/:id/export`, `/api/scenarios/import`, `/api/scenarios/:id/import`, `.../assets/:key` | GET/POST/PUT/DELETE | `libraryStore.js` scenarios + bundle import/export |
+| `/api/runtime/json/:key`, `/api/runtime/pmtiles/:key` | GET/PUT/HEAD | per-game runtime state + tiles |
+| `/api/mapeditor/documents…` | GET/POST/PUT/DELETE | `mapEditorStore.js` |
+| `/api/basemaps…`, `/api/flags…` | GET/POST/DELETE | `basemapStore.js`, `flagStore.js` |
+| `/api/ui-settings`, `/api/lang/:code` | GET/PUT | shared UI language + accumulated translation packs |
+| `/api/ai/relay` | POST | Server-to-server relay to the player's OpenAI-compatible AI endpoint (defeats CORS) |
+| `/api/hub/file`, `/api/hub/import-log`, `/api/hub/import-counts` | GET/POST | Community hub GitHub proxy (SSRF-guarded to GitHub hosts) + self-hosted import counter |
+| `/api/server/shutdown` | POST | Exits the process (the ⏻ button) |
+| `/fmg/*`, `*splat` | GET | Vendored FMG static + SPA fallback (`index.html`) |
+
+**Security middleware** (`server/server.js:73`, `:112`): blanket permissive CORS (so the Android WebView's cross-origin *probe* works) but state-changing writes are blocked unless same-origin or loopback (`crossOriginWriteAllowed` in `security.js`); override with `OH_ALLOW_CROSS_ORIGIN=1`. See [Server & security](server-api.md).
+
+### The three backends, one contract
+
+| Backend | Entry | How it answers `/api/*` |
+|---|---|---|
+| Express (desktop / mobile) | `server/server.js` | Real HTTP routes; assets on disk under `DATA_DIR` (`server/dataDir.js`) |
+| Web (browser) | `src/runtime/web/index.js` → `router.js` | Monkey-patches `window.fetch`: same-origin `/api/*` is routed to IndexedDB store handlers (`libraryStore.js`, `basemapStore.js`, `flagStore.js`, `editorStore.js`, `settingsStore.js`); PMTiles resolve to `VITE_OH_PMTILES_URL` or a connected content node; `/api/hub/*` forwards to the registry Worker. Everything non-`/api` passes through to the real `fetch`. |
+| Embedded mobile | `mobile/nodejs-project/main.js` | Picks a writable `OH_DATA_DIR`, first-run-seeds from a bundled `seed/` snapshot, best-effort downloads map binaries, then `import("./server/server.js")` bound to `127.0.0.1`; the WebView loads it same-origin |
+
+Because the web router keys on `url.origin === location.origin && pathname.startsWith("/api/")` (`router.js:153`), the client code (`library.js`, `assets.js`, editor IO, basemap library) is **byte-identical** across variants — it just calls `fetch("/api/…")`.
+
+### Map render path (read side)
+
+`World.jsx` builds a MapLibre style from three inputs — the ESRI basemap (via the `ohbase://` protocol that swaps ESRI's "not yet available" placeholder tiles for upscaled ancestors, `assets.js:418`), the terrarium DEM terrain/hillshade, or a **custom uploaded background** (image or vector) that replaces ESRI entirely (`useCustomBackground.js`). On top, child layers render game data pulled from the runtime JSON + PMTiles: `<Nations>` (region fills/borders/labels), `<Cities>`, `<Units>`, `<MarkersLayer>`, plus the `<Selection>` popups. Globe vs mercator, terrain on/off, and fullscreen are React state in `GameApp`, persisted to `localStorage` and passed down to both `<Map>` and `<UI>`. See [Map rendering](map-rendering.md).
+
+### Write side (mutations)
+
+Gameplay writes flow: **AI turn / cheat / UI action → `gameState.js` write → PUT `/api/runtime/json/{world|game|events|…}` → store persists → library token bumps → `assets.js` sweeps stale caches → affected layers re-read**. Library mutations (create/select/save game or scenario, asset upload) go through `src/runtime/library.js`, which force-refreshes the catalog and re-syncs the runtime token. See [World state](world-state.md) and [AI system](ai-system.md).
+
+---
+
+## 6. Beyond the game loop
+
+| Subsystem | Summary | Page |
+|---|---|---|
+| **Map editor** | `?editor=1` route, OpenLayers, authors custom region/city/basemap maps, exports scenario bundles; can run the vendored FMG generator | [Map editor](map-editor.md) |
+| **Community hub** | Scenario/basemap sharing via GitHub issues; server/Worker proxies downloads and counts imports | [Community hub](community-hub.md) |
+| **Content nodes** | `server/node.js` — anyone-runnable, hash-addressed, read-only file server that offloads map-tile/bundle delivery; client re-verifies every byte against the signed manifest | [Content nodes](content-nodes.md) |
+| **Web accounts + sync** | Google sign-in + E2E-encrypted game/scenario sync against the registry Worker (web build only) | [Web build & accounts](web-build.md) |
+| **i18n** | `startTranslator()` live-translates the UI; server accumulates AI-generated language packs | [i18n & translation](i18n.md) |
+
+---
+
+### Quick "where do I look?" index
+
+- Something wrong on the **map** → `src/Game/Map/` (start `World.jsx`, then `Nations.jsx`).
+- Wrong **HUD/button** → `src/Game/GameUI/main.jsx` wires the shell; each control is its own file.
+- **State not saving / stale after switch** → `src/runtime/gameState.js` + `src/runtime/assets.js` (`setRuntimeAssetEndpoints` cache sweep) + `src/runtime/library.js`.
+- **API 404 / route** → `server/server.js` (desktop) or `src/runtime/web/router.js` (web).
+- **Build/variant weirdness** → `vite.config.ts` (`define` flag + `dropMapBinaries`) and `.env.web`.
+- **Boot hangs / blank screen** → `src/App.jsx` startup race + `src/runtime/preload.js`.

--- a/docs/assets-and-data.md
+++ b/docs/assets-and-data.md
@@ -1,0 +1,298 @@
+# Map Data & Assets
+
+Open Historia paints the world from a handful of heavy, mostly-static binaries (three PMTiles vector archives, two GeoJSON seed/geometry files) plus small per-scenario JSON documents (colors, flags, tags, world state). This page traces where each asset physically lives (app bundle vs. the writable `OH_DATA_DIR` vs. a GitHub Release vs. a Cloudflare-hosted content swarm), how the server route layer resolves a scenario override on top of the shared default, and how the browser client (`src/runtime/assets.js`) caches, warms, primes, and memoizes everything without OOMing the tab. The single load-bearing rule: the big binaries are **never** in Git — they are downloaded from a GitHub Release named `map-data` on first launch, checksum-verified, and served locally.
+
+---
+
+## 1. Asset catalog
+
+Every runtime asset the map depends on, with its physical filename, MIME, and how it reaches the browser.
+
+| Asset | Key | File on disk | Source of truth | Served to client via | Notes |
+|---|---|---|---|---|---|
+| Regions vector tiles | `regions` | `regions.pmtiles` (~105.8 MB) | `map-data` Release | `GET /api/runtime/pmtiles/regions` | GADM level-1 borders; the z0 tile is the region catalog; paints owners above z6.5 |
+| Countries vector tiles | `countries` | `countries.pmtiles` (~62.7 MB) | `map-data` Release | `GET /api/runtime/pmtiles/countries` | z0 tile is the country index + label source; warmed on **every** map |
+| Cities vector tiles | `cities` | `cities.pmtiles` (~1.5 MB) | `map-data` Release | `GET /api/runtime/pmtiles/cities` | Modern-day city labels layer |
+| Custom regions geometry | `regionsGeojson` | `regions.geojson` (per-scenario) | Scenario dir / `default` scenario | `GET /api/runtime/json/regionsGeojson` | Editor-drawn shapes; `EMPTY_FEATURE_COLLECTION` when absent; **never cached client-side** |
+| Custom cities geometry | `citiesGeojson` | `cities.geojson` (per-scenario) | Scenario dir | `GET /api/runtime/json/citiesGeojson` | Era-accurate city points; rendered when `world.customCities`; **never cached client-side** |
+| Region seed | — | `regions-seed.geojson` (~55.3 MB) | `map-data` Release → `public/assets/` | `GET /assets/regions-seed.geojson` | Offline-produced seed the **map editor** imports; not a runtime map layer |
+| City seed | — | `cities-seed.json` (~7.9 MB) | `map-data` Release → `public/assets/` | `GET /assets/cities-seed.json` | Consumed by the editor (`citiesImport.js`) and AI prompt context (`promptContext.js`) |
+| Nation colors | `colors` | `colors.json` (~3.4 KB) | Scenario dir, else app palette | `GET /api/runtime/json/colors` | Owner-name → hex; falls back to immutable `public/assets/colors.json` |
+| Nation flags | `flags` | `flags.json` (per-scenario) | Scenario dir | `GET /api/runtime/json/flags` | Owner code → PNG data URL; `{}` when absent |
+| Nation tags | `tags` | `tags.json` (per-scenario) | Scenario dir | `GET /api/runtime/json/tags` | Owner code → `string[]`; **starting** tags only (merge with `world.countryTags`) |
+| Map background | `backgroundData` | `background.json` (per-scenario) | Scenario dir | `GET /api/runtime/json/backgroundData` | Heavy `{dataUrl}`/`{geojson}` payload; loaded only when `world.background` set |
+| World state | `world` | `world.json` (per-game/scenario) | Game dir, else scenario | `GET /api/runtime/json/world` | The live simulation document — see [World state](world-state.md) |
+| Runtime game JSON | `game`, `events`, `chat`, `actions`, `advisor`, `prompts`, `snapshots` | under game `storage/` | Game dir | `GET/PUT /api/runtime/json/<key>` | Per-game session state; polled ~5s |
+
+The client-side URL and PMTiles-archive tables are declared in `src/runtime/assets.js:63` (`JSON_URLS`) and `src/runtime/assets.js:122` (`PMTILES_ARCHIVES` / `PMTILES_PROTOCOL_URLS`). The server-side filename maps live in `server/libraryStore.js` — `PMTILES_ASSET_FILES` (`:281`), `SCENARIO_GEOJSON_ASSET_FILES` (`:291`), `OPTIONAL_JSON_ASSET_FILES` (`:258`), and `JSON_ASSET_DEFAULTS` (`:326`).
+
+**Basemap raster** (satellite/streets/terrain imagery) is *not* one of these files — it streams live from public ESRI/ArcGIS Online and AWS terrain tile servers (§8), so it is not part of the `map-data` Release.
+
+---
+
+## 2. Where assets come from — the four sources
+
+An asset can be resolved from up to four places. Which one wins depends on the build (desktop/embedded vs. web) and whether the active scenario ships an override.
+
+| Source | What lives there | Which builds |
+|---|---|---|
+| **App bundle** (`public/assets/`, or `dist/assets/` in a built app) | The shared default `*.pmtiles`, `*-seed.*`, immutable `colors.json` | Desktop / Termux |
+| **`OH_DATA_DIR`** (`server/data/…`, or a writable sandbox on Android) | Per-scenario overrides, per-game state, and — on the embedded server — the downloaded pmtiles under `<DATA_DIR>/assets/` | All node-server builds |
+| **`map-data` GitHub Release** | Canonical copies of every heavy binary, checksum-pinned | Fetched at install/update time |
+| **Cloudflare / content-node swarm** | Byte-identical pmtiles served over HTTP range requests, hash-verified | Web build only |
+
+### `OH_DATA_DIR` and the data-dir resolver
+
+`server/dataDir.js:16` exports the single writable root every store shares:
+
+```
+DATA_DIR = process.env.OH_DATA_DIR ? resolve(OH_DATA_DIR) : <server>/data
+```
+
+Desktop and Termux leave `OH_DATA_DIR` unset → `server/data` (byte-identical layout). The **Android** app runs `server.js` in-process via nodejs-mobile and sets `OH_DATA_DIR` to a writable sandbox, because the `server/data` shipped inside the APK is read-only. `server/libraryStore.js:20` derives `DIST_DIR`, `PUBLIC_DIR`, and `DATA_ASSETS_DIR` (`= <DATA_DIR>/assets`, `:32`) from it.
+
+### PMTiles resolution order (server)
+
+`resolveRuntimeBinaryAsset(assetKey)` — `server/libraryStore.js:2371` — resolves in this order and streams the first hit with `streamBinaryFile`:
+
+1. **Scenario override** — `getScenarioUploadPath(scenario.id, assetKey)` (an editor-uploaded per-scenario archive).
+2. **Fetched data-dir copy** — `<DATA_DIR>/assets/<file>.pmtiles` (embedded Android server, downloaded on first run).
+3. **Bundle fallback** — `public/assets/<file>.pmtiles`.
+
+Because step 1 can serve different bytes after a scenario switch, the client rotates its PMTiles caches on token change (§6) — a correctness fix, not just memory hygiene.
+
+### JSON resolution order (server)
+
+`readRuntimeJsonAsset(assetKey)` — `server/libraryStore.js:2218`:
+
+- **Custom geometry** (`regionsGeojson`/`citiesGeojson`, in `SCENARIO_GEOJSON_ASSET_FILES`): resolved from the active game's scenario dir. A non-default scenario with no `regions.geojson` of its own **borrows the `default` scenario's** Modern-Day geometry (`:2237`); missing entirely → `EMPTY_FEATURE_COLLECTION`.
+- **Per-game state** (`world`, `events`, `game`, `colors`, `flags`, `tags`, `snapshots`, …): active game dir first (`:2258`), then the selected scenario dir (`:2271`).
+- **Optional JSON fallback** (`:2285`): only `colors` has a built-in fallback — the immutable app palette resolved from `dist/assets/colors.json` or `public/assets/colors.json` (`COLORS_ASSET_CANDIDATES`, `:356`). `flags`/`tags` with no file → `{}`.
+- Otherwise → `JSON_ASSET_DEFAULTS[assetKey] ?? {}`.
+
+---
+
+## 3. The `map-data` GitHub Release + manifest
+
+The heavy binaries used to live in Git LFS; the org's free LFS *bandwidth* is 1 GB/month shared, and a full checkout pulls ~200 MB, so a few installs exhausted it and every subsequent download 403'd. They now ship as **assets on a GitHub Release** (`Open-Historia/open-historia`, tag `map-data`), whose download bandwidth is free and unmetered. See `scripts/fetch-map-assets.mjs:1` for the full rationale.
+
+### `scripts/map-assets.json`
+
+The manifest that `fetch-map-assets.mjs` reads. Note the **name/namespace split**: `path` is the *stable client location* the game serves from; `asset` is the *versioned release filename* uploaded to GitHub.
+
+| `path` (stable client name) | `asset` (release name) | bytes | Why the names differ |
+|---|---|---|---|
+| `public/assets/regions.pmtiles` | `regions.pmtiles` | 105 827 424 | same |
+| `public/assets/countries.pmtiles` | `countries.pmtiles` | 62 739 546 | same |
+| `public/assets/cities.pmtiles` | `cities.pmtiles` | 1 547 924 | same |
+| `public/assets/cities-seed.json` | `cities-seed.json` | 7 857 627 | same |
+| `public/assets/regions-seed.geojson` | **`regions-seed-z8.geojson`** | 55 350 393 | client name is stable; release name is versioned to a zoom generation (z8) |
+| `server/data/scenarios/default/regions.geojson` | **`default-regions-names.geojson`** | 55 401 660 | the `default` scenario's named custom-region geometry |
+
+Root keys: `owner: "Open-Historia"`, `repo: "open-historia"`, `release: "map-data"`. Download URL is `https://github.com/<owner>/<repo>/releases/download/<release>/<asset>`.
+
+**Namespacing gotcha:** the client always requests the *stable* path (e.g. `regions-seed.geojson`), while the release stores a *versioned* name (`regions-seed-z8.geojson`). The manifest is the only bridge. If a new zoom generation is uploaded under a new release name but the manifest's `sha256`/`bytes` aren't bumped, clients keep the old bytes; conversely a stable client name can silently point at a stale release generation. **When a map file changes: upload the new asset AND update its `sha256` + `bytes` in the manifest.**
+
+### `scripts/fetch-map-assets.mjs`
+
+Makes the local tree match the manifest. Called by the launcher and updater **in place of** `git lfs pull`.
+
+| Mode | Command | Behaviour |
+|---|---|---|
+| Verify | `node scripts/fetch-map-assets.mjs` | Re-fetch anything whose SHA-256 differs (picks up a re-uploaded map, repairs truncation) |
+| Ensure | `node scripts/fetch-map-assets.mjs --ensure` | Faster: trusts size, only fetches missing / wrong-size files |
+
+Downloads to `<dst>.download`, verifies the SHA-256 **before** renaming into place, and is **best-effort**: it never exits non-zero (`process.exit(0)` on every path, `fetch-map-assets.mjs:92`) so a network failure can never block a launch or update. Requires Node 18+ for global `fetch`.
+
+### Embedded (Android) variant
+
+`mobile/nodejs-project/fetchMapAssets.mjs` uses the **same** release + checksums but routes every asset into the writable `OH_DATA_DIR` instead of the read-only APK bundle (`fetchMapAssets.mjs:25` `targetFor`):
+
+- `server/data/<x>` → `<DATA_DIR>/<x>` (scenario geojson)
+- `public/assets/<x>` → `<DATA_DIR>/assets/<x>` (the pmtiles)
+
+This is why `resolveRuntimeBinaryAsset` checks `<DATA_DIR>/assets` before the bundle (§2).
+
+---
+
+## 4. Server runtime routes
+
+The client talks only to these same-origin routes (`server/server.js`). In the **web build** there is no Express server — a `fetch()` interceptor in `src/runtime/web/router.js` answers the same paths from IndexedDB / a content CDN (§7).
+
+| Route | Handler | Purpose |
+|---|---|---|
+| `GET /api/runtime/json/:assetKey` | `readRuntimeJsonAsset` | Serve a runtime JSON doc; `Cache-Control: no-store` (`server.js:459`) |
+| `PUT /api/runtime/json/:assetKey` | `writeRuntimeJsonAsset` | Persist to the active game; echoes back the normalized record (`server.js:470`) |
+| `GET /api/runtime/pmtiles/:assetKey` | `resolveRuntimeBinaryAsset` | Stream a pmtiles archive (range-capable via `streamBinaryFile`) (`server.js:481`) |
+| `HEAD /api/runtime/pmtiles/:assetKey` | `resolveRuntimeBinaryAsset` | `Content-Length` for the client freshness check; `Accept-Ranges: bytes` (`server.js:490`) |
+| `GET/PUT/DELETE /api/scenarios/:id/assets/:assetKey` | scenario asset store | Upload/serve per-scenario overrides (pmtiles, geojson, flags, tags, cover) (`server.js:333`) |
+| `GET/PUT/DELETE /api/games/:id/assets/:assetKey` | game asset store | Per-game images (`server.js:400`) |
+
+`writeRuntimeJsonAsset` (`libraryStore.js:2314`) auto-creates a game from the selected scenario if none is active, canonicalizes country refs for `world`/`game`/`colors`, then writes to the game dir and returns the re-read record. That echoed record is what the client caches (§5, `writeJson`).
+
+---
+
+## 5. Client asset layer — `src/runtime/assets.js`
+
+The browser's single module for reading, writing, warming, priming, and caching every asset. All URLs carry a `?v=<runtimeAssetToken>` query so a library mutation invalidates by URL identity.
+
+### Endpoint wiring — `setRuntimeAssetEndpoints`
+
+`assets.js:204`. Called on boot and on every scenario/game/library switch with a new `token`. It:
+
+1. **Sweeps the old generation's caches BEFORE rebuilding the URLs** (`:218`) — the old URL strings are the only handles to those entries, so this must run first or the parsed GeoJSON (~190 MB on a 55 MB `regions.geojson`) is stranded forever.
+2. Rebuilds every `JSON_URLS.*` = `withRuntimeToken("/api/runtime/json/<key>")` (`:260`).
+3. Rebuilds `PMTILES_ARCHIVES.*` = `buildAbsoluteUrl("/api/runtime/pmtiles/<key>")` (`:275`) and the `pmtiles://…` protocol URLs (`:279`).
+
+The token also gates the PMTiles cache rotation (`:239`): dropping `binaryValueCache`, `binaryRequestCache`, `pmtilesArchives`, the `Protocol` tile registry, and the `pmtilesCache` header — both to free the ~162 MB of warmed buffers and because `/api/runtime/pmtiles/:key` can serve *different bytes* after a switch (a stale directory applied to new bytes would decode garbage).
+
+### Reading JSON — `readJson`
+
+`assets.js:544`. Options: `{ cache, defaultValue, force, signal }`.
+
+| Behaviour | Detail |
+|---|---|
+| Store decision | Snapshotted synchronously at call time via `isNoStoreJsonUrl` (see below) — never re-evaluated post-`await` |
+| Value cache | `jsonValueCache` (Map, URL-keyed, no TTL/cap; swept on token change) |
+| Request batching | `jsonRequestCache` de-dupes concurrent fetches to the same URL even with `force:true` — the ~5 s Nations/Cities/background/units pollers share one network request |
+| Failure fallback | With `defaultValue`, serves a clone but **does not cache** it (transient failure must not pin a default) |
+| Parse bookkeeping | `jsonLoadedUrls.add(url)` records a genuine parse *inside* the try — lets `loadRegionCatalog` tell "no custom regions" apart from "fetch failed, retry" |
+
+`isNoStoreJsonUrl(url)` (`assets.js:158`) returns true for `regionsGeojson` and `citiesGeojson`. These FeatureCollections are huge and their only long-lived reader keeps them in React state (`Nations.jsx`/`Cities.jsx`, both `force:true`), so caching a second parsed copy is pure waste. It **must** be evaluated synchronously (the comment at `:154` explains why an after-`await` check resurrects the leak on scenario switch).
+
+### Writing JSON — `writeJson` / `primeJson`
+
+- `writeJson(url, data)` (`assets.js:618`) `PUT`s the payload, then caches **what the store echoed back** (the normalized record), not what was sent — legacy-record rewrites on the way in used to be pinned out of view. It calls `primeJson`, `invalidateDerivedCachesForWrite`, and `persistResponse`.
+- `primeJson(url, data)` (`assets.js:602`) seeds the value cache (or deletes it for no-store URLs) and marks `jsonLoadedUrls`. Used to make a write immediately visible without a round-trip.
+- `invalidateDerivedCachesForWrite(url)` (`assets.js:177`) drops the memoized `colors`/`flags`/`tags`/`world`-derived promises on a matching write and fires the `oh:colors-updated` DOM event so the live map repaints without a reload.
+
+### Reading/priming binary — PMTiles
+
+| Function | Line | Role |
+|---|---|---|
+| `getPmtilesArchive(url)` | `818` | Return cached `PMTiles` or register a new one |
+| `warmPmtilesArchive(url)` | `829` | Download the full archive into `binaryValueCache`, then prime. **Web build** tries the hash-verified node swarm first (`contentTrust.js`), falls through to the origin |
+| `primePmtilesArchive(url, buffer)` | `823` | Store the ArrayBuffer and register a `MemorySource`-backed archive |
+| `registerPmtilesArchive(url)` | `390` | `new PMTiles(source, pmtilesCache)` + register on the `Protocol` |
+
+`MemorySource` (`assets.js:364`) wraps an in-memory `Uint8Array` and satisfies `getBytes(offset, length)` locally, so once an archive is warmed the PMTiles library slices it in memory instead of issuing range requests. `createPmtilesArchive` (`:382`) uses a `MemorySource` when the bytes are in `binaryValueCache`, else the URL (range fetches). Directory/header decode caching is the shared `pmtilesCache = new SharedPromiseCache(256)` (`:141`).
+
+### `resolveCountryDisplayName` and the resolver
+
+`assets.js:288`. `resolveCountryDisplayName(name, code)` delegates to a swappable `countryNameResolver` installed via `setCountryNameResolver` (`:284`) — the i18n / localization layer registers a resolver so PMTiles feature names (`Country`/`NAME`/…) render translated. It defaults to identity. Used by both `loadCountryNames` and `loadRegionCatalog` when decoding the z0 tile.
+
+### Cache inventory
+
+| Cache | Keyed by | Contents | Rotated on token? |
+|---|---|---|---|
+| `jsonValueCache` | full URL | parsed JSON docs | yes |
+| `jsonRequestCache` | full URL | in-flight JSON promises | yes |
+| `jsonLoadedUrls` (Set) | full URL | "did a genuine parse happen" | yes |
+| `binaryValueCache` | full URL | pmtiles `ArrayBuffer`s | yes |
+| `binaryRequestCache` | full URL | in-flight pmtiles fetches | yes |
+| `pmtilesArchives` | full URL | `PMTiles` instances | yes |
+| `pmtilesCache` | source key | header/dir LRU (256) | header entry cleared |
+| `runtimeJsonValueCache` / `runtimeJsonRequestCache` | asset **key** | web-build IndexedDB-backed docs | cleared (correctness) |
+| `remoteValueCache` / `remoteRequestCache` | URL | warmed raster tile sizes | no |
+| memoized promises: `nationColorsPromise`, `nationFlagsPromise`, `nationTagsPromise`, `countryNamesPromise`, `regionCatalogPromise` | scenario token | derived catalogs | re-keyed |
+
+---
+
+## 6. Persistent Cache Storage + freshness
+
+`fetchWithPersistence(url)` (`assets.js:336`) layers a `CacheStorage` cache (`PRELOAD_CACHE_NAME = "open-historia-preload-v2"`, `:11`) over the network so warmed assets survive reloads:
+
+1. Look up the persisted `Response`.
+2. If present, issue a **`HEAD`** and compare `Content-Length` against the cached copy's. Equal (or the server can't answer, i.e. offline) → serve cached. Differ → refetch (an update replaced the file on disk).
+3. Miss → `fetch(url, {cache:"force-cache"})`, then `persistResponse(url, clone)`.
+
+The `v1` → `v2` cache-name bump (`:9`) exists because `v1` had no freshness check and could serve months-old map data forever; the bump flushes everyone once and the `HEAD` check keeps it fresh thereafter. `jsonHeadersFor` (`:32`) stamps the real UTF-8 byte length on client-written responses so the `HEAD` comparison isn't silently disabled by a missing `Content-Length`.
+
+The **web build** uses a parallel key namespace: `buildRuntimeCacheUrl(key)` (`:333`) → `…/__runtime-cache/<key>.json`, read/written by `readRuntimeJson` / `writeRuntimeJson` (`:666`, `:705`) which are keyed by *asset key* (not URL) and therefore cleared wholesale on a token change (they'd otherwise serve the previous game's state).
+
+---
+
+## 7. Web build differences
+
+Under `import.meta.env.VITE_OH_WEB` there is no node server:
+
+- **Route interception:** `src/runtime/web/router.js:31` installs a `fetch` interceptor for same-origin `/api/*`. `/api/runtime/pmtiles/:key` (`router.js:51`) checks a scenario override in IndexedDB (`getScenarioPmtilesOverride`), else fetches `${VITE_OH_PMTILES_URL || "/assets"}/<key>.pmtiles`. The hosted site sets `VITE_OH_PMTILES_URL` to the **registry Worker's CORS+range proxy**, because Cloudflare Pages can't host the 60–100 MB archives directly (same-origin would 404 to the SPA fallback).
+- **Verified content swarm:** `warmPmtilesArchive` (`assets.js:855`) dynamically imports `src/runtime/web/contentTrust.js` and calls `fetchVerifiedBuffer(url)`. It maps the URL to a manifest asset id (`assetIdFromUrl`, `contentTrust.js:72`), fetches `<node>/oh/v1/content/<sha256>` from the vetted node swarm, and verifies **every byte** against the signed `content-manifest.json` (`:140`). A bad/broken node can at worst force a retry — it can never deliver tampered bytes — and any failure falls through to the canonical origin, so a node outage is invisible. The signed node **directory** (`VITE_OH_DIRECTORY_URL`) is a deny-list/control doc; live addresses come from `nodes-live.json`. This whole block is stripped from the local download.
+
+See the [Node network](node-network.md) notes for the swarm/registry architecture.
+
+---
+
+## 8. Startup preload + the ~162 MB prime
+
+`src/runtime/preload.js` warms the map before React fully mounts, inside a **30 s time budget** (`STARTUP_TIME_BUDGET_MS`, `:16`). Tasks run serially, each with an `AbortController` wired to the remaining budget; the budget expiring aborts the current task and leaves the rest to load lazily in-game.
+
+| # | id | Label | Weight | Warms | Skipped on custom map? |
+|---|---|---|---|---|---|
+| 1 | `state` | Syncing saves and runtime state | 12 | `game`,`prompts`,`colors`,`actions`,`chat`,`advisor`,`events`,`world` JSON | no |
+| 2 | `textures` | Warming world textures | 20 | ESRI basemap + AWS terrain raster tiles (global z0–2 + initial viewport) | **yes** — a custom `world.background` replaces the basemap entirely |
+| 3 | `countries` | Caching country geometry | 26 | `countries.pmtiles` (~62.7 MB) | **no** — needed for names + labels on every map |
+| 4 | `country-index` | Building country index | 8 | `loadCountryNames()` | no |
+| 5 | `country-labels` | Building country labels | 14 | `warmCountryLabelCollections()` | no |
+| 6 | `cities` | Caching city layer | 10 | `cities.pmtiles` (~1.5 MB) | no |
+| 7 | `regions` | Caching regional borders | 24 | `regions.pmtiles` (~105.8 MB) | **no** — paints owners above z6.5 even on custom maps |
+
+**The ~162 MB prime:** warming tasks 3+6+7 pulls all three archives fully into `binaryValueCache` as in-memory `ArrayBuffer`s — the code cites regions ≈101 MB + countries ≈60 MB + cities ≈1.5 MB ≈ **162 MB** resident (`assets.js:231`; on-disk manifest sizes total ~170 MB). This is a deliberate memory-for-latency trade: a fully-warmed `MemorySource` archive answers tile requests without further network I/O. The cost is that this ~162 MB must be **freed on scenario switch** — which is exactly what the PMTiles cache rotation in `setRuntimeAssetEndpoints` (§5) does. See the [RAM & paint audit](performance.md) notes for the broader memory backlog (the geojson double-store, pinned PMTiles).
+
+Task results feed a weighted progress bar: `normalizeTaskResult` (`preload.js:165`) sums the `.size` of each warmed asset into `loadedBytes`, and `progress = completedWeight / TOTAL_WEIGHT`.
+
+---
+
+## 9. Derived catalogs (memoized accessors)
+
+These read the z0 PMTiles tile (or a JSON doc) once per scenario and cache the derived result on the scenario token. They power AI prompts, pickers, and labels.
+
+| Accessor | Line | Reads | Produces | Cache key |
+|---|---|---|---|---|
+| `getNationColors()` | `900` | `colors.json` | owner-name → hex map | `JSON_URLS.colors` |
+| `getNationFlags()` | `949` | `flags.json` | owner-code → PNG data URL (`{}` default) | `JSON_URLS.flags` |
+| `getNationTags()` | `933` | `tags.json` | owner-code → `string[]` **starting** tags (merge with `world.countryTags`) | `JSON_URLS.tags` |
+| `loadCountryNames()` | `965` | `countries.pmtiles` z0 tile + `world.polityOverrides` | sorted `{code,name}[]` country index | `PMTILES_ARCHIVES.countries` |
+| `loadRegionCatalog()` | `1036` | `regions.pmtiles` z0 tile + `regions.geojson` custom names | sorted `{id,name,country,countryCode}[]` | `PMTILES_ARCHIVES.regions` + `JSON_URLS.regionsGeojson` |
+
+Common invariants: each drops its promise on failure so the next call **retries** instead of pinning an empty catalog for the session; each is invalidated by `invalidateDerivedCachesForWrite` when its underlying asset is written.
+
+- **`loadCountryNames`** decodes the `countries` vector-tile layer, dedupes by resolved display name (`resolveCountryDisplayName`), then merges `world.polityOverrides` — a nameless override never degrades a real name to a bare code (`:1008`).
+- **`loadRegionCatalog`** decodes the stock `regions` layer, then **overlays the scenario's own `regions.geojson`**: the world's own name for a region wins (a world that renamed "Warmińsko-Mazurskie" to "South Konisburg" talks about South Konisburg everywhere, `:1109`), and editor-drawn `reg_*` shapes the stock tiles don't know get named from the custom geometry. It uses `jsonLoadedUrls.has(regionsGeojson)` (`:1101`) — not a truthiness test on the payload — to distinguish "no custom regions" (stock names correct) from "fetch failed" (retry), because the server answers a geometry-less scenario with a 200 empty FeatureCollection.
+
+`decodeVectorTile(data)` (`assets.js:885`) lazily imports `@mapbox/vector-tile` + `pbf` and is the shared decoder for both catalogs.
+
+---
+
+## 10. Basemap raster + terrain (asset-adjacent)
+
+Not part of the `map-data` Release, but resolved through this module. `ESRI_BASEMAPS` (`assets.js:82`) lists ten public, token-free ArcGIS Online services with per-layer `maxZoom`; `DEFAULT_BASEMAP_ID = "ocean"` (`:94`). The selected id is read from `localStorage["map_basemap_style"]` (`selectedBasemapId`, `:112`).
+
+| Concern | Mechanism |
+|---|---|
+| Low-zoom source | Direct ESRI XYZ template `esriTileTemplate(id)` (`:104`) |
+| High-zoom source | `ohbase://<id>/{z}/{y}/{x}` protocol (`basemapProtocolTemplate`, `:109`), registered by `ensureBasemapProtocol` (`:537`) |
+| Placeholder swap | ESRI serves an identical "Map Data Not Yet Available" JPEG (HTTP 200) past a layer's coverage; `basemapTileLoader` (`:513`) byte-detects it (learned from two ocean tiles, `loadPlaceholderRef` `:454`) and synthesizes an upscaled crop of the nearest real ancestor (`synthesizeFromAncestor`, `:471`) |
+| Terrain | `TERRAIN_TILE_TEMPLATE` → AWS `elevation-tiles-prod` terrarium PNGs (`:119`) |
+| Runtime tuning | `configureMapRuntime` (`:398`) sizes MapLibre worker count + parallel image requests from `hardwareConcurrency` |
+
+Raster tiles are warmed via `warmRemoteResources` / `warmRemoteResource` (`assets.js:775`, `:732`) with bounded concurrency (default 6), caching only the *size* per URL (the bytes live in the browser HTTP cache under `force-cache`).
+
+---
+
+## Quick file map
+
+| File | Role |
+|---|---|
+| `src/runtime/assets.js` | Client asset layer: read/write/warm/prime, caches, derived catalogs, basemap protocols |
+| `src/runtime/preload.js` | 30 s startup warm sequence + progress model |
+| `src/runtime/web/router.js` | Web-build `fetch` interceptor for `/api/*` (pmtiles → `VITE_OH_PMTILES_URL`) |
+| `src/runtime/web/contentTrust.js` | Web-build hash-verified content-node fetch |
+| `scripts/fetch-map-assets.mjs` | Desktop/updater: sync local tree to the `map-data` Release |
+| `scripts/map-assets.json` | The Release manifest (paths, versioned asset names, sha256, bytes) |
+| `mobile/nodejs-project/fetchMapAssets.mjs` | Embedded-server variant → downloads into `OH_DATA_DIR` |
+| `server/server.js` | Express `/api/runtime/{json,pmtiles}` routes |
+| `server/libraryStore.js` | Server-side asset resolution (scenario override → data-dir → bundle) |
+| `server/dataDir.js` | `DATA_DIR` / `OH_DATA_DIR` resolver |
+
+Related pages: [World state](world-state.md) · [Node network](node-network.md) · [Performance / RAM](performance.md)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,263 @@
+# Contributing & Conventions
+
+Open Historia is an open-source, community-driven alternative to Pax Historia: a React + Vite client, an Express server (`server/server.js`), a vector map editor, and a small fleet of build/release scripts. This page is the practical orientation for a new contributor — where the code lives, how it flows to players through the release channels, how to run and test it locally, the commit/style rules the maintainer enforces, and the handful of identifiers and data-hosting rules you must **not** break. There is no `CONTRIBUTING.md` in the repo; this doc is the closest thing, distilled from `README.md`, `package.json`, `.github/workflows/`, the license banners in the source, and `.gitattributes`/`.gitignore`.
+
+For the systems these conventions govern, see [Architecture](architecture.md), [Server](server.md), [Assets & data](assets-and-data.md), and [Web build](web-build.md).
+
+---
+
+## 1. Repository & remote layout
+
+The canonical repo is the **`Open-Historia` GitHub org**: `Open-Historia/open-historia`. That is what `README.md` tells players to clone (`git clone https://github.com/Open-Historia/open-historia.git`) and what every workflow, license banner, and asset manifest points back to.
+
+This working clone (`work-repo`) has several remotes configured — useful to know so you push to the right place:
+
+| Remote | URL | Role |
+|--------|-----|------|
+| `upstream` | `github.com/Open-Historia/open-historia` | The canonical org repo. PRs land here; this is "the repo". |
+| `origin` | `github.com/Arkniem/pax-historia-2` | Maintainer's personal working fork. |
+| `beta` | `github.com/Arkniem/Open-Historia-Beta` | Beta staging fork. |
+| `ltfork` | `github.com/lt20202122/open-historia` | A contributor fork. |
+
+`scripts/map-assets.json` hard-codes `"owner": "Open-Historia", "repo": "open-historia", "release": "map-data"` — the org repo is also where the large binary release assets live (see §9).
+
+Sibling repos in the same org that the code and docs reference (not part of this repo):
+
+| Repo | Purpose |
+|------|---------|
+| `Open-Historia/open-historia-node` | Community **content node** — caches/serves read-only, checksum-verified map data. |
+| `Open-Historia/open-historia-admin` | Private registry Worker (D1) + signing panel; deploys the website and node directory. |
+| `Open-Historia/Open-historia-scenarios` | The Scenario Hub — official presets + community scenarios. |
+
+---
+
+## 2. Branches & the release channel model
+
+The repo ships to players through **rolling per-channel GitHub Releases**, driven entirely by which branch you push to. The workflows in `.github/workflows/` are the source of truth:
+
+| Branch | Built by | Produces |
+|--------|----------|----------|
+| `main` | `.github/workflows/app-bundle.yml` | `Open-Historia.zip` on the **`app-stable`** release (stable desktop bundle). |
+| `main` | `.github/workflows/deploy-site.yml` | Deploys **openhistoria.com** (Cloudflare Pages) via `npm run build:site`. |
+| `beta` | `.github/workflows/app-bundle.yml` | `Open-Historia.zip` on the **`app-beta`** release. |
+| (any) `mobile/**` change | `.github/workflows/android-apk.yml` | `pax-historia.apk` on the **`android`** release (run from the Actions tab, or push an `android-v*` tag). |
+
+`app-bundle.yml` runs on **every push to `main` and `beta`**, so the download never goes stale (`.github/workflows/app-bundle.yml:13-15`). It picks the channel from `github.ref_name`: `main → app-stable`, else `app-beta` (`app-bundle.yml:57-68`).
+
+`deploy-site.yml` skips its build for `**.md`, `mobile/**`, and `.github/**` changes (docs/app can't change what the site serves) and refuses to deploy any file over Cloudflare Pages' 25 MiB limit (`deploy-site.yml:21-27`, `:58-68`).
+
+There is also an **`alpha`** staging branch and a large number of feature branches (typically a `feature`, `feature-alpha`, `feature-beta`, `feature-main` family per change). Feature work is developed on a topic branch, staged, then merged toward the release channels. When in doubt about the target branch for a PR, ask the maintainer rather than guessing — the channel topology (dev → alpha → beta → main) is maintainer-managed.
+
+---
+
+## 3. The PR-only workflow (submit; maintainer merges)
+
+**Contributors submit pull requests. A maintainer reviews and merges — you do not merge your own PR.** The git history is almost entirely `Merge pull request #NNN from Open-Historia/<branch>` commits authored by the maintainer (`Arkniem`), i.e. every change lands through a reviewed PR.
+
+Practical flow:
+
+1. Fork `Open-Historia/open-historia` (or branch, if you have push access).
+2. Create a topic branch off the appropriate base.
+3. Make your change; run `npm run lint` and `npm test` locally (see §7–8).
+4. Open a PR against the org repo. Describe *why*, not just *what* — the codebase's comment culture (§5) extends to PR descriptions.
+5. A maintainer merges. Do not force-push shared branches or self-merge.
+
+---
+
+## 4. Commit identity & attribution rules
+
+These are hard rules — the maintainer enforces them on every commit and PR.
+
+### No AI attribution — ever
+
+**Do not add `Co-Authored-By: Claude …` trailers, `Generated with Claude Code` footers, or any AI-attribution line** to commit messages or PR bodies. This applies whether or not an AI tool touched the change. Commits and PRs read as authored by a human contributor, full stop.
+
+### Author identity
+
+Commit under **your own GitHub-linked identity** (use your GitHub `noreply` email so commits attribute to your account, e.g. `<id>+<user>@users.noreply.github.com`). The maintainer commits as `Arkniem` (Nicholas Krol). Do not impersonate another contributor's name/email.
+
+### License-banner authorship is separate from Git authorship
+
+The **file-header license banners** (§5) credit **Nicholas Krol** because they mark the portions covered by the map-editor MIT license — that is a *licensing* statement, not a claim of Git authorship. Don't remove or rewrite an existing banner when you edit a file; leave the attribution intact.
+
+---
+
+## 5. Coding style & conventions
+
+### License banners on source files
+
+Almost every source file (~111 across `src/`, `server/`, `scripts/`) opens with a one-line (or short block) MIT banner pointing at `src/Editor/LICENSE`. Two forms are in use:
+
+```js
+/*! Open Historia — portions (short description of what this file does) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+```
+
+```js
+/*!
+ * Open Historia Map Editor
+ * Copyright (c) 2026 Nicholas Krol - MIT License (see src/Editor/LICENSE).
+ */
+```
+
+Even config, workflows, and `.gitattributes` carry the banner (`.github/workflows/*.yml:1`, `vite.config.ts:1`, `eslint.config.js` excepted). **When you add a new file, add a banner** in the same style with a short parenthetical describing the file's role. When you edit an existing file, keep its banner.
+
+Licensing is split by directory: the map editor and its tooling — the contents of `src/Editor/`, `scripts/extract-regions.mjs`, and `server/mapEditorStore.js` — are MIT © Nicholas Krol per `src/Editor/LICENSE`; the project as a whole is MIT © "Developers of the Open-Historia Project" per the top-level `LICENSE`.
+
+### Verbose, explanatory comments (the house style)
+
+The single most distinctive convention: **comments explain *why*, name the trap, and often cite the failure mode** — not what the next line literally does. They are frequently multi-sentence and read like short design notes. Representative examples worth imitating:
+
+- `vite.config.ts:7-23` — a full paragraph on why the pmtiles are dropped from the bundle, including that "the trap is that it only fires on a machine that has actually played."
+- `server/security.js:1-4`, `:11-14` — the banner explains *why* the helpers are split out (unit-testable without the server), and each function comment states the exact attack it blocks ("Rejects `../`, a path separator (including the `%2f` Express decodes back into `/`)…").
+- `.github/workflows/deploy-site.yml:5-15` — explains *why* CI deploys the site rather than connecting Pages to the repo, and the map-binary trap it sidesteps.
+- `server/ownerMigration.test.js:3-7` — notes fixtures are "TRANSCRIBED FROM THE REAL SHIPPED DATA, not invented."
+
+Match this: when you write a non-obvious line, leave a comment that would stop the next person from "fixing" it back into a bug.
+
+### Linting, TypeScript, and the React compiler
+
+| Tool | Config | Notes |
+|------|--------|-------|
+| ESLint 9 (flat config) | `eslint.config.js` | Runs on `**/*.{ts,tsx}` with `js.configs.recommended`, `typescript-eslint`, `react-hooks`, and `react-refresh` (Vite). `dist` is globally ignored. Run: `npm run lint`. |
+| TypeScript 5.9 | `tsconfig*.json` | `.ts`/`.tsx` are type-checked and linted; much of the game UI is `.jsx` (not strictly typed). Both coexist. |
+| React 19 + React Compiler | `vite.config.ts:77-82` | The build enables `babel-plugin-react-compiler`. Don't hand-write memoization that fights the compiler; follow the Rules of Hooks (react-hooks lint enforces this). |
+
+Note ESLint only targets `.ts`/`.tsx` — the many `.jsx`/`.js` files are not linted by the current config, so rely on review and the comment culture there.
+
+### Line endings
+
+`.gitattributes` forces **LF** on `*.sh` and `*.command` — "CRLF breaks bash on Linux/macOS." Keep the launcher scripts LF; don't let an editor rewrite them to CRLF.
+
+---
+
+## 6. Running the app locally
+
+Prerequisites: **Node.js 22 LTS or newer** (minimum `^20.19.0 || >=22.12.0`, enforced by `package.json:engines`; Vite 7 requires it) and Git.
+
+### First-time setup
+
+```bash
+git clone https://github.com/Open-Historia/open-historia.git
+cd open-historia
+node scripts/fetch-map-assets.mjs   # download world-map binaries (NOT in the repo — see §10)
+npm install
+```
+
+### Two ways to run
+
+**A. Production-style (matches what players get):**
+
+```bash
+npm run build           # vite build -> dist/
+node server/server.js   # Express server on http://localhost:3000
+```
+
+Open **http://localhost:3000**. The server (`server/server.js`) serves `dist/`, exposes the `/api/*` routes (library/scenario stores, map-editor store, basemaps, flags, the AI relay, the hub proxy, and `/api/runtime/pmtiles/:assetKey` for streaming map binaries off disk), and enforces the CORS/CSRF guards in `server/security.js`. See [Server](server.md).
+
+**B. Hot-reload dev (run BOTH processes):**
+
+```bash
+node server/server.js   # terminal 1 — the API/server on :3000
+npm run dev             # terminal 2 — Vite dev server (HMR)
+```
+
+Vite proxies `/api` to `http://localhost:3000` (`vite.config.ts:86-91`), so the editor's save/load and the game's runtime endpoints work under HMR. You need the Express server running alongside `vite` — the dev server alone has no backend.
+
+### Other run/build scripts (`package.json:scripts`)
+
+| Script | What it does |
+|--------|--------------|
+| `npm run dev` | Vite dev server (desktop/local mode). |
+| `npm run dev:web` | Seeds web defaults (`scripts/seed-web-defaults.mjs`) then `vite --mode web`. |
+| `npm run build` | `vite build` → `dist/` (the desktop client). |
+| `npm run build:web` | Web build → `dist-web/` (base `/`). See [Web build](web-build.md). |
+| `npm run build:site` | Web build at base `/play/` + `scripts/assemble-site.mjs` (landing page at `/`, game at `/play/`) → `dist-site/`. |
+| `npm run build:mobile-server` | `scripts/build-mobile-server.mjs` — assembles the in-process Node server the Android app embeds (nodejs-mobile). |
+| `npm run lint` | ESLint over the repo. |
+| `npm run preview` / `preview:web` | Serve a built bundle for inspection. |
+
+`--mode web` builds the browser-playable website; **any other mode builds the local/desktop app** (`vite.config.ts:63-64`). The web flag is compiled to a literal (`import.meta.env.VITE_OH_WEB`) so Rollup dead-code-eliminates the web runtime out of the desktop build (`vite.config.ts:66-76`).
+
+### The desktop launcher scripts
+
+`Launch Open Historia.{bat,command,sh}` are the player-facing entry points: they check Node, run `scripts/fetch-map-assets.mjs`, `npm install`, `npm run build`, and start the server. `Update Open Historia.*` re-pulls while preserving saves/scenarios/map data. Keep them LF (§5).
+
+---
+
+## 7. Running tests
+
+```bash
+npm test
+# => node --test "server/**/*.test.js"
+```
+
+Tests use the **built-in Node test runner** (`node --test`) with `node:assert/strict` — **no test framework, no extra deps**. They target the server's pure, dependency-light helpers (they run without booting the server):
+
+| Test file | Covers |
+|-----------|--------|
+| `server/security.test.js` | Path containment, the CSRF/origin guard, HTTP range parsing, the hub host allowlist (`server/security.js`). |
+| `server/ownerMigration.test.js` | The owner-code → owner-name resolver, with fixtures transcribed from real shipped scenario data (`server/ownerMigration.js`). |
+
+Convention when adding tests: colocate a `*.test.js` next to the module under `server/`, keep the tested functions **pure** so they need no server, and prefer real transcribed fixtures over invented ones (`server/ownerMigration.test.js:3-7`). The `server/**/*.test.js` glob picks them up automatically. The client (`src/`) has no automated test suite; render-path changes are verified by actually booting the app.
+
+---
+
+## 8. Load-bearing identifiers that must never change
+
+These strings are wired into external contracts (release assets players download, the Android package identity, update checks). Renaming any of them silently breaks installs or self-updates. **Treat them as frozen.**
+
+| Identifier | Where | Why it's frozen |
+|-----------|-------|-----------------|
+| **`io.github.arkniem.paxhistoria`** (Capacitor `appId`) | `mobile/capacitor.config.json:2` | The Android application ID. Changing it makes every existing install a *different* app — no in-place update; users would get a duplicate. |
+| **`pax-historia.apk`** (release asset name) | `.github/workflows/android-apk.yml:59,63,75` | The exact filename players download from the `android` release, and what the app's self-update check fetches. The README links it by name. |
+| **`android`** (rolling release tag) | `android-apk.yml:73-75` | The APK is republished to this single rolling release; the app updates itself from it. |
+| **`app-stable` / `app-beta`** (release tags) | `app-bundle.yml:57-68` | The `Open-Historia.zip` download tags for the two desktop channels. |
+| **`Open-Historia.zip`** (bundle asset name) | `app-bundle.yml:54,84`; README | The one-download full app; linked by name. |
+| **`map-data`** (release) + the per-asset names | `scripts/map-assets.json` | The map-binary release and asset names (`regions.pmtiles`, `regions-seed-z8.geojson`, `default-regions-names.geojson`, …). The fetch script resolves these by name; a rename orphans every fetch. |
+| **`app.paxhistoria`** (Capacitor `hostname`) | `mobile/capacitor.config.json:7` | The WebView origin the Android app serves under. |
+| **`Build: N`** convention | `android-apk.yml:32-35,72` | The boot screen matches `__APP_BUILD__` (stamped from the run number) against `Build: N` in the release notes to decide whether to self-update. Keep both sides in sync. |
+
+When a map file legitimately changes, you upload a *new* asset and update its `sha256`/`bytes` in `scripts/map-assets.json` — you don't rename the contract-facing names.
+
+---
+
+## 9. The map-data-off-LFS rule
+
+**The large world-map binaries are not in the repo and must never be re-added to Git (or Git LFS).** They are hosted as assets on the `map-data` GitHub Release and downloaded on demand by `scripts/fetch-map-assets.mjs`, which reads `scripts/map-assets.json`.
+
+Why: LFS's free bandwidth (1 GB/month, shared org-wide) was exhausted by a handful of player installs. Release-asset download bandwidth is free and unmetered. This is stated three times in the tree so it can't be missed: `.gitattributes:6-11`, `.gitignore` ("Large world-map binaries" block), and `scripts/map-assets.json:_comment`.
+
+The gitignored / release-hosted files:
+
+| File | Manifest asset name |
+|------|--------------------|
+| `public/assets/regions.pmtiles` | `regions.pmtiles` |
+| `public/assets/countries.pmtiles` | `countries.pmtiles` |
+| `public/assets/cities.pmtiles` | `cities.pmtiles` |
+| `public/assets/cities-seed.json` | `cities-seed.json` |
+| `public/assets/regions-seed.geojson` | `regions-seed-z8.geojson` |
+| `server/data/scenarios/default/regions.geojson` | `default-regions-names.geojson` |
+
+Rules of thumb:
+- **Never `git add`** any `*.pmtiles`, the seed geojson/json, or the default scenario's `regions.geojson`. They're gitignored; don't `-f` them in.
+- **To change a map file:** upload the new asset to the `map-data` release, then update its `sha256` + `bytes` in `scripts/map-assets.json`. `fetch-map-assets.mjs` re-downloads any listed file that's missing or hash-mismatched.
+- **The builds actively drop these from the bundle** — `vite.config.ts`'s `dropMapBinaries` plugin deletes the pmtiles (and, for web, the editor seeds) after copy, because Cloudflare Pages rejects any file over 25 MiB and nothing loads a pmtiles archive from the bundle anyway (the desktop streams them off disk via `/api/runtime/pmtiles/:assetKey`; the web build fetches them from content nodes, hash-verified). Don't defeat this plugin. See [Assets & data](assets-and-data.md).
+
+Related gitignored-but-not-in-LFS runtime artifacts you also shouldn't commit: `/fmg/` (vendored Fantasy Map Generator, fetched by `scripts/fetch-fmg.mjs`), `/src/runtime/web/generated/` (web seed), `/node-content/` (content-node store), and the offline signing keys `trust/*.key.pem` / `*.key` (**never commit a signing key**).
+
+---
+
+## 10. Quick reference — where things live
+
+| You want to… | Look at |
+|--------------|---------|
+| Change the server API / routes | `server/server.js`, `server/*Store.js`, [Server](server.md) |
+| Touch security guards | `server/security.js` (+ `security.test.js`) |
+| Edit the map editor | `src/Editor/` (separately licensed — `src/Editor/LICENSE`) |
+| Edit the game map / UI | `src/Game/` — see [Game map](game-map.md), [Game UI](game-ui.md) |
+| World-state fields & flow | [World state](world-state.md) |
+| AI prompts / schemas | [AI overview](ai-overview.md), [AI schemas](ai-schemas.md) |
+| Build/release plumbing | `.github/workflows/`, `scripts/`, `vite.config.ts` |
+| Map-data hosting | `scripts/map-assets.json`, `scripts/fetch-map-assets.mjs` (§9) |
+| Rebuild an official preset | `scripts/presets/build-preset.mjs <spec>` |
+| Web/site deploy | `WEB-DEPLOY.md`, [Web build](web-build.md) |

--- a/docs/delivery-and-deploy.md
+++ b/docs/delivery-and-deploy.md
@@ -1,0 +1,342 @@
+# Delivery, Deploy & Releases
+
+Open Historia ships to four surfaces from one repo: a **downloadable desktop app** (self-hosted local server), an **Android app** (embedded in-process server), the **playable website** (`openhistoria.com`, static app on Cloudflare Pages), plus supporting **Cloudflare Workers** (import counter, node registry). Which surface a commit reaches, and when, is decided by *which long-lived channel branch it lands on* (`main` / `beta` / `alpha`) and *which GitHub Actions workflow or local deploy engine fires*. This page maps every build script, workflow, release, and the local admin-panel deploy path, and traces how a single change flows out to players.
+
+The Vite build has one pivotal switch — `--mode web` — that produces a *completely different* artifact from the default build (`vite.config.ts:65`). Almost everything below hangs off that distinction: desktop vs. web.
+
+---
+
+## 1. Build scripts (`package.json`)
+
+Every delivery path starts with one of these npm scripts (`package.json:9`). The mode (`web` or not) is the load-bearing difference — it flips `import.meta.env.VITE_OH_WEB` into a compile-time literal so Rollup dead-code-eliminates the whole web (or desktop) runtime from the other build (`vite.config.ts:75`).
+
+| Script | Command | Output dir | Mode | Base | Purpose |
+|---|---|---|---|---|---|
+| `build` | `vite build` | `dist/` | *(default/desktop)* | `/` | The desktop/local app bundle. Served by the Express server (`server/server.js`) and copied into the Android app. |
+| `build:web` | `seed-web-defaults.mjs` → `vite build --mode web --outDir dist-web --emptyOutDir` | `dist-web/` | `web` | `/` | The browser game as a standalone Pages site (base `/`). Used by `WEB-DEPLOY.md`'s manual path. |
+| `build:site` | `seed-web-defaults.mjs` → `vite build --mode web --base /play/ --outDir dist-web` → `assemble-site.mjs` | `dist-site/` | `web` | `/play/` | The **combined** `openhistoria.com`: landing page at `/`, game under `/play/`. This is what actually deploys to production. |
+| `build:mobile-server` | `node scripts/build-mobile-server.mjs` | `mobile/nodejs-project/` | — | — | Assembles the embedded Node server for the APK. Runs *after* `build`. |
+| `dev` / `dev:web` | `vite` / `seed-web-defaults.mjs && vite --mode web` | — | — | — | Local dev. `dev` proxies `/api` → `localhost:3000` (`vite.config.ts:87`). |
+
+**The map-binary trap** (`vite.config.ts:10-60`): the ~160 MB pmtiles/geojson live in `public/` so the dev and Express servers can serve them off disk, but Vite copies `publicDir` wholesale into the bundle. Neither build wants them there (the desktop streams them via `/api/runtime/pmtiles/:assetKey`; the web build fetches them from content nodes). The `oh-drop-map-binaries` Vite plugin deletes them from the output in `closeBundle()` — pmtiles from both builds, plus the editor seeds (`regions-seed.geojson`, `cities-seed.json`) from the *web* build only. This matters because Cloudflare Pages rejects any file over 25 MiB, and `regions.pmtiles` is ~101 MB — so without the drop, `build:site` produces a site Pages refuses. The trap "only fires on a machine that has actually played" (the files are gitignored and only arrive from the `map-data` Release), which is why CI and fresh clones build fine and the failure looks random.
+
+---
+
+## 2. Branch topology & the PR-triplet convention
+
+### Remotes (`work-repo`)
+
+| Remote | URL | Role |
+|---|---|---|
+| `upstream` | `github.com/Open-Historia/open-historia` | Canonical org repo. Has `main`, `beta`, `alpha` branches. All CI runs here. |
+| `beta` | `github.com/Arkniem/Open-Historia-Beta` | Beta fork lineage. |
+| `origin` | `github.com/Arkniem/pax-historia-2` | Working fork. |
+| `ltfork` | `github.com/lt20202122/open-historia` | Contributor fork. |
+
+### The three long-lived channels
+
+| Channel branch | What it feeds | CI trigger | Reaches players via |
+|---|---|---|---|
+| `main` | Stable | `app-bundle.yml` (push) → `app-stable` release; `deploy-site.yml` / admin-panel button → Cloudflare Pages | Desktop stable download; the live website |
+| `beta` | Beta testers | `app-bundle.yml` (push) → `app-beta` release | Desktop beta download |
+| `alpha` | Experimental staging | *(no push-triggered workflow)* — `android-apk-beta.yml` checks out `alpha` on demand | Only reaches users when its work is **bridged** into `beta`/`main`, or via a manually dispatched beta APK |
+
+`alpha` is a staging branch with **no CI publish trigger of its own**. Work on `alpha` does not reach any installed app or the website until it is bridged forward into `beta` (then `main`). The one exception is `android-apk-beta.yml`, which is dispatch-only and always builds from `alpha` regardless of where it is run (§4.3).
+
+### The PR-triplet convention
+
+A single change is landed as **three parallel branches**, one per channel, and submitted as three PRs — one against `main`, one against `beta`, one against `alpha`. The naming is `<feature>-main` / `<feature>-beta` / `<feature>-alpha`. This is visible throughout the branch list, e.g.:
+
+- `colony-labels-disputed-{alpha,beta,main}`
+- `editor-verbatim-region-shade-{alpha,beta,main}`
+- `fix/editor-autosave-{alpha,beta,main}`
+- `ai-time-limit-toggle-{alpha,beta,main}`
+- `date-salvage-{alpha,beta,main}`
+
+Each triplet member targets its like-named channel because the three channels have diverged (different features in flight), so a change usually needs a per-channel port rather than a clean cherry-pick. PRs are submit-only; the maintainer merges (see the repo-conventions memory).
+
+> **Commit/PR attribution:** commit as the account-linked identity; **no** Claude `Co-Authored-By` trailer and **no** "Generated with Claude Code" footer (repo policy).
+
+---
+
+## 3. GitHub Releases catalog
+
+Delivery leans on **rolling releases** (fixed tags whose assets are re-uploaded with `--clobber`) rather than one release per version. This keeps a single stable download URL per surface.
+
+| Release tag | Built by | From | Asset(s) | Prerelease? | For |
+|---|---|---|---|---|---|
+| `app-stable` | `app-bundle.yml` | push to `main` | `Open-Historia.zip` (source + map data) | no (`--latest=false`) | One-download desktop install, stable |
+| `app-beta` | `app-bundle.yml` | push to `beta` | `Open-Historia.zip` | no (`--latest=false`) | One-download desktop install, beta |
+| `android` | `android-apk.yml` | `workflow_dispatch` / `android-v*` tag | `pax-historia.apk` | no | Stable Android app; the app self-updates from here |
+| `android-beta` | `android-apk-beta.yml` *(off-main, §4.3)* | `workflow_dispatch`, checks out `alpha` | `pax-historia.apk` | **yes** (`--prerelease`) | Experimental in-app-server Android build; isolated from stable |
+| `map-data` | *manually uploaded* | — | `regions.pmtiles`, `countries.pmtiles`, `cities.pmtiles`, `cities-seed.json`, `regions-seed-z8.geojson`, `default-regions-names.geojson` | — | The ~200 MB world-map binaries, off Git LFS (§7) |
+
+The `pax-historia.apk` asset name is contractual — it (and the Android `appId`) must never change, because the installed app's self-update polls a fixed release/asset URL.
+
+---
+
+## 4. GitHub Actions workflows (`.github/workflows/`)
+
+Three workflow files live on `main`. A fourth (`android-apk-beta.yml`) lives only on the beta-APK lineage.
+
+### 4.1 `app-bundle.yml` — full-app one-download bundle
+
+`.github/workflows/app-bundle.yml`. Packages the **whole app plus the world-map data** into one `Open-Historia.zip` so players install with a single download — no Git, no Git LFS, no separate map-data step.
+
+| Aspect | Detail |
+|---|---|
+| Triggers | `workflow_dispatch`; push to `main` or `beta` |
+| Map data | `node scripts/fetch-map-assets.mjs` writes the binaries into the tree (guarded: absent script → code-only bundle, never a failure) |
+| Assemble | `rsync` the tree into `bundle/Open-Historia/` excluding `.git`, `.github`, `node_modules`, `dist`, `bundle`; restore exec bits on the `Launch`/`Update` scripts; `zip -r` |
+| Channel pick | `github.ref_name == main` → tag `app-stable`; else → `app-beta` (`.github/workflows/app-bundle.yml:57`) |
+| Publish | `gh release create <tag> --latest=false … || gh release edit …`; then `gh release upload <tag> Open-Historia.zip --clobber` |
+
+Runs on **every** push to `main`/`beta` so the download never goes stale. The zip's launchers (`Launch Open Historia.{bat,command,sh}`) install deps, build, fetch map assets, and start the game at `http://localhost:3000`.
+
+### 4.2 `android-apk.yml` — stable Android APK
+
+`.github/workflows/android-apk.yml`. Builds the thin Android client (`mobile/`) with an **in-process** `nodejs-mobile` server and attaches the APK to the rolling `android` release.
+
+| Aspect | Detail |
+|---|---|
+| Triggers | `workflow_dispatch`; push tag `android-v*` |
+| Toolchain | Node 20, Temurin Java 21 |
+| Build number | `sed` stamps `${{ github.run_number }}` into `mobile/www/index.html` over `__APP_BUILD__`. The boot screen compares this against `Build: N` in the release notes to decide whether to self-update (`.github/workflows/android-apk.yml:32`) |
+| Build | `npm ci` → `npm run build` (produces `dist/`) → `node scripts/build-mobile-server.mjs` (assembles the embedded server) → in `mobile/`: `npm ci` → `npx cap sync android` → `./gradlew assembleDebug --no-daemon` |
+| Collect | copies `app-debug.apk` → `pax-historia.apk` |
+| Publish | `gh release create android … || gh release edit android`; `gh release upload android pax-historia.apk --clobber`; notes end with `Build: ${{ github.run_number }}` |
+
+The embedded server must be assembled **before** `cap sync` copies it into the native app — that ordering is why `build-mobile-server.mjs` runs between `npm run build` and the Gradle step.
+
+### 4.3 `android-apk-beta.yml` — experimental Android beta *(off-main)*
+
+Lives on the `beta-apk-workflow` lineage (e.g. `upstream/beta-apk-workflow`), **not on `main`**. Builds the experimental embedded-node-server app and publishes to the **isolated `android-beta` pre-release**, leaving stable `android` and every installed stable app untouched.
+
+| Aspect | Detail |
+|---|---|
+| Trigger | `workflow_dispatch` only |
+| Source | `actions/checkout@v4` with `ref: alpha` — always builds `alpha`'s node-server code regardless of dispatch branch |
+| Self-update redirect | `sed 's#releases/tags/android"#releases/tags/android-beta"#'` on `mobile/www/index.html`, so the beta polls `android-beta` and never nags a tester back to stable |
+| Publish | `gh release create android-beta --prerelease … || gh release edit android-beta --prerelease …`; `--clobber` upload |
+
+### 4.4 `deploy-site.yml` — website via CI *(superseded, still present)*
+
+`.github/workflows/deploy-site.yml`. The original CI path for `openhistoria.com`. It still exists on `main` but is now **superseded by the local admin-panel deploy button** (§6); the token used to push branches lacks the `workflow` OAuth scope needed to delete the file, so it is left in place (website-deploy-button memory).
+
+| Aspect | Detail |
+|---|---|
+| Triggers | `workflow_dispatch`; push to `main` with `paths-ignore` for `**.md`, `mobile/**`, `.github/**` (docs/app can't change what the site serves) |
+| Concurrency | group `deploy-site`, `cancel-in-progress: true` — a newer push supersedes an in-flight deploy rather than racing it live |
+| Build | `npm ci` → `npm run build:site` |
+| Size guard | fails if any `dist-site` file exceeds 24 MiB (Pages rejects >25 MiB *after* reporting a green build) |
+| Deploy | `cloudflare/wrangler-action@v3` → `pages deploy dist-site --project-name=open-historia --branch=main`. `--branch=main` is what marks it the **production** deployment; without it Pages treats it as a preview and the live domain keeps the old build |
+| Secrets | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` |
+
+Why an Action rather than Git-connected Pages: the Pages project is direct-upload and Cloudflare can't convert those to Git-connected without a new project + domain move (downtime). CI is also "the one place the map-binary trap cannot fire" — a runner never has the gitignored pmtiles.
+
+---
+
+## 5. The website build pipeline (`build:site` → `assemble-site.mjs`)
+
+`build:site` runs three stages in order, then hands off to the assembler:
+
+1. `node scripts/seed-web-defaults.mjs` — bundles the built-in default scenario for the browser (§8).
+2. `vite build --mode web --base /play/ --outDir dist-web` — the game, based at `/play/`.
+3. `node scripts/assemble-site.mjs` — stitches `site/` (landing page) + `dist-web/` (game) into `dist-site/`.
+
+### `scripts/assemble-site.mjs`
+
+Produces `dist-site/`: landing page at `/`, game under `/play/`.
+
+| Constant / step | Location | Behavior |
+|---|---|---|
+| `siteDir` = `site/` | `assemble-site.mjs:10` | Marketing landing page source (`index.html`, `_redirects`) copied to `dist-site/` root |
+| `gameDir` = `dist-web/` | `assemble-site.mjs:11` | Web game (base `/play/`) copied to `dist-site/play/` |
+| `outDir` = `dist-site/` | `assemble-site.mjs:12` | The deployable output |
+| `ROOT_PAGES` | `assemble-site.mjs:22` | Pages that must answer at the **root** (`guides`, `get-started`, `how-to-play`, `ai-setup`, `self-hosting`, `pax-historia-alternative`, `sitemap`, `guides.css`, `robots.txt`, `sitemap.xml`). Their only copy lives in `public/` (so a local install serves them offline too); assembler lifts them out of `/play/` up to `/`. **A listed page that's missing fails the build** (a dropped page would otherwise 404 only to a crawler) |
+| `ROOT_ASSETS` | `assemble-site.mjs:34` | Images referenced by absolute `/…` paths from both root guides and the game (`logo.png`, five `loading_screen*`, PWA icons, `screenshot.png`). Copied to `/` if present; **silently skipped** if renamed (a missing image is a cosmetic 404, not build-fatal) |
+| Guard | `assemble-site.mjs:41` | Fatal if `dist-web/index.html` is missing (build the game first) |
+
+The `--base /play/` split is why absolute `/logo.png` in the game needs a duplicate at the site root: under `/play/` an absolute URL resolves against the origin, not the base.
+
+---
+
+## 6. The local admin-panel deploy engine (primary website path)
+
+The website is now deployed with a **button in the admin panel**, which runs on the maintainer's machine. Source: `open-historia-admin/panel/lib/deploy-site.mjs` (a separate private repo), driven by `open-historia-admin/panel/server.js`, with the button in `open-historia-admin/panel/public/index.html` and the standalone `open-historia-admin/admin-panel.html`.
+
+### Why a git worktree, not an in-place build
+
+`deploySite()` (`panel/lib/deploy-site.mjs:123`) never builds the maintainer's checkout. It maintains a **throwaway worktree pinned to `<remote>/main`** for three reasons (`deploy-site.mjs:6-19`):
+
+1. "Deploy from main" must mean *main* — the maintainer's `work-repo` usually sits on a feature branch.
+2. It sidesteps the map-binary trap for free — a freshly hard-reset worktree never has the gitignored pmtiles, so they can't be swept into `dist-site`.
+3. It leaves the maintainer's working tree and `node_modules` untouched.
+
+### Configuration (env-overridable)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `OH_SITE_REPO` | sibling `../../../work-repo` | The game repo (must have the `upstream` remote) |
+| `OH_SITE_WORKTREE` | `../../.site-build` | The throwaway checkout; its `node_modules` persists between runs |
+| `OH_SITE_REMOTE` | `upstream` | Remote to fetch/reset from |
+| `OH_SITE_BRANCH` | `main` | Branch to deploy |
+| `OH_PAGES_PROJECT` | `open-historia` | Cloudflare Pages project |
+| `MAX_FILE_BYTES` | `24 * 1024 * 1024` | Local mirror of Pages' 25 MiB reject-after-green-build limit |
+| `OH_DEPLOY_DRY_RUN` | — | Build + size-guard only; skip the actual publishes |
+| `OH_DEPLOY_SKIP_WORKERS` | — | Deploy only the site, skip the two Workers |
+
+### Steps (`deploySite`)
+
+1. **Fetch** `upstream/main`; record the target commit (`deploy-site.mjs:130`).
+2. **Prepare a clean tree** — if the worktree is registered, `git reset --hard upstream/main` + `git clean -fd` (no `-x`, so gitignored `node_modules` survives for a fast install); otherwise `git worktree add --force --detach` (`deploy-site.mjs:135`).
+3. **Install** `npm install --no-audit --no-fund` in the worktree.
+4. **Build** `npm run build:site`.
+5. **Size guard** — recursive scan of `dist-site`; refuse to deploy if any file > 24 MiB (`deploy-site.mjs:153`).
+6. **Deploy** `wrangler pages deploy dist-site --project-name=open-historia --branch=main --commit-dirty=true` (build output is untracked in the throwaway worktree by design). Parses the printed `*.pages.dev` URL from stdout.
+7. **Deploy the Workers** (§6.1) unless skipped — the site is already live, so a worker failure is collected and reported, not treated as "nothing deployed."
+
+Auth uses whatever `wrangler login` OAuth token (or `CLOUDFLARE_API_TOKEN`) is already on the machine; nothing secret is stored or read by this file.
+
+### The button (`server.js` + panel HTML)
+
+- `POST /api/deploy-site` (`panel/server.js:154`) sets a `deploying` mutex (409 if already running), then **streams** the log as `text/plain` one line per chunk; the final line is `DEPLOY_OK <url>` or `DEPLOY_FAILED <message>` so the client can tell how it ended.
+- **CSRF guard** (`server.js:130`): `admin-panel.html` opens from `file://` (origin `null`), so the Deploy button hits this endpoint cross-origin. Allowed only when Origin is absent/`null` or a `localhost`/`127.0.0.1`/`[::1]` host — never a real website. Origin can't be forged by a browser, making it a reliable guard.
+- The 🚀 button ("Deploy website + workers") lives at `panel/public/index.html:51` and `admin-panel.html:73`; it confirms, POSTs, and renders the live log.
+
+### 6.1 Workers that ride every site deploy (`WORKERS`, `deploy-site.mjs:44`)
+
+Two Cloudflare Workers deploy alongside the site so merged worker code can never sit undeployed while the website moves on (this happened once — the import-counter shipped in a PR and served stale code for days because nothing ran `wrangler deploy`). Each is skipped with a log line if its `wrangler.toml` is absent.
+
+| Worker | Deployed from | Source of truth | Why there |
+|---|---|---|---|
+| import-counter | `<worktree>/tools/import-counter` | the game repo (`main`) | Deploys *exactly* merged main, never a local edit |
+| registry | `open-historia-admin/registry` (admin repo, next to the panel) | the admin repo | Its code lives in the admin repo, not the game repo |
+
+---
+
+## 7. Cloudflare Workers (the control/edge plane)
+
+### 7.1 Import counter — `tools/import-counter/`
+
+A tiny Worker that counts community-scenario imports. The game server pings it once per successful install via `server/server.js` → `/api/hub/import-log` (`server/server.js:657`), giving real numbers even for scenarios GitHub can't count (issue attachments).
+
+| Item | Value |
+|---|---|
+| Worker name | `oh-import-counter` (`tools/import-counter/wrangler.toml`) |
+| Entry | `worker.js` |
+| Storage | KV binding `IMPORTS` (counts live in each key's metadata so `/counts` is one list call) |
+| Default URL baked into the app | `https://oh-import-counter.nichojkrol.workers.dev` (`server/server.js:654`) |
+| Override | `OH_IMPORT_COUNTER_URL` env on the game server |
+| Dedup | Website: once per **account _and_ IP** (skip if either seen); app/anonymous web: once per **IP**. Raw IPs never stored — hashed with `HASH_SALT` |
+| Read routes | `/counts` (all), `/count/<hub-issue-number>` (one) |
+
+### 7.2 Node registry — `open-historia-admin/registry/`
+
+The web-mode control plane (source of truth: the admin repo). Serves the signed node directory, proxies map content, and hosts hub + accounts. Worker name `open-historia-registry`.
+
+| Binding | Kind | Purpose |
+|---|---|---|
+| `NODES` | KV | Small hot keys + TTL items (magic-link tokens, sessions via `acct:`/`magic:`/`sess:` prefixes) |
+| `OH_ACCOUNTS` | D1 (`oh-accounts`) | Nodes table, users, sessions, wrapped account keys, encrypted sync blobs; schema in `registry/schema.sql` |
+| `IMPORT_COUNTER` | Service binding → `oh-import-counter` | Direct binding because a Worker can't reach another same-account Worker via its public `workers.dev` URL (subrequest silently never arrives) |
+| `EMAIL` | Email Sending | Magic-link emails, sent by the Worker itself |
+
+The **admin panel** (`open-historia-admin/panel/server.js`) is the human interface to the registry: it lists nodes, accepts/pauses/bans/rate-limits/redirects them, and after **any** change rebuilds the node directory, signs it with the offline root key (`oh-root.key.pem`), and POSTs it to the registry, which serves it live to players and nodes (`panel/server.js:66`). No game rebuild is needed for a directory change.
+
+The web game points at the registry through build-time env (`.env.web`):
+
+| `VITE_OH_*` flag | Value | Used for |
+|---|---|---|
+| `VITE_OH_WEB` | `1` | The compile-time web/desktop switch |
+| `VITE_OH_PMTILES_URL` | `…workers.dev/content` | Map tiles served/proxied by the registry |
+| `VITE_OH_DIRECTORY_URL` | `…/node-directory.json` | The signed content-node directory |
+| `VITE_OH_HUB_URL` / `VITE_OH_ACCOUNT_URL` | `…workers.dev` | Scenario hub + magic-link accounts/sync |
+| `VITE_OH_GOOGLE_CLIENT_ID` | *(client id)* | Google sign-in |
+
+---
+
+## 8. Map-data Release & `fetch-map-assets.mjs`
+
+The ~200 MB world-map binaries left Git LFS (whose free 1 GB/mo org-wide bandwidth was exhausted by a handful of full checkouts, then 403'd) and now ship as assets on the `map-data` GitHub Release, whose download bandwidth is free and unmetered.
+
+- **Manifest:** `scripts/map-assets.json` — `owner`/`repo`/`release` (`Open-Historia`/`open-historia`/`map-data`) plus each asset's `path`, release `asset` name, `bytes`, and `sha256`.
+- **Fetcher:** `scripts/fetch-map-assets.mjs` makes the local tree match the manifest. Full run verifies SHA-256 and re-fetches anything missing or changed; `--ensure` trusts byte-size for speed. **Best-effort — never exits non-zero**, so it can never block a launch, update, or the `app-bundle.yml` bundle step. Downloads to a `.download` temp then atomic-renames.
+- **Name namespaces:** the manifest maps a *versioned* release asset name to a *stable* local path — e.g. `regions-seed-z8.geojson` (release) → `public/assets/regions-seed.geojson` (tree), and `default-regions-names.geojson` → `server/data/scenarios/default/regions.geojson`. The client always reads the stable path.
+- **Callers:** the app launchers/updater and `app-bundle.yml` call it in place of `git lfs pull`. **Never re-add these files to Git LFS.**
+
+When a map file changes: upload the new asset to the `map-data` Release, then update its `sha256` + `bytes` in `scripts/map-assets.json`.
+
+---
+
+## 9. Mobile embedded-server assembly (`build-mobile-server.mjs`)
+
+`scripts/build-mobile-server.mjs` populates `mobile/nodejs-project/` with everything `nodejs-mobile` needs to run the real Express server in-process inside the APK. It runs **after** `vite build` (it needs `dist/`) and is idempotent (wipes and rebuilds copied dirs, leaving the committed `main.js` / `fetchMapAssets.mjs` alone).
+
+| Step | What it copies/does |
+|---|---|
+| 1 | `server/` verbatim; `dist/` **minus** heavy map files (`copyLight` strips `*.pmtiles`, `*.geojson`, `cities-seed.json`) |
+| 2 | `public/lang/` (the server's read-only lang fallback); `public/assets` pmtiles intentionally excluded |
+| 3 | `seed/` = default scenarios + `scenario-manifest.json` + `game-manifest.json`, minus heavy map files |
+| 4 | `scripts/map-assets.json` → the first-run map fetch manifest |
+| 5 | Writes a minimal `package.json` whose only runtime dep is `express`, pinned to the root's version so the phone runs the same Express as desktop |
+| 6 | `npm install --omit=dev` into the project so the APK bundles `node_modules` (skip with `--no-install`) |
+
+The ~200 MB map binaries deliberately never ship in the APK — the app downloads them on first run (`mobile/nodejs-project/fetchMapAssets.mjs`).
+
+---
+
+## 10. Web-mode seed (`seed-web-defaults.mjs`)
+
+`scripts/seed-web-defaults.mjs` runs only from `build:web` / `build:site` / `dev:web`. It bundles the built-in `default` scenario (`server/data/scenarios/default`) into JS modules under `src/runtime/web/generated/` (git-ignored) so a fresh browser can seed its IndexedDB library with a playable scenario. The desktop build never imports these, so no seed data ships in the download.
+
+| Output | Content |
+|---|---|
+| `defaultScenario.js` | `{ meta, cover (base64), colors, data{game,prompts,world,actions,advisor,chat,events} }` |
+| `countryNames.js` | Canonical code→name registry, mirroring `server/country-names.json` (used by `canonicalizeCountryRef`) |
+| `fallbackColors.js` | App-level default palette from `public/assets/colors.json`, immutable & scenario-independent |
+
+It reads only from `server/data`, which **is** committed — so the website build (including CI) needs nothing from the `map-data` Release.
+
+---
+
+## 11. End-to-end: how a change reaches each surface
+
+| Surface | Landing branch | Build artifact | Delivery mechanism | Player action |
+|---|---|---|---|---|
+| **Desktop (stable)** | `main` | `Open-Historia.zip` on `app-stable` | `app-bundle.yml` on push | Download zip once, or run "Update Open Historia" |
+| **Desktop (beta)** | `beta` | `Open-Historia.zip` on `app-beta` | `app-bundle.yml` on push | Download the beta zip |
+| **Android (stable)** | `main` (mobile client) | `pax-historia.apk` on `android` | `android-apk.yml` (dispatch / `android-v*` tag) | App self-updates by comparing `Build: N` |
+| **Android (beta)** | `alpha` | `pax-historia.apk` on `android-beta` | `android-apk-beta.yml` (dispatch, off-main) | Sideload from the pre-release; self-updates from `android-beta` |
+| **Website** | `main` | `dist-site/` | Admin-panel 🚀 button → clean `upstream/main` worktree → `build:site` → `wrangler pages deploy` (or legacy `deploy-site.yml`) | Nothing — next page load |
+| **Import counter Worker** | `main` | `tools/import-counter/worker.js` | Rides the admin-panel site deploy from the same worktree | — |
+| **Registry Worker** | admin repo | `registry/worker.js` | Rides the site deploy from the admin repo dir | — |
+| **Node directory** | *runtime data* | signed JSON | Admin panel re-signs + POSTs to the registry on any node change | Live, no rebuild |
+| **Map binaries** | *manual* | Release assets | Uploaded to `map-data`; fetched by `fetch-map-assets.mjs` at launch/update/bundle | Downloaded on first run |
+
+Key asymmetries a newcomer should internalize:
+
+- **A push to `main` or `beta` re-ships the desktop zip automatically; a push does *not* ship the website or the APK.** The website waits for a maintainer to click 🚀 (or dispatch `deploy-site.yml`); the APK waits for a `workflow_dispatch` or an `android-v*` tag.
+- **`alpha` ships nothing on its own** — it only reaches users via the manually dispatched `android-beta` build, or once bridged into `beta`/`main`.
+- **Worker code and website move together** through the admin-panel deploy engine, precisely to stop merged worker code from sitting undeployed.
+- **Map data is decoupled from code** — a code release does not re-cut the map; a map change is a manual Release upload + manifest edit.
+
+---
+
+## 12. Traps & invariants
+
+- **Never re-add map binaries to Git LFS** — they live on the `map-data` Release only (§8).
+- **Never let a pmtiles/large geojson into a Pages build** — the `oh-drop-map-binaries` plugin, both CI size guards, and the local deploy engine's `findOversized` all defend the 25 MiB Pages limit, which rejects *after* a green build (`vite.config.ts:43`, `deploy-site.yml:58`, `deploy-site.mjs:95`).
+- **`pax-historia.apk` asset name and the Android `appId` must never change** — the self-updater polls fixed URLs.
+- **Assemble the mobile server before `cap sync`** — `android-apk.yml` runs `build-mobile-server.mjs` between `npm run build` and Gradle.
+- **`ROOT_PAGES` is fail-hard, `ROOT_ASSETS` is fail-soft** — a dropped root *page* fails `build:site`; a dropped root *image* is only a cosmetic 404 (`assemble-site.mjs:46`, `:59`).
+- **`deploy-site.yml` is superseded but still on `main`** — the admin-panel button is the live path; the yml stays because the pushing token lacks the `workflow` scope to delete it.
+- **`--branch=main` / `--branch=<BRANCH>` is what makes a Pages upload production** — omit it and the live domain keeps the old build while the deploy still reports success.
+
+---
+
+### See also
+
+- [World state](world-state.md) — the `world.json` shape that scenarios and the web seed carry
+- [Web mode & content nodes](web-mode.md) — how the browser build resolves map data from the signed directory
+- [Scenario hub](hub-and-scenarios.md) — the import flow that feeds the import counter

--- a/docs/game-map.md
+++ b/docs/game-map.md
@@ -1,0 +1,388 @@
+# Game Map & Rendering
+
+The in-game map is a single MapLibre GL instance (via `react-map-gl/maplibre`) mounted by `src/Game/Map/World.jsx`, with every gameplay layer added as a React child that declares its own `<Source>`/`<Layer>`. All political state flows in from `world.json` (polled every 5s by `useWorldState`) and `colors.json` (the owner→rgb palette); nothing on the map is server-rendered — owners are recoloured, labels rebuilt, and units/markers re-fed from that JSON every poll. The same code renders two ways: a flat Web-Mercator map and a decorative 3D globe (with a real-sun terminator and starfield), switched by the `projection` prop, which remounts the whole `<Map>`.
+
+Everything below is in `src/Game/Map/` unless noted.
+
+---
+
+## 1. Component tree & data sources
+
+`World.jsx` renders one `<Map>` and, inside it, these children (order = paint order, later = on top):
+
+| Child | File | Renders | Primary data in |
+|---|---|---|---|
+| `<Nations>` | `Nations.jsx` | Country/region fills, borders, disputed stripes, country/owner labels | `world.json` + `colors.json` + PMTiles + `regionsGeojson` |
+| `<Cities>` | `Cities.jsx` | City symbols (★/◆/■) + labels | `cities.pmtiles` (stock) or `citiesGeojson` (custom) |
+| `<MarkersLayer>` | `MarkersLayer.jsx` | Built structures (bases, silos, embassies…) | `world.markers` |
+| `<Units>` | `Units.jsx` | Troop counters (circle + glyph + strength) | `unitsController` (from `world.units`) |
+| `<GlobeEffects>` | `GlobeEffects.jsx` | Sun, stars, day/night lighting, auto-rotation (globe only) | wall-clock sun math |
+| `<RegionPopup>` / `<CountryInfoPanel>` / `<UnitPopup>` / `<FeaturePopup>` | `../Selection/*` | Selection popups | click events from `Nations.jsx` |
+
+### Shared state hooks
+
+| Hook | File | What it provides |
+|---|---|---|
+| `useWorldState()` | `useWorldState.js` | Singleton 5s poll of `world.json`; one poll shared by all consumers |
+| `useCustomBackground()` | `useCustomBackground.js` | Resolves a scenario's uploaded image/vector basemap from `world.background` |
+| `useMapSetting(key)` | `../../runtime/mapSettings.js` | Reactive localStorage map toggles (`hideCountryLabels`, `disableIdleRotation`) |
+| `unitsController` | `unitsController.js` | Separate 5s poll of `world.units` + player order mutations |
+
+`useWorldState` is a module-level singleton: `startPolling()` fires one `setInterval(poll, 5000)` reading `JSON_URLS.world`, and all mounted consumers subscribe. It returns a **stable object identity** across polls when nothing it exposes changed (deep/shallow compares each field — arrays like `markers`/`regionClaimants` are `JSON.stringify`-compared) so React children don't re-render on every 5s tick. See [World state](world-state.md) for the `world.json` schema.
+
+Fields `useWorldState` derives from `world.json`:
+
+| Field | Source key | Used by |
+|---|---|---|
+| `worldKnown` | `Object.keys(state).length > 0` | Gate: stock layers only paint once the world is known |
+| `customRegions` (`customFlag`) | `state.customRegions` | Switches stock↔custom render path |
+| `customCities` | `state.customCities` | `Cities.jsx` stock↔custom path |
+| `basemap` | `state.basemap` | ESRI style variant |
+| `background` | `state.background` | Uploaded image/vector basemap descriptor |
+| `regionOwnershipOverrides` | `state.regionOwnershipOverrides` | region id → owner name (live conquests) |
+| `regionClaimants` | `state.regionClaimants` | region id → claimant list (disputed stripes) |
+| `polityOverrides` | `state.polityOverrides` | polity name → `{name, color, aliases}` registry |
+| `markers` | `state.markers` | `MarkersLayer.jsx` |
+| `labelFont` / `labelHaloColor` / `labelTextColor` | same | Label styling |
+
+> **Note on the `customRegions` flag:** `readRuntimeJsonAsset` / `normalizeRuntimeWorld` forces `customRegions:true` onto every world it serves. In practice the game is *always* on the custom render path (`customFlag` true); the stock-country path (`showStockCountries`) is effectively dead — see [§4](#4-owner-colouring--the-single-resolver) and the `countries-source` note.
+
+---
+
+## 2. `<Map>` setup and key props
+
+Defined in `World.jsx` (`src/Game/Map/World.jsx:286`). The `<Map>` has `key={projection}`, so **toggling globe↔mercator unmounts and remounts the entire map** (and all its GL images — which is why disputed stripe tiles are rebuilt reactively, see [§5](#5-disputed--striped-regions)).
+
+| Prop | Value | Why |
+|---|---|---|
+| `key` | `projection` | Remount on projection change |
+| `initialViewState` | `{longitude:0, latitude:0, zoom:3.5, bearing:0, pitch:0}` | Kept in `viewStateRef` and updated on every `onMove` so a remount restores the camera |
+| `minZoom` | `2.25` | Deliberate floor (see [§10](#10-zoom-caps--why-theyre-deliberate)) |
+| `maxZoom` | `16` | Deliberate ceiling; PMTiles overzoom past their z8 max |
+| `maxBounds` | `[[-Inf,-80],[Inf,85]]` | Lock latitude to the usable band; longitude free (world copies wrap) |
+| `doubleClickZoom` | `false` | Double-click is reserved for gameplay |
+| `dragRotate` / `touchPitch` / `pitchWithRotate` | `false` | No bearing/pitch — top-down only |
+| `dragPan` | on | Pan enabled |
+| `cursor` | `"default"` | No grab cursor |
+| `attributionControl` | `false` | Hidden |
+| `fadeDuration` | `0` | No label cross-fade flicker |
+| `collectResourceTiming` | `false` | Skip perf-entry overhead |
+| `crossSourceCollisions` | `false` | Symbols from different sources don't fight for placement (cities vs labels vs markers) |
+| `renderWorldCopies` | on | Wrap the map E/W infinitely |
+| `maxTileCacheSize` | `256` | **Caps per-source retained-tile GPU textures** |
+| `projection` | `useMemo(() => ({type: projection}))` | `"globe"` or `"mercator"` |
+| `terrain` | memoized (below) | 3D terrain, flat non-custom maps only |
+| `mapStyle` | `worldStyle` (`buildWorldStyle(...)`) | Base ESRI/terrain OR custom background |
+
+Handlers: `onMove` → stores `viewState` in `viewStateRef` + `applyDynamicPixelRatio`; `onIdle` → fires `onInitialIdle` once (boot signal) and clears the loading toast; `onLoading` → shows a "Loading tiles…" toast with an 8s safety timeout.
+
+### `maxTileCacheSize={256}` (the OOM cap)
+
+Left unset, MapLibre sizes this cache dynamically to roughly `(ceil(w/256)+1)*(ceil(h/256)+1)*5` tiles **per source** — ~270 at 1080p but ~800 on a 4K viewport. With `renderWorldCopies`, panning E/W feeds successive wrapped world-copy tiles into that cache, so retained GPU textures climb until the tab OOMs. `256` caps the 4K case ~3× while being a no-op on phones. In-view tiles are a separate structure and are never evicted by this, so on-screen tiles are never re-fetched. This is orthogonal to `applyDynamicPixelRatio` (which bounds framebuffer pixels, not tiles).
+
+### Dynamic pixel ratio (`applyDynamicPixelRatio`, `World.jsx:212`)
+
+Zoomed far out, the whole world (every region, border, label) draws at once and native resolution wastes frames on invisible detail. So:
+
+| Zoom | Mode | `map.setPixelRatio(...)` |
+|---|---|---|
+| ≤ 4.5 | `low` | `min(devicePixelRatio, 1) * 0.75` |
+| ≥ 5 | `native` | `window.devicePixelRatio` |
+| 4.5–5 | unchanged | hysteresis band to prevent flapping |
+
+Applied on `onMove` **and** `onIdle`, so the soft ratio is in effect from the very first settled frame at world zoom, not only after the first pan.
+
+### `terrain` memo (`World.jsx:197`)
+
+`terrain = { source: "terrain-source", exaggeration: 15 }` **only** when `terrainEnabled && !isGlobe && !customBg && !bgDeclared`. Globe terrain is unsupported by MapLibre and can corrupt the shader cache across projection changes, so it's disabled on the globe and on any custom-background map (which has no terrain source).
+
+---
+
+## 3. The base style (`buildWorldStyle`)
+
+`buildWorldStyle(basemapId, customBg, backgroundDeclared, isGlobe)` (`World.jsx:57`) returns a MapLibre style JSON. It picks **one of four** branches:
+
+| # | Condition | Sources | Layers |
+|---|---|---|---|
+| 1 | `customBg.kind === "image"` | `custom-bg` (image, corners per `WORLD_IMAGE_COORDS_*`) | `custom-bg-base` (solid `#0b1a2b`), `custom-bg-layer` (raster) |
+| 2 | `customBg.kind === "vector"` | `custom-bg-vec` (geojson) | `custom-bg-sea` (bg), `custom-bg-fill` (per-feature `fill`), `custom-bg-line` |
+| 3 | `backgroundDeclared` (payload not loaded yet) | none | `custom-bg-loading` (solid `#0b1a2b`) |
+| 4 | default (stock world) | ESRI satellite + terrain (below) | satellite + hillshade |
+
+Branches 1–3 **drop ESRI entirely** so a custom-map game never flashes satellite Earth or fires basemap tile requests it won't use. Branch 3 is the pre-load placeholder: `useCustomBackground` flips `declared:true` from the light `world.json` poll *before* the heavy background payload loads.
+
+Every branch sets `sky: { "atmosphere-blend": 0 }` — MapLibre's uniform atmosphere is off because `GlobeEffects` supplies directional surface light instead, and transparent space lets the stars/sun show through the canvas.
+
+### Default stock style (branch 4)
+
+| Source id | Type | Tiles / template | Notes |
+|---|---|---|---|
+| `satellite-lowres` | raster | `esriTileTemplate(basemapId)` | z0–2 always have real data; `maxzoom:2` |
+| `satellite` | raster | `basemapProtocolTemplate(basemapId)` → `ohbase://…` | High-res via the **ohbase protocol** so ESRI "Map Data Not Yet Available" placeholders get replaced with upscaled ancestor tiles; `maxzoom` = the basemap's native max |
+| `terrain-source` | raster-dem | `TERRAIN_TILE_TEMPLATE` (AWS terrarium) | `encoding:"terrarium"`, `maxzoom:5` |
+| `hillshade-source` | raster-dem | same terrarium tiles | for the `hills` layer |
+
+Layers: `satellite-lowres-layer`, `satellite-layer` (both with `SATELLITE_PAINT` grading — brightness cap, slight desaturation/contrast so it sits against the dark UI), and `hills` (hillshade, exaggeration 0.1). The default basemap is `DEFAULT_BASEMAP_ID = "ocean"`; the in-game basemap picker was removed, so stock worlds are fixed to that preset. `ensureBasemapProtocol()` (called at module load) registers the `ohbase://` protocol handler. Basemap helpers live in `src/runtime/assets.js` (`ESRI_BASEMAPS`, `esriTileTemplate`, `basemapProtocolTemplate`, `basemapMaxZoom`).
+
+### World-image corner coordinates
+
+Two constants (`World.jsx:44`) give the image-source corners:
+
+- `WORLD_IMAGE_COORDS_FLAT` — ±85.0511° (the Mercator projection limit).
+- `WORLD_IMAGE_COORDS_GLOBE` — ±89.9° (the globe shows to the poles; **not** exactly ±90 because `mercatorYfromLat(±90)` is ±Infinity and `ImageSource.setCoordinates` throws — the `custom-bg-base` layer fills the negligible sliver).
+
+`styleUsesGlobeCoords = customBg?.kind === "image" && isGlobe` selects between them.
+
+---
+
+## 4. Region & country layers (`Nations.jsx`)
+
+`Nations.jsx` (the `WorldMap` component) declares four sources. The core idea is a **crossfade**: at low zoom, GADM region *fills* come from a coarse seed GeoJSON (`regionsGeojson`); past z6.5 they hand off to crisp stock vector tiles (`regions.pmtiles`). Author-drawn/edited geometry always comes from the GeoJSON, on top.
+
+### 4.1 Sources & layers
+
+| Source id | Type | Data | Gated on | Layers |
+|---|---|---|---|---|
+| `countries-source` | vector | `PMTILES_PROTOCOL_URLS.countries`, `maxzoom 8` | `!customFlag` | `countries-fill`, `countries-outline` |
+| `regions-source` | vector | `PMTILES_PROTOCOL_URLS.regions`, `maxzoom 8` | **never gated** | `regions-fill`, `regions-disputed`, `regions-outline` |
+| `custom-regions-source` | geojson | `enrichedCustomRegionData`, `tolerance 0` | inert unless `customActive` | `custom-regions-fill-far`, `custom-regions-hairline-far`, `custom-regions-disputed-far`, `custom-regions-fill`, `custom-regions-disputed`, `custom-regions-outline` |
+| `country-curved-label-source` | geojson | `activeCurvedLabelData` | — | `country-curved-labels` |
+| `country-point-label-source` | geojson | `activePointLabelData` | — | `country-labels` |
+
+**`countries-source` is dead code by design.** Its `countries-fill` uses `fillStyle`, whose `match` is the only expression that keys on a country **code** (`["get","GID_0"]`). Because `customRegions` is forced true everywhere, `showStockCountries` (`worldKnown && !customFlag`) is always false and the source never mounts. It's left intact (not half-fixed) for a future dead-code sweep. The layer that actually paints the political map is `regions-fill` via `stockRegionsFillPaint`, which matches `GID_1` (a region id) and needs no code→name bridge.
+
+**`regions-source` is NOT gated on `customFlag`** — this is load-bearing. On a re-ownership scenario (Modern Day, Rome, WWII: stock GADM geometry, nothing hand-drawn) `regions-fill` is the *only* thing painting owners above z6.5, because `custom-regions-fill-far` stops at `maxzoom 7` and `FAR_FILL_FADE` has already faded it to 0 by z6.5. Unmounting it once left every such map blank past 6.5 and (via the `getLayer()` filter in the click handler) unclickable too.
+
+### 4.2 The crossfade constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `FAR_FILL_FADE` | interpolate zoom 5.5→0.72, 6.5→0 | seed-GeoJSON fill opacity (fades **out** on zoom in) |
+| `TILE_FILL_FADE` | interpolate zoom 5.5→0, 6.5→0.72 | stock-tile fill opacity (fades **in**) |
+| `GADM_GEOMETRY_FILTER` | `index-of "." in id >= 0` | GADM region (dotted id like `USA.1_1`) |
+| `CUSTOM_GEOMETRY_FILTER` | `index-of "." in id == -1` | author-drawn (`reg_…`, no dot) |
+| `AUTHORED_GEOMETRY_FILTER` | `custom OR edited==true` | geometry that lives **only** in the GeoJSON |
+| `STOCK_GEOMETRY_FILTER` | `GADM AND edited!=true` | unedited GADM → paints via tiles |
+
+The crossfade band is z5.5–6.5 because the seed geometry was extracted at tile-zoom 5; hand-off happens just past that. The **`edited` split** matters: a GADM region the editor *reshaped* has a dotted id but its true shape is now in the GeoJSON, while the stock tile still carries the *original* shape. Painting both stacks two 0.72 fills and darkens the reshaped area, so edited GADM ids are pulled out of the tile layers (`editedStockIds`, computed in `Nations.jsx:949`) and rendered from the GeoJSON like author-drawn shapes.
+
+### 4.3 Fill / outline paint objects
+
+| Layer | Paint driver | Behaviour |
+|---|---|---|
+| `regions-fill` | `stockRegionsFillPaint` | `match GID_1 → ownerColorCss(owner)` for every non-drawn, non-edited region; opacity `TILE_FILL_FADE` (0 unless `customActive`) |
+| `regions-outline` | `regionsOutlinePaint` | black hairline; width `interp 3→0.2, 8→0.6, 12→1.0`; opacity fades in `5.5→0, 6.5→0.6, 8→0.7` (only when the tile fills do — below that the seed hairlines carry it); excludes `editedStockIds` |
+| `custom-regions-fill-far` | `["get","_fillColor"]` | seed-GeoJSON fill for GADM regions, `maxzoom 7`, opacity `FAR_FILL_FADE` |
+| `custom-regions-hairline-far` | — | seed hairlines that sit exactly on the far fills, hand off at z6.5 |
+| `custom-regions-fill` | `["get","_fillColor"]` | author-drawn/edited geometry, opacity constant `0.72` at all zooms |
+| `custom-regions-outline` | — | black outline for authored geometry, opacity `3→0, 4→0.35, 8→0.6` |
+
+`_fillColor` is **pre-baked into each GeoJSON feature** by `enrichedCustomRegionData` (`Nations.jsx:852`) so the GL paint expression is the constant `["get","_fillColor"]` — a match expression that never recompiles when ownership changes. The colour per feature is: override colour (`regionOwnershipOverrides[id]`) → owner colour (`ownerColorCss(props.owner)`) → `NEUTRAL_LAND_COLOR = rgb(88,98,110)`.
+
+---
+
+## 5. Owner colouring — the single resolver
+
+There is **one** owner→rgb resolver, `resolveOwnerRgb(owner)` (`Nations.jsx:727`), used by every paint path (region fills, stripes, and — via `ownerColorCss` — labels). Owners are **names now** (`"Russia"`, `"Roman Empire"`), not GADM codes. Resolution order:
+
+1. `colorMap[owner]` — exact hit in `colors.json` (loaded by `getNationColors`).
+2. `parseColorToRgb(polityOverrides[owner].color)` — the live polity registry from `world.json` (stores CSS strings; `colors.json` stores `[r,g,b]` triplets, so `parseColorToRgb` bridges the two namespaces).
+3. Case/diacritic/punctuation-folded match (`ownerFoldKey`) against `colorMap` keys, then against `polityOverrides` keys **and their `aliases`**.
+4. `fallbackRgbFromOwner(owner)` — a procedural hash of the first three A–Z letters.
+
+The two-namespace merge is the whole point: a polity can be correctly *named* by the registry while `colors.json` has no key for it (shipped example: "British Empire" owns 426 regions in `world-war-ii-1939-copy` with its colour only in `polityOverrides`). Resolving the name but not the colour painted those regions a muddy procedural fallback — reading to players as "the map didn't annex it."
+
+`ownerColorCss(owner)` wraps it into a `rgb(...)` string (or `NEUTRAL_LAND_COLOR`). `fallbackRgbFromOwner` strips to A–Z first so accented/two-word names hash usefully instead of collapsing to a dark corner; it's the JS twin of `buildFallbackColorExpression` (which still hashes the *code* off the stock tiles, because tile properties are baked GADM and never become names).
+
+### Palette live-reload
+
+`colors.json` can be rewritten mid-game (every AI turn, or the faction creator writing the player's colour). `getNationColors` memoizes on the scenario token and won't see a runtime write, so the asset layer dispatches a `oh:colors-updated` window event on write; `Nations.jsx` listens (`colorsEpoch`) and re-reads. `shallowEqualColors` guards against swapping in a fresh object with identical contents, which would needlessly rebuild every MapLibre match expression.
+
+---
+
+## 6. Disputed / striped regions
+
+A region whose `claimants` list names contesting countries renders **diagonally striped** in their colours (current administrator's band first).
+
+| Piece | Location | Role |
+|---|---|---|
+| `stripeImageId(rgbList)` | `Nations.jsx:158` | Encodes the rgb list into an image id: `oh-stripes-r_g_b-r_g_b…` |
+| `parseStripeImageId(id)` | `Nations.jsx:160` | Decodes it back |
+| `buildStripeImage(rgbList)` | `Nations.jsx:173` | Raw RGBA diagonal-stripe tile; band = `(x+y) mod period` (tiles seamlessly), `STRIPE_BAND_PX = 8` |
+| `styleimagemissing` handler | `Nations.jsx:512` | On demand, builds and `addImage`s any stripe tile the style asks for |
+
+Because the image id **encodes its own colours**, the `styleimagemissing` handler can rebuild *any* combination — including after a globe↔mercator remount wipes all GL images. This is why stripes are reactive rather than pre-registered.
+
+Claimants come from `world.regionClaimants[id]` first (how the modern-world scenario declares disputes, since its geometry is an immutable seed), else the region feature's own `claimants` prop (editor maps). `enrichedCustomRegionData` bakes a `_stripes` property (the image id) onto disputed features; layers select on `["has","_stripes"]` and paint with `fill-pattern` instead of the solid fill:
+
+- `custom-regions-disputed-far` — seed geometry, `FAR_FILL_FADE`.
+- `custom-regions-disputed` — authored geometry, constant `0.72`.
+- `regions-disputed` — the tile twin for GADM disputed regions (uses `disputedTileStops`, opacity `TILE_FILL_FADE`), excluding `editedStockIds`.
+
+`DISPUTED_TERRITORY_CLAIMANT` (`Nations.jsx:338`) maps GADM's `Z01`–`Z09` disputed codes (Kashmir, Aksai Chin, Arunachal Pradesh…) to a claimant country so the map shows `"Disputed (India)"` instead of a bare `"Z01"` label.
+
+---
+
+## 7. Country / owner labels
+
+Two label render paths, selected by the world flag:
+
+| State | Point labels | Curved labels |
+|---|---|---|
+| `!worldKnown` | empty | empty (no flash before load) |
+| `customFlag` (custom map) | `ownerLabelData` (per-owner) | empty |
+| stock world | `pointLabelData` | `curvedLabelData` |
+
+### Stock labels — `src/runtime/countryLabels.js`
+
+`loadCountryLabelCollections({ force, ownedCodes })` reads the **z0 tile** of `countries.pmtiles`, decodes it, and for each country builds either a **curved** multi-glyph label (one Point feature per letter, following the country's principal axis — `buildCurvedLabelPath` + `buildCurvedLabelGlyphFeatures`) or a single **point** label when the shape is too compact/round to curve text along. Names run through `resolveCountryDisplayName` + `translateLabel` (labels are baked into map features, not DOM, so they must be pre-translated). `ownedCodes` filters out countries owning no territory this scenario (so modern names don't float over medieval land). Results are cached in runtime JSON, keyed on `tile-hash + byteLength + archiveUrl + language + owner-set` (`COUNTRY_LABELS_CACHE_KEY = "country-labels-v3"`; an empty build is served once but never cached, since an empty z0 read is almost always a degraded tile, not a label-less world).
+
+### Owner labels for custom maps — `buildOwnerLabelCollection` (`Nations.jsx:343`)
+
+The stock pipeline labels *modern* countries, which is wrong on scenario maps (it printed "Russia"/"Ukraine" over the USSR). Instead, one label per **owner per contiguous landmass**:
+
+1. `buildRegionAdjacency` (`Nations.jsx:278`) — which regions physically touch, by hashing every vertex on a ~11 m (`1e-4°`) grid. Geometry-only, so it's memoized per world and survives ownership changes.
+2. Union-find groups same-owner **adjacent** regions into one territory each. Contiguity (not distance) is what keeps a colony separate from its metropole (France's mainland vs French West Africa) while keeping a touching chain like Siberia a single label.
+3. `mergeOwnerClusters` then does a small centroid mop-up (`CLUSTER_JOIN_DEGREES = 10`) to fold islands into nearby mainland and heal adjacency near-misses.
+4. Each cluster becomes a Point feature named by `polityOverrides[owner].name || countryNameByCode.get(owner) || owner`, run through `resolveCountryDisplayName` + `translateLabel`, uppercased. Every owner keeps its largest cluster; extra clusters must clear `MIN_CLUSTER_AREA = 1.5` (deg²).
+
+`ownerLabelData` recomputes as `regionOwnershipOverrides` poll in, so **labels follow conquests**. A `labelEpoch` (bumped on the `i18n:updated` event) forces a rebuild when translations land.
+
+### Label layers & styling
+
+Both label sources feed `type:"symbol"` layers (`country-labels`, `country-curved-labels`). Shared config:
+
+| Property | Value |
+|---|---|
+| `text-font` | `labelFontStack` = `[world.labelFont || "Impact", "Arial Black", "sans-serif"]` (drawn locally as a CSS font-family — MapLibre v5 has no glyphs endpoint here) |
+| `text-size` | `buildCountryTextSize(1, isGlobe)` — exponential-in-zoom, scaled by each feature's baked `areaScale`, capped at 254 |
+| `text-color` / `text-halo-color` | `world.labelTextColor || "#FFFFFF"` / `world.labelHaloColor || "rgba(0,0,0,0.5)"` |
+| `text-opacity` | interp zoom `5→0.75, 8→0` (labels fade out as you zoom in and cities take over) |
+| `visibility` | `none` when `hideCountryLabels` map setting is on |
+| `text-pitch/rotation-alignment` | `"map"`, `text-keep-upright:false` |
+
+**Globe text-size fix (issue #6):** globe projection oversizes a label's own high-latitude text relative to its outline. `GLOBE_LAT_CORRECTION = cos(feature.lat * π/180)` undoes it, applied via `buildCountryTextSize(..., correctForGlobe=true)` **only** in globe mode (the factor is visibly wrong in Mercator at high latitude). Every label feature carries its own `lat` for this — the reason `countryLabels.js` bumped its cache to `v3`.
+
+---
+
+## 8. Cities & markers
+
+### Cities — `Cities.jsx`
+
+`<Cities>` picks a path from `world.customCities`:
+
+| Path | Source | Visibility filter | Sort |
+|---|---|---|---|
+| `StockCities` | `cities.pmtiles` (vector, layer `cities`) | `populationFilter` — capitals always; else population thresholds that step down as you zoom (2.5M at z<5 → 100k at z8+) | by population |
+| `CustomCities` | `citiesGeojson` (geojson) | `customTierFilter` — authored tier: 4=capital, 3=major, 2=city (z≥4.3), 1=town (z≥5.8) | `customSortKey` (tier then population) |
+
+Custom scenarios never show the 70k modern database (anachronistic), and while the custom set loads they render nothing rather than flash modern names. Both paths use the same visual language and the same two layers (`minzoom 3.4`):
+
+- `cities-shapes` — a glyph per city: `★` capital / `◆` major / `■` other (transparent text, white halo, so only the outline shows).
+- `cities-labels` — the city name (`Open Sans Semibold`, white with dark halo, variable anchor).
+
+### Markers (built structures) — `MarkersLayer.jsx`
+
+Fed from `world.markers` (structures founded during play — bases, silos, embassies…). Each valid marker (`Number.isFinite(lng/lat) && name`) becomes a Point feature. Shape by keyword: `MILITARY_KIND` regex → `▲`, else `■`. Colour by owner via `ownerColorString(colorMap, ownerCode)` (from `getNationColors`; unowned = neutral parchment `rgb(226,222,205)`). Two layers: `markers-shapes` (glyph, owner-coloured) and `markers-labels` (`minzoom 2.6`).
+
+---
+
+## 9. Units (troops)
+
+### Render — `Units.jsx`
+
+`units-source` (geojson) is fed from `unitsController.getUnits()`. Each unit → a Point feature with a `TYPE_GLYPH` (`infantry:I, armor:A, air:F, naval:N, artillery:G, garrison:C`) and an owner colour. Three stacked layers:
+
+| Layer | Type | Encodes |
+|---|---|---|
+| `units-fill` | circle | owner colour; radius scales with zoom |
+| `units-icons` | symbol | the type glyph |
+| `units-strength` | symbol | numeric strength, offset below (`minzoom 3`) |
+
+Status drives styling — **pending** (player-requested, not yet AI-confirmed) units are translucent (`circle-opacity 0.32`) with a blue stroke; **moving** = amber stroke; **engaged** = red stroke; else white.
+
+### Controller — `unitsController.js`
+
+A module-level store, separate from `useWorldState` but with the same 5s cadence (`startUnitsSync`). It holds `units`, `playerCode`, `round`, `gameDate`, `allowedUnitTypes`, and an `interactionMode` (`idle | deploy | move | attack`), plus a `subscribeUnits` pub/sub the map/popups/Forces panel listen to.
+
+| Function | Effect | Instant feedback | AI hand-off |
+|---|---|---|---|
+| `deployUnit` | Add a `pending` unit (translucent) | placed locally | queues a "Deploy request" order; revert = remove |
+| `moveUnitTo` | Within era/type leash → move + `moving`; beyond `moveLeashKm` → stay put, `moving` | snaps or holds | queues Move / Long-range order |
+| `attackWith` | In `engagementRangeKm` → `resolveClash` (seeded, instant); out of range → approach order | strength/positions update, losers filtered out | queues Attack order (`regionTransfer` hint) |
+| `attackFeature` | Attack a city/marker; no local clash — positional only | closes on objective, reads `engaged` | queues assault order (`markerOps`/`regionTransfer` hints) |
+
+Player deploy is purely local; move/attack write to `world.units` immediately **and** queue a machine-readable `action` (via `queueOrder`) so the AI honours/contests them on the next time-jump. `queueOrder` records a `unitRevert` so deleting the queued action before the jump undoes the on-map change (#368). Combat maths (`resolveClash`, `distanceKm`, `engagementRangeKm`, `moveLeashKm`) live in `unitCombat.js`. `busy` suppresses the poll from clobbering an in-flight commit.
+
+### Interaction dispatch — `Nations.jsx` `handleRegionClick`
+
+The map's single `click` handler (`Nations.jsx:564`) routes by `getInteractionMode()`:
+
+- **deploy/move/attack modes** intercept the click as a *target* (`deployUnit` / `moveUnitTo` / `attackWith` or `attackFeature`), then `clearInteractionMode()`.
+- **normal click** priority: unit (`units-fill`) → feature (`markers-shapes` > `cities-shapes`/`cities-labels`) → region. Region query uses `["custom-regions-fill","custom-regions-fill-far"]` on drawn-geometry maps but `["custom-regions-fill","regions-fill"]` on re-ownership maps (so a click on fantasy ocean resolves to nothing, not the leftover real country underneath — `hasDrawnGeometry`). The resolved region is handed to `onRegionSelected` with the **owner name** resolved (via `ownerLookupRef`), the underlying GADM `gid0` kept as a flag fallback.
+
+The staged-reveal system (`setUnitsOverride` / `setWorldStateOverride`) lets the map show units/world as of the last revealed event during a turn's event playback, snapping back to live state when cleared (see [World state](world-state.md) and the turn/time system).
+
+---
+
+## 10. The decorative globe (`GlobeEffects.jsx`)
+
+Active only when `projection === "globe"` (`active` prop). It drives four things, all outside MapLibre's own render: the sun sprite (`#oh-globe-sun`), the starfield canvas (`#oh-globe-stars`), the day/night lighting canvas (`#oh-globe-lighting`), and idle auto-rotation. Those DOM elements are declared in `World.jsx` around the transparent `<Map>` canvas so the globe provides correct sun occlusion.
+
+- **Real sun:** `sunWorldPosition = subsolarPoint()` — the actual subsolar point for the current wall clock (seasonal declination + Earth's rotation). Moving the camera changes perspective without sliding light across the countries; the terminator matches the planet outside your window. `LIVE_SUN_REFRESH_MS = 60_000` refreshes it even when the map is fully idle.
+- **Auto-rotation:** `ROTATION_DEG_PER_MS = 360 / (10 min)`. Disabled by the `disableIdleRotation` map setting, and interrupted by any drag/zoom/pointerdown.
+- **Aggressive idle throttling (the main perf lever):** while actively dragging/zooming, sun+lighting+stars redraw at 60 fps; while idle (including auto-rotate) they drop to ~15 fps (`*_FRAME_MS_IDLE`), and the auto-rotate `jumpTo` itself steps at 15 fps (`IDLE_ROTATE_FRAME_MS`) using real elapsed time so rotation *speed* is unchanged. Idle auto-rotate previously forced a full MapLibre re-render + from-scratch lighting repaint 60×/s forever — this was cooking phones.
+- **Projection morph:** the globe↔mercator morph fades stars/lighting via `projectionTransition` (1 on settled globe, 0 on flat, between only mid-fade). The morph fires no map "move" event, so `isMorphing` forces full-rate redraws during the fade; only the settled globe throttles.
+- **WebGL context loss** is handled: on `webglcontextlost` it cancels the rAF loop and releases the canvases; on restore it resyncs and resets the rotation clock so the first tick doesn't jump the globe by the whole lost interval.
+
+Sun/star/lighting math is in `globeSunMath.js`, `globeCanvasLighting.js`, `globeCelestialCanvas.js` (with `globeLightingPixels.js`, `globeCelestialCanvas.js`, `globeSunMath.js`).
+
+---
+
+## 11. Zoom caps & why they're deliberate
+
+| Cap | Where | Rationale |
+|---|---|---|
+| `minZoom 2.25` | `<Map>` | World-view floor |
+| `maxZoom 16` | `<Map>` | Camera ceiling; past PMTiles' z8 the tiles overzoom |
+| `maxBounds` lat `-80…85` | `<Map>` | Keep the camera in the usable latitude band |
+| PMTiles `maxzoom 8` | `countries-source`, `regions-source` | **Not the archive's z10.** `extract-regions.mjs` can't stitch a z10 seed (dies in `JSON.stringify` past V8's 512 MB max string); z9's 4.1 M vertices OOM'd the editor renderer; z8's 2.6 M is stable — and rendering finer than the editor can author only draws detail no map can be built against. MapLibre overzooms past z8. |
+| `custom-regions-fill-far maxzoom 7` | seed-GeoJSON far layer | Stops just past the z5.5–6.5 crossfade; the stock tiles own the crisp zoom |
+| Crossfade band z5.5–6.5 | `FAR_FILL_FADE`/`TILE_FILL_FADE` | Seed extracted at tile-zoom 5; hand off just past it |
+| Pixel-ratio switch z4.5 / z5 | `applyDynamicPixelRatio` | Soften the whole-world view; hysteresis prevents flapping |
+| Cities `minzoom 3.4`, city thresholds step by zoom | `Cities.jsx` | Thin out symbols as you zoom out |
+| Label `text-opacity` fades to 0 by z8 | `labelLayerPaint` | Country/owner labels hand the screen to city labels on zoom in |
+| Markers labels `minzoom 2.6` | `MarkersLayer.jsx` | Structure names appear slightly earlier than cities |
+
+---
+
+## 12. Data-flow summary
+
+```
+world.json ──(useWorldState, 5s)──► customRegions, regionOwnershipOverrides,
+   │                                 regionClaimants, polityOverrides, markers,
+   │                                 labelFont/Color, basemap, background, units
+   │
+   ├─► Nations.jsx ──► enrichedCustomRegionData (_fillColor/_stripes baked in)
+   │                   ownerLabelData (per-owner, follows conquests)
+   │                   stockRegionsFillPaint (GID_1 → owner colour)
+   │
+   ├─► useCustomBackground ──► buildWorldStyle (image/vector/placeholder/ESRI)
+   ├─► MarkersLayer ──► markers-source
+   └─► unitsController (own 5s poll of world.units) ──► Units.jsx / popups
+
+colors.json ──(getNationColors, oh:colors-updated event)──► colorMap
+   └─► resolveOwnerRgb ──► every fill / stripe / label / marker / unit colour
+
+regionsGeojson / citiesGeojson ──(readJson, force)──► custom region & city geometry
+countries.pmtiles / regions.pmtiles / cities.pmtiles ──► stock tile geometry
+   └─► countryLabels.js (z0 countries tile) ──► point + curved stock labels
+```
+
+Every owner recolour, label rebuild, and unit/marker update is a consequence of a `world.json` (or `colors.json`) change surfacing through the 5s polls — there is no push channel; the map is a pure function of that polled state plus the static per-scenario geometry.
+
+### Cross-references
+
+- [World state](world-state.md) — the `world.json` schema, `regionOwnershipOverrides`, `polityOverrides`, `regionClaimants`, `markers`, `units`, staged-reveal overrides.
+- Runtime asset layer (`src/runtime/assets.js`) — `JSON_URLS`, `PMTILES_PROTOCOL_URLS`, the `ohbase://` protocol, `getNationColors`, `resolveCountryDisplayName`, scenario-token cache sweeping.
+- Selection popups (`src/Game/Selection/*`) — consumers of `onRegionSelected` / `onFeatureSelected` / `onUnitSelected`.

--- a/docs/game-ui.md
+++ b/docs/game-ui.md
@@ -1,0 +1,401 @@
+# In-Game UI (HUD, Panels & Buttons)
+
+The in-game UI is a flat set of `position: fixed` React components layered over a full-screen MapLibre canvas — there is no single container div, each widget positions itself against the viewport edges and competes for the stacking order through an explicit z-index ladder. `src/Game/GameUI/main.jsx` is the shell: it mounts every HUD element, owns the panel-open booleans, and computes `rightShift` (the horizontal offset that slides the bottom-right cluster left when the advisor drawer opens). Everything the UI reads or writes flows through the runtime state stores (`readJson`/`writeJson`, `readGameData`/`readWorldState`, `useLibraryState`) and the AI layer (`src/Game/AI/*`) — the components hold almost no game data of their own, they poll the stores on a 5-second cadence and push edits back.
+
+- Shell & mount point: `src/App.jsx` (`GameApp`) renders `<UI>` = `src/Game/GameUI/main.jsx` once `isReady`, passing `mapRef`, `isGlobeEnabled`, `isTerrainEnabled`, and their setters.
+- Related pages: [World state](world-state.md) · [AI gameplay pipeline](ai-gameplay.md) · [Map rendering](map-rendering.md) · [Library & scenarios runtime](library-runtime.md) · [Diplomacy & chat](diplomacy.md)
+
+---
+
+## 1. The GameUI shell — `src/Game/GameUI/main.jsx`
+
+`Main` is the default export (`src/Game/GameUI/main.jsx:128`). It is mounted by `App.jsx` and **keyed on the active game id** (`key={\`ui-${activeGameId}\`}`, `src/App.jsx:179`) so the entire UI tree remounts when a game activates. That remount is why several open/closed flags live at module scope instead of component state (see [§4.1](#41-menuopendefault--the-remount-trap)).
+
+### 1.1 Props
+
+| Prop | Source | Used for |
+|---|---|---|
+| `mapRef` | `App.jsx` `useRef` handed to `<Map>` | Passed to `DateWidget`, `Toolbar`→n/a, `Search`, `ForcesPanel`; components call `mapRef.current.flyTo/fitBounds/getMap()` to move the camera |
+| `isGlobeEnabled` / `setIsGlobeEnabled` | `App.jsx` state (persisted `localStorage["Globe"]`) | Fed to `SettingsMenu`'s **3D Globe** toggle; `App.jsx` re-projects the map |
+| `isTerrainEnabled` / `setIsTerrainEnabled` | `App.jsx` state (persisted `localStorage["Terrain"]`) | Fed to `SettingsMenu`'s **3D Terrain** toggle |
+
+### 1.2 Local state in `Main`
+
+| State | Init | Purpose |
+|---|---|---|
+| `isSettingsOpen` | `false` | ⋮ settings menu visibility |
+| `isCheatsOpen` / `shouldLoadCheats` | `false` | Cheats panel open + lazy-load latch (never imports the chunk until first opened) |
+| `isAdvisorOpen` / `shouldLoadAdvisor` | `false` | Advisor drawer open + lazy-load latch |
+| `advisorWidth` | `readAdvisorWidth()` | Drawer width in px, persisted (see [§5.1](#51-advisor-width-state)) |
+| `isForcesOpen` | `false` | Forces panel open (also opened from the Cheats panel) |
+| `activeBottomPanel` | `null` | Which bottom panel (`"chat"`, `"actions"`, `"skip"`, `"history"`) is open — single-slot, so opening one closes another |
+| `isFullscreenEnabled` | `false` | Mirrors the Fullscreen API state; persisted `localStorage["Fullscreen"]` |
+| `showWebGLWarning` | `false` | Set true if `checkWebGL()` fails on mount → renders `WebGLWarningPopup` |
+| `apiProvider` | `getStoredProvider()` | AI provider id; persisted `localStorage["api_provider"]` via effect |
+| `providerSettings` | `loadProviderSettingsFormState()` | Per-provider keys/models/params form state |
+| `{ games, loaded }` | `useLibraryState()` | `hasNoGames = loaded && games.length === 0` gates the idle-diplomacy timer |
+
+### 1.3 Side effects owned by the shell
+
+| Effect | Behavior | Connects to |
+|---|---|---|
+| WebGL probe | On mount, `checkWebGL()`; on failure shows the popup | `src/Game/GameUI/main.jsx:55` |
+| **Idle diplomacy drip** | Every 60 s, if the tab is visible and a game exists, lazy-imports `../AI/gameplay.js` and calls `maybeSendIdleDiplomacy()` | `src/Game/AI/gameplay.js`; drops a message into the diplomatic chat store unprompted |
+| Advisor lazy-load latch | `isAdvisorOpen` → `setShouldLoadAdvisor(true)` (one-way) | Keeps the Chart.js/markdown chunk out of first paint |
+| Fullscreen persist + sync | Writes `localStorage["Fullscreen"]`; listens `fullscreenchange`/`webkitfullscreenchange` | `toggleFullscreen()` probes prefixed APIs (mobile Safari safe) |
+| Provider persist | Writes `localStorage["api_provider"]`; reloads provider form when settings opens | `src/Game/AI/providerConfig.js` |
+| Advisor-width resize guard | On window `resize`, re-clamps `advisorWidth` so a shrunk window never leaves the drawer wider than the viewport | — |
+
+### 1.4 What `Main` mounts (render order)
+
+`WebGLWarningPopup?` → `LibraryTopBar` → `DateWidget` → `Toolbar` → `Other` → `Search` → `ForcesPanel` → `AdvisorButton` → lazy `AdvisorPanel` → lazy `CheatsPanel` → `SettingsButton` → `SettingsMenu?`.
+
+| Mounted component | File | Role |
+|---|---|---|
+| `WebGLWarningPopup` | `main.jsx` (inline) | Full-screen blocker if WebGL is missing |
+| `LibraryTopBar` | `libraryBar.jsx` | Main menu + game/scenario editor + country picker + map-editor host + server shutdown |
+| `DateWidget` | `time.jsx` | Date/country pill + timeline-skip + event-history panels |
+| `Toolbar` | `chat.jsx` | Bottom-left cluster: 💬 Chat + ✦ Actions launchers |
+| `Other` | `other.jsx` | Player-country flag badge (desktop only) |
+| `Search` | `search.jsx` | Place search (Nominatim) → `map.flyTo` |
+| `ForcesPanel` | `forces.jsx` | Unit list + deploy controls + mode banner |
+| `AdvisorButton` (🧭) | `main.jsx` (inline) | Toggles the advisor drawer; sits at `rightShift` |
+| `AdvisorPanel` | `advisor.jsx` (lazy) | Advisor chat + Stats tabs, resizable drawer |
+| `CheatsPanel` | `cheats.jsx` (lazy) | God-mode tools (opened from Settings) |
+| `SettingsButton` (⋮) | `settings.jsx` | Toggles the settings menu |
+| `SettingsMenu` | `settings.jsx` | AI provider, language, map/AI toggles, cheats/guides/social |
+
+---
+
+## 2. Z-index ladder
+
+Every fixed element declares its own `zIndex`. From back to front (source-verified):
+
+| z-index | Element | File |
+|---:|---|---|
+| 9997 | In-game floating cluster (session summary pill, **⌂ Exit Game**, **⏻**) | `libraryBar.jsx:1993` / `:2061` |
+| 9998 | Timeline panels (`panelSurface`), **Actions** panel, **Chat** panel | `time.jsx:149`, `actions.jsx:427`, `chat.jsx:851` |
+| 9999 | `DateWidget` pill, bottom `Toolbar`, `Search`, `Other` flag badge, 🧭 `AdvisorButton`, ⋮ `SettingsButton`, `SettingsMenu`, `ForcesPanel` body, `WebGLWarningPopup` | shared `baseStyle`/`widgetSurface` |
+| 10000 | Forces **mode banner** (deploy/move/attack hint) | `forces.jsx:156` |
+| 10028 | "Loading games and scenarios…" indicator | `libraryBar.jsx:2565` |
+| 10040 | **Advisor drawer** | `advisor.jsx:320` |
+| 10045 | **Cheats panel** | `cheats.jsx:280` |
+| 10046 | **Main menu** (full page) | `libraryBar.jsx:2302` |
+| 10048 | **Editor drawer** (game/scenario editor) | `libraryBar.jsx:741` |
+| 10050 | **Map editor** overlay | `libraryBar.jsx:2125` |
+| 10060 | **Country / faction picker** modal | `libraryBar.jsx:2152` |
+| 10070 | Cheats **click-capture toast** | `cheats.jsx:256` |
+| 20000 | **Server stopped** full-screen overlay | `libraryBar.jsx:2113` |
+| 99999 | Chat reaction tooltip (React portal to `document.body`) | `chat.jsx:260` |
+
+Design intent captured in comments: the advisor drawer (10040) sits above every HUD button/panel so nothing covers it on phones, but below the editor/picker/server-down overlays. The editor drawer (10048) deliberately lands **above** the main menu (10046) because the menu's `+`/Edit buttons open it. The in-game cluster sits at 9997 — below the settings menu and date widget (9998/9999) — so opening either covers it rather than the reverse.
+
+---
+
+## 3. Bottom toolbar & diplomacy — `src/Game/GameUI/chat.jsx`
+
+`Toolbar` (`chat.jsx:962`) is the bottom-left 2-button cluster (`bottom/left: 0.5rem`, z 9999). It's memoized and driven by `activePanel`/`onTogglePanel` from `Main`.
+
+| Button | Component | Opens | Notes |
+|---|---|---|---|
+| 💬 Chat | `Chat` (`chat.jsx:886`) | `ChatPanel` (bottom-left, z 9998) | Unread badge: polls stored chats every 15 s, counts open chats that gained messages since last opened |
+| ✦ Actions | `Actions` (`actions.jsx:700`) | `ActionsPanel` | See [§7](#7-actions-panel--srcgamegameuiactionsjsx) |
+
+Both launchers use `hasOpened` latches so the panel body isn't mounted until first opened.
+
+### 3.1 ChatPanel (diplomacy)
+
+| Concern | Detail | Connects to |
+|---|---|---|
+| Data | `chats` from `readChatsState`/`writeChatsState`; player country + date polled from `JSON_URLS.game` every 5 s | `src/runtime/gameState.js` |
+| Country list | `loadCountryNames()` (PMTiles-derived), filtered to exclude the player | `src/runtime/assets.js` |
+| Live sync | While open, polls stored chats every 5 s and merges additions (jump invitations, idle drip) without clobbering the active conversation | — |
+| Send | `sendDiplomaticMessage(text, countryName, countries)` → `{ reply, reaction }`; multi-country chats rotate speakers via `chooseNextDiplomaticSpeaker` | `src/Game/AI/main.jsx`, `src/Game/AI/gameplay.js` |
+| Group turn UI | `phase` = `player`/`pending`/`leader`; "Let X speak →" vs "Speak" buttons offer each queued country | `ConversationView` |
+| External trigger | `requestDiplomaticChat(country)` bridge (`chat.jsx:697`) lets the map region popup open/reuse a 1-on-1 chat | Map selection layer |
+| Reactions | Leader reactions attach an emoji to the player's last message; hover tooltip is a portal at z 99999 | — |
+
+---
+
+## 4. Main menu & library — `src/Game/GameUI/libraryBar.jsx`
+
+`LibraryTopBar` (exported at `libraryBar.jsx:1042`) is a single large component that renders the whole main menu, both editor drawers, the country picker, the map-editor host, and the in-game floating cluster. It subscribes to `useLibraryState()` (`src/runtime/library.js`) for `games`, `scenarios`, `activeGame`, `activeGameId`, `selectedScenarioId`, `countryNames`, `loaded`, `loading`, `error`.
+
+### 4.1 `menuOpenDefault` — the remount trap
+
+`menuOpenDefault` (`libraryBar.jsx:97`) is a **module-scoped boolean**, not state. The whole UI remounts on game activation (App keys on `activeGameId`), so per-component `useState("open")` would reset the menu back open mid game-start. Every open/close goes through `setMenuOpen` (`libraryBar.jsx:1060`), which writes the module var **first**, then the React state. Flows that activate a game (`startGameForCountry`, `handleGameActivate`, `applyMapToScenario`, …) call `setMenuOpen(false)` **before** awaiting the request, so the remounted instance mounts closed over the new game.
+
+- `isMainMenuOpen()` (exported, `libraryBar.jsx:100`) lets background work (e.g. `maybeGeneratePregameHistory` in `time.jsx`) skip while the player is only browsing.
+- `openLibraryTab(tab)` (exported, `libraryBar.jsx:89`) + module `_openLibraryTab` bridge lets outside callers open the menu on a specific tab.
+
+### 4.2 Menu chrome
+
+Full-page overlay at z 10046. Header is a 3-column grid: **logo/title** | **tab buttons** | **actions**.
+
+| Tab | Content | Component |
+|---|---|---|
+| Games | `MenuRow`s: 🕐 Last Played, 🔥 Most Played | `GameCard` |
+| Scenarios | 🔥 Most Played, 🕐 Last Updated, ✦ Your Scenarios (with `CreateScenarioTile`) | `ScenarioCard` |
+| Community | Lazy `CommunityPanel fullPage` | `communityHub.jsx` |
+
+Header action buttons (right cell): **Refresh** (`refreshLibraryCatalog({force:true})`, hidden on Community), **Import JSON** (Scenarios only → hidden file input `handleImportScenarioFile`), **⏻** shutdown (hidden on the web build via `import.meta.env.VITE_OH_WEB`).
+
+The Games tab's empty state ("No games yet") offers **Start from a scenario** / **Browse community scenarios** shortcuts.
+
+### 4.3 Menu shelves (derived, memoized)
+
+| Shelf | Sort | Source |
+|---|---|---|
+| `lastPlayedGames` | `lastPlayedAt` desc | `games` |
+| `mostPlayedGames` | `playCount` desc, then `round` | `games` |
+| `mostPlayedScenarios` | `playCount` desc, then `gameCount` | `scenarios` |
+| `lastUpdatedScenarios` | `updatedAt` desc | `scenarios` |
+| `yourScenarios` | filter `!hubOrigin` and not the untouched built-in | `scenarios` |
+
+### 4.4 Cards
+
+**`GameCard`** (`libraryBar.jsx:519`) — cover image + accent gradient; shows country/date/round, pending-action & event counts. Buttons:
+
+| Button | Handler | Effect |
+|---|---|---|
+| Play / Current | `onActivate`→`handleGameActivate` | `activateGame(id)`; closes menu (module flag first) |
+| Edit | `onEdit`→`openGameEditor` | `loadGameDetails` → editor drawer |
+| Clone Game | `onClone`→`handleGameClone` | `createGame({seedGameId, setActive})` → editor |
+
+**`ScenarioCard`** (`libraryBar.jsx:360`) — asset badges (Cities/Colors/Countries/Regions PMTiles), game count. Buttons:
+
+| Button | Handler | Effect |
+|---|---|---|
+| **New Game** / **⬆ Update** | `onPlay`→`handleScenarioPlay` **or** `onUpdate`→`handleScenarioUpdate` | Update replaces the primary action when a hub-imported, unmodified scenario has a newer bundle upstream (see [§4.7](#47-hub-update-detection)) |
+| Edit | `onEdit`→`openScenarioEditor` | `loadScenarioDetails` → editor drawer |
+| Clone Scenario | `onClone`→`handleScenarioClone` | `createScenario({seedScenarioId, setActive})` |
+| (whole card) | `onSelect`→`selectScenario` | Marks `selectedScenarioId` |
+
+### 4.5 Country / faction picker (New Game flow)
+
+`handleScenarioPlay` (`libraryBar.jsx:1276`) opens a modal (z 10060) instead of starting immediately. Two nested steps:
+
+| Step / state | UI | Resolves to |
+|---|---|---|
+| `pickerTab === "country"` | `CountryPickerMap` (lazy OpenLayers) + a country list built by `buildScenarioCountryOptions` (only factions the scenario actually contains: `world.ownerCodes` ∪ `polityOverrides`, incl. landless factions) | `pickCountry(code)` → `difficultyPick` |
+| `pickerTab === "faction"` | `FactionCreator` (invent a nation: name/color/lore/flag/regions) | `pickFaction(faction)` → `difficultyPick` |
+| `difficultyPick` set | Difficulty grid from `DIFFICULTY_LEVELS` (`src/runtime/difficulty.js`) | `pickDifficulty(id)` |
+
+`pickDifficulty` routes to `startGameForCountry` (new game with country), `startGameForFaction` (new game seeded with an invented polity — merges into `world.polityOverrides`/`regionOwnershipOverrides`/`ownerCodes`, writes colors/flags), or `choosePlayCountry` (Apply-&-Play: `playGameId` set → refines an already-active game). Custom scenario geometry is loaded via `downloadScenarioJsonAsset(id, "regionsGeojson")` so the picker map shows real borders.
+
+### 4.6 Editor drawer (game & scenario editor)
+
+`EditorDrawer` (`libraryBar.jsx:692`) — the fixed right-side form (z 10048, `width: min(34rem, …)`), the primary scenario/game authoring surface. Driven by `editorKind` (`"scenario"`|`"game"`), `editorDetails`, `editorState`, `editorSection`, `promptSectionKey`.
+
+Section tabs (`SectionTabs`): scenarios show `overview | world | prompts | assets | bundles`; games drop `bundles`.
+
+| Section | Fields | Writes via |
+|---|---|---|
+| overview | Name, Eyebrow, Accent (color), Subtitle, Description, Hero Title, Hero Subtitle | `saveScenario`/`saveGame` meta |
+| world | Player Country, Game Date, Language, **Deployable Troop Types** (scenario only, `UNIT_TYPES` toggles), World Before Round One (`startingTimelineText`), Simulation Rules, Country Label Font/Letter Color/Border Color | merged into `world` |
+| prompts | `PromptSectionEditor`: per-section prompt textareas + helpers from `PROMPT_SECTION_DEFINITIONS` | `serializePromptPack` → `prompts` |
+| assets | Upload/Reset per asset (cover; scenario adds cities/colors/countries/regions) via hidden file inputs | `uploadScenarioAsset`/`clearScenarioAsset` etc. |
+| bundles | **Download .zip** / **Download JSON** (`exportScenarioBundle` + `splitScenarioBundleImage`) | disk download |
+
+Footer: **Save** (`handleSave`), **🗺️ Open Map Editor** (scenario only — loads current geometry/owners/cities/palette/flags/background then opens the lazy `MapEditor` at z 10050; on apply → `applyMapToScenario`), **Delete** (if `record.canDelete`, `window.confirm`).
+
+Save is careful: scenario/game meta writes merge `currentGame`/`currentWorld` so a partial write never wipes `startDate`/`gameDate`/`round` or `polityOverrides`/`ownerCodes` (the "Undated" and wiped-map bugs called out in comments).
+
+### 4.7 Hub update detection
+
+When the Scenarios tab shows any scenario carrying `hubOrigin`, an effect (`libraryBar.jsx:1308`) lazy-imports `communityHub.jsx`'s `fetchHubPosts()` and builds `hubPostById`. `scenarioUpdateAvailable(scenario)` returns true when the post's current `bundleUrl` differs from the imported one → the card's primary button flips to **⬆ Update**. `handleScenarioUpdate` calls `downloadHubBundle` + `updateScenarioFromBundle(id, bundle)`, replacing the copy in place (existing games keep working).
+
+### 4.8 In-game floating cluster & server shutdown
+
+When the menu is closed, `LibraryTopBar` renders a compact cluster (z 9997): a session-summary pill (`summaryText` = name / country / date), **⌂ Exit Game** (→ `setMenuOpen(true)`), and **⏻** (`handleShutdownServer` → `POST /api/server/shutdown`, then a full-screen "Server stopped" overlay at z 20000). Desktop lays them out top-left of the date widget; phones stack **⌂**/**⏻** vertically in the left gutter. **⏻** is stripped from the web build (`!import.meta.env.VITE_OH_WEB`).
+
+---
+
+## 5. Advisor drawer & stats — `src/Game/GameUI/advisor.jsx` + `stats.jsx`
+
+`AdvisorPanel` (`advisor.jsx:186`) is the right-docked drawer (z 10040, full `100vh`). It slides in/out via `transform: translateX(...)` (a prior `right: calc(-min()…)` was invalid CSS and silently never slid). Two tabs, both kept mounted so flipping is instant:
+
+| Tab | Component | Behavior |
+|---|---|---|
+| 🧭 Advisor | inline chat | Loads/saves history to `JSON_URLS.advisor`; `startChat()`/`loadHistory()` bootstrap; `sendMessage(text)` → advisor reply. Renders markdown (`react-markdown`) and inline ` ```chart ` blocks via `AdvisorChart` (Chart.js). 🗑 clears the chat; ✕ closes (the only exit on phones where the drawer covers 🧭) |
+| 📊 Stats | `StatsPane` | National stat sheet (see [§5.2](#52-statspane--srcgamegameuistatsjsx)) |
+
+### 5.1 Advisor width state
+
+The drawer is user-resizable by dragging its **left edge**. Width lives in `Main` as px (drag maps 1:1 to the pointer):
+
+| Constant / fn | Value / behavior | File |
+|---|---|---|
+| `ADVISOR_MIN_WIDTH` | `280` | `main.jsx:21` |
+| `ADVISOR_DEFAULT_WIDTH` | `320` (the old fixed 20rem) | `main.jsx:22` |
+| `clampAdvisorWidth(px)` | clamps to `[min(280, vw−16), vw−16]` | `main.jsx:23` |
+| `readAdvisorWidth()` | reads `localStorage["oh-advisor-width"]`, else default | `main.jsx:27` |
+| `handleAdvisorResize(px)` | sets state + writes `localStorage["oh-advisor-width"]` | `main.jsx:238` |
+
+The drag handler lives in the drawer (`advisor.jsx:202`): on `pointerdown` it captures the pointer and, on each `pointermove`, calls `onResize(window.innerWidth - ev.clientX)` (docked right, so width = viewport − pointer x). `Main` clamps + persists. `rightShift = isAdvisorOpen ? \`calc(${advisorWidth}px + 0.5rem)\` : "0.5rem"` (`main.jsx:253`) is passed to the date widget, the flag badge (`Other`), and the 🧭 button so they slide left exactly the drawer's width when it's open.
+
+### 5.2 `StatsPane` — `src/Game/GameUI/stats.jsx`
+
+| Concern | Detail | Connects to |
+|---|---|---|
+| Target | `targetCountry` seeds from the player's country; **clicking any country on the map** re-targets it (`setRegionClickObserver`) | `src/Game/Selection/Regions.jsx` |
+| Data | `generateCountryStatSheet({code, name})` (AI), validated by `validateGameplayPayload("countryStatSheet", …)` | `src/Game/AI/gameplay.js`, `gameplaySchemas.js` |
+| Caching | Per `gameKey:code`, keyed by game date; memory + `localStorage["oh-stat-sheets"]` (cap 60); regenerated when the date moves; ↻ forces regen | — |
+| Render | Flag/initials header, national stability bar, 6 strategic indices (`INDEX_ROWS`), economy cards (`compactEconomyValue` trims 30000000000→30.0B), GDP breakdown bar | — |
+| Flag logic | author flag (`flags.json`) > polity flag > code-derived — but a **landless player** never borrows a code-derived flag (`isPolityLandless`) | `src/runtime/countryFlags.js` |
+
+`Other` (`other.jsx`) is the standalone player-country flag badge at bottom-right (desktop only; hidden on mobile because the date widget already shows the country). It polls `JSON_URLS.game` + world every 5 s and applies the same landless-suppression logic; falls back emoji → `FallbackBadge` initials for non-ISO polities.
+
+---
+
+## 6. Date widget & timeline — `src/Game/GameUI/time.jsx`
+
+`DateWidget` (`time.jsx:1226`) is the top-right pill (z 9999) plus two slide-up panels (z 9998). It's the time-advance control center.
+
+### 6.1 The pill
+
+Shows player country + formatted date (`«` opens Events history, `»` opens the Skip panel; `»` becomes a spinner during a jump). `rightShift`/`topOffset` come from `Main`. Polls `readGameData`/`readEventsState`/`readWorldState` every 5 s, but **never regresses** — a stale poll with a lower round/date than what's on screen is skipped (`gameStampRef`), so a just-completed jump is never reverted.
+
+### 6.2 Timeline skip panel (`»`)
+
+| Control | Effect | Connects to |
+|---|---|---|
+| Fixed jumps (6h…1yr) | `runJump(days, "jump")` → `simulateTimelineJump` | `src/Game/AI/gameplay.js` |
+| Custom amount + unit | same, arbitrary days | — |
+| **Auto-jump** | `runJump(365, "auto")` → `simulateAutoJump` (AI picks how far) | — |
+| **↩ Undo last turn** | `runUndo()` → `rollBackToSnapshot(0)`; `undoCount` from `loadRollbackSnapshots` | rollback snapshots |
+| Cancel (during load) | `cancelJump()` aborts the in-flight `AbortController` | — |
+
+On success it swaps to the **history panel** with `visibleEventCount = 1`. Fallback generations surface a warning banner.
+
+### 6.3 Event history panel (`«`) + staged reveal
+
+Renders the latest turn's events (`buildTurnRecord`) one at a time; **Next event** / **Skip to end** reveal more. The camera follows every revealed event (`deriveEventFocusBounds` → `focusMapOnBounds`), unless the **Disable camera movement during events** map setting is on. A **staged reveal** (`time.jsx:1558`) replays the pre-jump world from the rollback snapshot and applies only revealed events' impacts through a purely visual override (`setWorldStateOverride`/`setUnitsOverride`) so ownership/units/markers animate in; finishing/closing clears the override.
+
+### 6.4 Pregame history
+
+If a fresh game (round 1, no events/turns) has a "World Before Round One" briefing and the menu is closed, `maybeGeneratePregameHistory()` runs once (`time.jsx:1351`). The `isMainMenuOpen()` gate ensures tokens aren't spent on a game the player is only hovering past in the menu.
+
+---
+
+## 7. Actions panel — `src/Game/GameUI/actions.jsx`
+
+`ActionsPanel` (`actions.jsx:225`) — bottom-left slide-up (z 9998). The player's planned-action queue for the current turn.
+
+| Control | Effect | Connects to |
+|---|---|---|
+| Composer (textarea) + ✈ send | `createManualAction` → `writeActionsState` | `src/runtime/gameState.js` |
+| ✦ sparkle | `refinePlayerAction(text)` rewrites the draft in place (no persist) | `src/Game/AI/gameplay.js` |
+| **Help brainstorm actions** | `onOpenAdvisor` (opens the advisor drawer) | `Main.openAdvisor` |
+| **Get/Refresh AI suggestions** | `generateActionSuggestions({force:true})` → `SuggestionCard`s | AI |
+| Queue a suggestion | `normalizeSuggestionAction` → persisted; button flips to "✓ Queued" | — |
+| Delete an action | `handleDelete`; if it was a queued unit order (`unitRevert`, still `planned`), also `revertUnitOrder` to undo its map effect | `src/Game/Map/unitsController.js` |
+
+Only `status === "planned"` actions render. Country + date poll `JSON_URLS.game` every 5 s (display only). The launcher button (`Actions`, `actions.jsx:700`) lives in the toolbar.
+
+---
+
+## 8. Forces panel — `src/Game/GameUI/forces.jsx`
+
+`ForcesPanel` (`forces.jsx:85`) — bottom-left panel (z 9999), a **controlled** component (open state owned by `Main.isForcesOpen`; opened from the toolbar historically, now primarily from the Cheats panel's "Manual force deployment"). Manual troop control is treated as a cheat.
+
+| Element | Behavior | Connects to |
+|---|---|---|
+| Unit list | `subscribeUnits`/`getUnits`; split into "Your units" (`getPlayerCode`) and dimmed "Other forces". Clicking a unit `flyTo`s it | `src/Game/Map/unitsController.js` |
+| Deploy controls | type (restricted by scenario `getAllowedUnitTypes()`), strength (1–1000), optional name → `setInteractionMode({kind:"deploy", params})` then closes the panel | unitsController |
+| **Mode banner** (z 10000) | Global hint while `mode.kind !== "idle"` (deploy/move/attack) + Cancel (`clearInteractionMode`) | interaction-mode state |
+
+Owner codes render as full names via `ensurePolityNames`/`polityDisplayName` (re-renders once the lookup warms). `TYPE_GLYPH`/`TYPE_LABEL` map unit types to icons/labels; strength color-codes >600 green / >250 amber / else red.
+
+---
+
+## 9. Cheats panel — `src/Game/GameUI/cheats.jsx`
+
+`CheatsPanel` (`cheats.jsx:164`) — right-side panel (z 10045), opened from Settings → 🧪 Cheats (lazy-loaded). A list of tools (`TOOLS`); selecting one renders `ToolView`. Several tools enter **click-capture mode**: the panel hides behind a toast (z 10070) and map clicks route through `setRegionClickInterceptor` instead of opening the region popup.
+
+| Tool id | Does | Writes / calls |
+|---|---|---|
+| `master-ai` | Free-text world command | `applyGameMasterCommand(text)` (`src/Game/AI/gameplay.js`) — records a game-master event |
+| `roll-back-turn` | Restore to the start of an earlier turn (discards later turns) | reads `JSON_URLS.snapshots`; writes game/world/events/actions/chat/colors |
+| `your-country` | Switch which country you play | `writeGameData({…country})` |
+| `difficulty` | Set difficulty | `writeGameData({…difficulty})` (`DIFFICULTY_LEVELS`) |
+| `annex-country` | Click a country → fold all its regions into a target | resolves current owner via overrides + `loadRegionCatalog`; writes `regionOwnershipOverrides` |
+| `annex-regions` | Click individual regions → transfer to a target | per-region `regionOwnershipOverrides` write |
+| `edit-country` / `add-country` | Rename/recolor or create a polity (name **is** the identifier) | `polityOverrides` + `colors.json` |
+| `regions` | Click a region → edit name/owner | owner via overrides; name only on custom-geometry maps (`regionsGeojson`) |
+| `edit-feature` / `add-feature` / `clear-features` | Edit/add/clear cities & landmarks | `citiesGeojson`; adding the first custom feature flips `customCities: true` |
+| `events` | Edit/delete recorded events | `writeEventsState` |
+
+Ownership/name resolution is done in **one namespace** (country display name) — the file's comments call out the recurring bug where a GADM code (`RUS`) and a name (`Russia`) never compared equal. All map changes repaint within ~5 s (the map's own poll).
+
+`loadPolities()` (`cheats.jsx:103`) enumerates the countries actually in the game (polity overrides ∪ current region owners ∪ owners of rendered geometry — custom regions when present, else the stock catalog), each resolved to a display name.
+
+---
+
+## 10. Settings — `src/Game/GameUI/settings.jsx`
+
+`SettingsButton` (⋮, `settings.jsx:709`) sits top-left (z 9999); toggles `SettingsMenu` (`settings.jsx:727`), a scrollable panel below it.
+
+| Section | Control | Persists to / calls |
+|---|---|---|
+| AI Provider | `ApiProviderSelector` — searchable catalog of `PROVIDER_OPTIONS` | `onApiProviderChange`→`Main.apiProvider`→`localStorage["api_provider"]` |
+| Provider settings | `ProviderSettingsPanel` — per-provider API key/model/custom-params (gemini, openai, anthropic, openai-compatible, anthropic-compatible) + global **Model reasoning** toggle | `persistProviderSetting` (browser localStorage); `setReasoningEnabled` |
+| Language | `LanguageSelector` — searchable; applying reloads the page | `setStoredLanguage` (server + browser) |
+| Display | **Fullscreen**, **3D Globe**, **3D Terrain** (labeled "Very Experimental") toggles | `Main` toggles / `App.jsx` state |
+| Map | Hide country labels, **Reduce motion** (umbrella over the two below), Disable idle globe rotation, Disable camera movement during events | `setMapSetting(MAP_SETTING_KEYS.*)` (`src/runtime/mapSettings.js`) |
+| AI | **Limit AI generation** (5-min cap then canned fallback vs. wait-as-long-as-needed) | `MAP_SETTING_KEYS.limitAiGeneration` |
+| Footer | **🧪 Cheats** (→ `onOpenCheats`), **📖 Guides** (`/guides/`), Discord/Reddit/GitHub links | — |
+
+`Toggle` (`settings.jsx:156`) is the shared switch primitive (also exported). Map-setting toggles read initial values from `getMapSetting` and mirror them locally.
+
+---
+
+## 11. Search — `src/Game/GameUI/search.jsx`
+
+`Search` (`search.jsx:144`, memoized) — collapsed 3rem circle just right of the toolbar (z 9999), expands to an input (rightward on desktop, full-width above the toolbar on mobile). Debounced (200 ms) autocomplete against **Nominatim** (`nominatim.openstreetmap.org/search`), results deduped + cached in-module. Picking a result (click / Enter / ↑↓) calls `mapRef.current.flyTo({center:[lon,lat], zoom:5})`. Purely a camera control — it does not touch game state.
+
+---
+
+## 12. Legacy: `src/Game/GameUI/scenarios.jsx`
+
+`ScenarioTopBar` (`scenarios.jsx:686`) is an **older, standalone** scenario deck + editor (full-width top bar z 10030, deck z 10029, editor z 10031) that reads from a separate `../../runtime/scenarios.js` store (`useScenarioState`) rather than `library.js`. It is **not imported anywhere** in `src/` — it has been superseded by `LibraryTopBar` + `EditorDrawer` in `libraryBar.jsx`. Its `ScenarioEditor` still shows the older flat prompt fields (Advisor Prompt / Leader Prompt / **Advanced AI Prompt Pack** JSON textarea) rather than the sectioned `PromptSectionEditor`. Treat it as reference/dead code unless you're wiring the old top-bar mode back in; new work goes in `libraryBar.jsx`.
+
+---
+
+## 13. Master reference — every panel/button
+
+| # | UI element | File | Kind | Open/toggle driver | Reads | Writes / calls |
+|---|---|---|---|---|---|---|
+| 1 | ⋮ Settings button | `settings.jsx` | button | `Main.isSettingsOpen` | — | opens `SettingsMenu` |
+| 2 | Settings menu | `settings.jsx` | panel | `isSettingsOpen` | provider/map settings | localStorage, `setMapSetting`, `setStoredLanguage` |
+| 3 | 🧭 Advisor button | `main.jsx` | button | `Main.isAdvisorOpen` | — | opens advisor drawer |
+| 4 | Advisor drawer (Advisor tab) | `advisor.jsx` | panel | `isAdvisorOpen` | `JSON_URLS.advisor`, `JSON_URLS.game` | `sendMessage`, `writeJson(advisor)` |
+| 5 | Advisor resize handle | `advisor.jsx` | drag | pointer capture | — | `onResize`→`localStorage["oh-advisor-width"]` |
+| 6 | Stats tab | `stats.jsx` | panel | advisor tab state | game/world, stat cache | `generateCountryStatSheet`, `localStorage["oh-stat-sheets"]` |
+| 7 | Date pill `«` / `»` | `time.jsx` | buttons | `Main.activeBottomPanel` | game/events/world | opens skip/history panels |
+| 8 | Timeline skip panel | `time.jsx` | panel | `activeBottomPanel==="skip"` | game date, snapshots | `simulateTimelineJump`/`simulateAutoJump`/`rollBackToSnapshot` |
+| 9 | Event history panel | `time.jsx` | panel | `activeBottomPanel==="history"` | `simulationHistory`, events | `setWorldStateOverride`/`setUnitsOverride`, `fitBounds` |
+| 10 | 💬 Chat button (+ unread badge) | `chat.jsx` | button | `activeBottomPanel==="chat"` | chats store | opens `ChatPanel` |
+| 11 | Chat panel / conversation | `chat.jsx` | panel | `isOpen` | chats, country names, game | `sendDiplomaticMessage`, `writeChatsState`, `chooseNextDiplomaticSpeaker` |
+| 12 | ✦ Actions button | `actions.jsx` | button | `activeBottomPanel==="actions"` | — | opens `ActionsPanel` |
+| 13 | Actions panel | `actions.jsx` | panel | `isOpen` | `JSON_URLS.game`, actions | `writeActionsState`, `generateActionSuggestions`, `refinePlayerAction`, `revertUnitOrder` |
+| 14 | Forces panel + mode banner | `forces.jsx` | panel | `Main.isForcesOpen` | units, allowed types, player code | `setInteractionMode`/`clearInteractionMode`, `map.flyTo` |
+| 15 | Cheats panel + tools | `cheats.jsx` | panel | `Main.isCheatsOpen` (+ `shouldLoadCheats`) | world/game/events/catalogs | many `writeWorldState`/`writeGameData`/`writeJson`, `applyGameMasterCommand`, `setRegionClickInterceptor` |
+| 16 | Search box | `search.jsx` | widget | local `expanded` | Nominatim | `map.flyTo` |
+| 17 | Player flag badge | `other.jsx` | badge | always (desktop) | `JSON_URLS.game`, world | — |
+| 18 | Main menu (Games/Scenarios/Community) | `libraryBar.jsx` | full page | `menuOpenDefault` | `useLibraryState`, hub posts | `activateGame`, `createGame/Scenario`, catalog refresh |
+| 19 | Game/Scenario editor drawer | `libraryBar.jsx` | panel | `editorKind`/`editorDetails` | scenario/game details | `saveScenario`/`saveGame`, asset up/clear, `exportScenarioBundle` |
+| 20 | Country / faction picker | `libraryBar.jsx` | modal | `countryPicker` | country options, custom regions | `createGame`, `saveGame`, `activateGame` |
+| 21 | Map editor host | `libraryBar.jsx` | overlay | `isMapEditorOpen` | scenario assets | `applyMapToScenario` → many asset writes + new game |
+| 22 | ⌂ Exit Game / ⏻ shutdown / summary | `libraryBar.jsx` | cluster | `!menuOpen` | `activeGame` | `setMenuOpen(true)`, `POST /api/server/shutdown` |
+| 23 | Community hub tab | `communityHub.jsx` | panel | menu tab | GitHub hub API, `/api/hub/*` | `downloadHubBundle`+`importScenarioBundle`, publish/export |
+
+---
+
+## 14. Shared conventions
+
+- **Surface styling**: most HUD elements share a `baseStyle`/`surface` object — `rgba(17,24,39,0.9)` bg, `backdrop-filter: blur`, 12px radius, subtle border/shadow. The main menu/editor use `surfaceStyle` (darker gradient + heavier blur).
+- **5-second polling**: Chat, Actions, Stats, `Other`, and `DateWidget` each run their own `setInterval(refresh, 5000)` against the runtime stores rather than sharing a subscription — the map's own poll then repaints ownership within ~5 s of any cheat/edit.
+- **`data-no-translate`**: player-typed text, economic figures, and raw dropdown values are marked so the UI translator ([i18n](i18n.md)) leaves them verbatim.
+- **Mobile branching**: `useIsMobile()` (`src/runtime/useIsMobile.js`) reshapes the search box, the date/country row, the exit cluster, and menu paddings. The advisor drawer and bottom panels clamp to `calc(100vw − …)`.
+- **Lazy chunks**: advisor (Chart.js + markdown), cheats, community hub, the map editor, and the OpenLayers country picker are all `React.lazy` — none are in the first paint.

--- a/docs/map-editor.md
+++ b/docs/map-editor.md
@@ -1,0 +1,443 @@
+# Map Editor
+
+The Map Editor is a standalone OpenLayers map-authoring surface (reachable at `/?editor=1`, or embedded from a scenario's library bar) that lets a user re-own, reshape, recolour, and re-populate the world map and export it as a game-playable seed. It runs in its own React tree with its own map instance, deliberately isolated from the game's MapLibre map so the two can never disturb each other (`src/Editor/MapEditor.jsx:6`). Region *geometry* lives outside React in an OpenLayers vector source and is driven imperatively; everything else (types, cities, colours, flags, tags, metadata) lives in a document-state hook.
+
+The editor writes a game seed in one of two tiers: **tier 1 (re-ownership)** keeps stock GADM region ids so the game renders from the shipped `regions.pmtiles`, and **tier 2 (custom geometry)** ships an exported `regions.geojson` the game renders directly. Understanding that split (`src/Editor/exportPreset.js`) is the key to the whole subsystem.
+
+---
+
+## 1. How the editor is reached (routes / entry points)
+
+| Entry | Where | What it does |
+|---|---|---|
+| `/?editor=1` | `src/App.jsx:200` | Standalone mode. `App` reads the URL param once at render and mounts `<MapEditor />` (lazy-loaded) with no props — no `onClose`, no `onApplyToScenario`. Authoring-only; export happens via the Documents menu's download buttons. |
+| Scenario "Edit map" button | `src/Game/GameUI/libraryBar.jsx:2511` (`onOpenMapEditor`) | Embedded mode. Sets `mapEditorScenario`, opens the editor, and streams the scenario's current map assets into `mapEditorSeed`. |
+| Embedded `<MapEditor>` mount | `src/Game/GameUI/libraryBar.jsx:2133` | Passes `onClose`, `scenarioName`, `initialMap={mapEditorSeed}`, and `onApplyToScenario`. Presence of `onApplyToScenario` is what flips the editor into "scenario mode". |
+
+`MapEditor`'s prop contract (`src/Editor/MapEditor.jsx:40`):
+
+| Prop | Meaning |
+|---|---|
+| `onClose` | Present in embedded mode → renders the top-right **✕ Close** button. |
+| `scenarioName` | Label shown in the Apply button tooltip. |
+| `onApplyToScenario(seed)` | Callback that writes the built game seed into the scenario. Its presence sets `scenarioMode = true` (`:45`), which forces `seedKind="deferred"` so the default world is **not** auto-seeded underneath the scenario's own map. |
+| `initialMap` | The scenario's current map (regions/owners/cities/palette/flags/tags/background/basemap), hydrated once it arrives (`:339`). |
+
+---
+
+## 2. File map (`src/Editor/`)
+
+| File | Role |
+|---|---|
+| `MapEditor.jsx` | Root component. Composes the map + toolbar + panels + inspector + bottom bar; owns cross-cutting state (open panel, paint owner, doc id, save flow, custom background, FMG). |
+| `OlMap.jsx` | The OpenLayers surface. Owns the region source/layers, all editing interactions, click-selection, undo/redo, and the imperative region API exposed via `onReady`. |
+| `useMapDocument.js` | Document state hook: metadata, types, features (cities), colorOverrides, flags, tags + all setters + ephemeral UI state. Region geometry is **not** here. |
+| `Toolbar.jsx` | Top tool strip (single-choice tool + undo/redo/fit). |
+| `BottomBar.jsx` | Status bar: counts (open managers), Layers/Reference buttons, basemap picker, map name, save-status dot, search box. |
+| `SelectionInspector.jsx` | Right panel for the current region selection: name/type/country/disputed-by/colour/flag/tags + merge/copy/zoom/delete. |
+| `TypeManager.jsx` | Region "type" editor (render + gameplay settings). |
+| `RegionsPanel.jsx` | Searchable region list → select + zoom. |
+| `FeatureManager.jsx` | City/point-feature list; bulk import from the seed. |
+| `CityPopup.jsx` | Inline city editor anchored at the click. |
+| `SearchBar.jsx` | Unified place search (this map's cities, regions, ~70k world places). |
+| `LayersPanel.jsx` | Region / label layer visibility toggles. |
+| `ReferencePanel.jsx` | Tracing-image upload/opacity/placement (session-only). |
+| `BasemapPicker.jsx` | Overlay to choose a built-in ESRI basemap, a saved basemap, upload, or a community one. |
+| `FlagPicker.jsx` | Overlay to choose a country flag (My flags / built-in / community). |
+| `DocumentsMenu.jsx` | Top-left menu: new/open/save/export-JSON/export-for-game + author field. |
+| `exportPreset.js` | `buildGameSeed` + tier detection + region normalization + verbatim-polity logic. |
+| `regionImport.js` | Loads `regions-seed.geojson` into the OL source; resolves owner NAMEs from `gid0`. |
+| `documentMigration.js` | Brings a legacy code-keyed document forward to name-keyed on open. |
+| `documentIO.js` | REST client for `/api/mapeditor/documents` + local JSON download. |
+| `customBackground.js` | Loads uploaded backgrounds (GeoJSON/KML/KMZ/SHP/GeoTIFF/PMTiles/image) into OL layers; persistence helpers. |
+| `geometry.js` | Polygon boolean ops (union/difference/intersection), line split, translate. |
+| `olStyle.js` | Region → OL `Style` mapping (owner colour, opacity, stroke, disputed striping). |
+| `basemaps.js` | ESRI basemap presets + XYZ/preview URL builders. |
+| `editorStyles.js` | Shared chrome styling constants (`panelSurface`, `inputStyle`, `ACCENT`, `pillButton`, `toolButton`). |
+| `fields.jsx` | Form-field primitives (`Row`, `TextField`, `NumberField`, `ColorField`, `Toggle`, `SelectField`, `TagField`) + hex/rgb helpers. |
+| `fmg/FmgPanel.jsx`, `fmg/fmgDriver.js`, `fmg/fmgImport.js` | Fantasy Map Generator drawer, headless Azgaar runner, result→editor-seed converter. |
+| `flagImage.js`, `citiesImport.js` | Flag downscaling; seed-city import + search. |
+
+---
+
+## 3. Architecture & data flow
+
+Two stores, split by weight (`src/Editor/useMapDocument.js:6`):
+
+- **Document state** (React, in `useMapDocument`) — metadata, region `types`, point `features` (cities), `colorOverrides`, `flags`, `tags`. Cheap, serialisable, the source of truth for everything except geometry.
+- **Region geometry** (OpenLayers `VectorSource`, in `OlMap`) — ~3,662 filled/stroked polygons, far too heavy for React state. Materialised into the document only on **save/export** via `api.serializeRegions()`.
+
+`MapEditor` receives the imperative region API through `OlMap`'s `onReady={setApi}` callback (`src/Editor/MapEditor.jsx:453`). Panels never touch the map directly; they call `api.*` methods, which mutate OL features and call `layer.changed()` to restyle. Region mutations fire `onRegionsChanged` → `setSaveStatus("dirty")` → debounced autosave.
+
+```
+DocumentsMenu / BottomBar ─┐
+SelectionInspector ────────┤   props (colors, types, selection…)
+TypeManager / Features … ──┼──► MapEditor ──► OlMap  ──► OL VectorSource (geometry)
+                           │        │  ▲            (api.* imperative calls)
+                           └────────┘  └── onReady(api), onSelectionChange, onRegionsChanged
+```
+
+---
+
+## 4. Document model (`useMapDocument.js`)
+
+`createDocument()` (`:59`) shape:
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string \| null | Server document id; null until first save. |
+| `version` | number | Document schema version (1). |
+| `metadata.name` | string | Map name. |
+| `metadata.kind` | `"import-world"` \| `"blank"` | Drives seeding + tier detection. |
+| `metadata.author` | string | Shown as "Made by …" credit. |
+| `metadata.basemap` | string | Built-in basemap id (default `"ocean"`). |
+| `metadata.customBackground` | object \| null | Persisted uploaded background (image `dataUrl`+aspect, or vector `geojson`). |
+| `metadata.simulationRules`, `startingTimelineText`, `startDate`, `gameDate` | string | Carried into the game seed. |
+| `types` | Type[] | Region types (see §11). Seeded with `DEFAULT_TYPES` (Land, Coastal). |
+| `features` | Feature[] | Point features / cities (see §12). |
+| `ownerSchema` | number | `OWNER_SCHEMA` marker — says "owners are NAMEs, not codes". Critical: a doc without it re-migrates every open. |
+| `colorOverrides` | `{ [countryName]: [r,g,b] }` | The map-maker's own colour choices. |
+| `flags` | `{ [countryName]: dataURL }` | Author-set flags (downscaled PNG data URLs). |
+| `tags` | `{ [countryName]: string[] }` | Starting ideology/alignment tags. |
+
+**Colours are keyed by country NAME, not GADM code** — this is true of `colorOverrides`, `flags`, `tags`, and region `owner` alike. See §10.
+
+The hook exposes a derived `colors` = `{ ...fetchedPalette, ...colorOverrides }` (`:194`) so an edited colour paints immediately exactly as it will in-game; `basePalette` is the fetched palette alone (`/assets/colors.json`, `:110`) so the UI can offer a **Reset** when an override exists. `mergeColors(extra)` layers a scenario's own polity colours on top.
+
+Setters (all set `saveStatus="dirty"`):
+
+| Setter | Guard |
+|---|---|
+| `setColorOverride(country, rgb)` | `null` rgb deletes the key. |
+| `setFlag(country, dataUrl)` | `null` deletes. Value is an already-downscaled PNG data URL. |
+| `setTags(country, list)` | Uses `.length` (not truthiness) so an empty `[]` deletes rather than persisting `[]` for every touched country (`:160`). |
+| `setTypes`, `setFeatures` | Accept updater fn or value. |
+| `patchMetadata` / `setBasemap` / `setName` / `setAuthor` | Metadata patches. |
+
+`saveStatus` ∈ `saved | dirty | saving | error`; `counts` = `{ regions, features, types }`.
+
+---
+
+## 5. The OpenLayers surface (`OlMap.jsx`)
+
+Created once in a `[]`-dep effect and driven through refs so it survives React re-renders (`:232`). Props flow in through refs (`typesByIdRef`, `colorsRef`, `selectedIdsRef`, `activeToolRef`, `paintOwnerRef`, …) so the map stays valid without recreating.
+
+### Layers (z-index ladder)
+
+| Layer | Type | zIndex | Source / notes |
+|---|---|---|---|
+| Base basemap | `TileLayer` (XYZ ESRI / OSM) | 0 | Swapped by `basemap` prop; **not created** while a custom image/vector background is active (`:1019`). |
+| Custom background | vector/raster `VectorLayer`/`WebGLTileLayer`/`TileLayer`, or image `ImageLayer`(`ImageStatic`) | 5 | Uploaded map; image is stretched across the whole world extent (`WORLD_EXTENT_3857`). |
+| Regions | `VectorImageLayer` | 10 | `regionSource`, `imageRatio:2`, `wrapX:false`; style = `makeRegionStyle(...)`. |
+| Region labels | `VectorLayer` (declutter) | 20 | Same source; `minZoom:4`; label per named region unless `type.includedInLabels === false`. |
+| Cities / points | `VectorLayer` (declutter) | 30 | `pointSource`; zoom+prominence gated so ~70k cities never all render. |
+| Reference image | `ImageLayer` | 40 | Tracing aid (session only). |
+| Reference frame | `VectorLayer` | 41 | Dashed outline + corner handles while the Reference panel is open. |
+
+**Two performance-critical choices** (documented at `:232` and `:250`): `wrapX:false` on the source/layers (stops OL redrawing the world sideways *and* fixes ±180° editing), and `VectorImageLayer` for regions (rasterise-once/re-blit instead of re-rasterising thousands of paths per frame). Serialisation uses `writeFeaturesObject` (not `JSON.parse(writeFeatures(...))`) to avoid building an ~83MB string on every 2s autosave (`:785`).
+
+### Click handling (`map.on("singleclick")`, `:372`)
+
+Only these tools consume a click: `select`, `delete`, `paint`, `feature`, `dissolve`. `map.forEachFeatureAtPixel` hit-tests the region layer (tolerance 2). Ctrl/Cmd/Shift = additive selection. Double-click with Select selects the **whole country** (all regions sharing the owner) and returns `false` to suppress OL's DoubleClickZoom (`:480`).
+
+### The imperative region API (returned by `onReady`, `:601`)
+
+This is the surface every panel drives. Each mutating call pushes an undo/redo command onto an 80-entry stack (`pushCmd`, `:225`) and calls `notifyRegions()` (→ dirty).
+
+| Method | Purpose |
+|---|---|
+| `map`, `regionSource`, `regionLayer`, `labelLayer` | Raw OL handles. |
+| `fitToData()` | Fit view to all regions. |
+| `zoomToRegion(id)` / `zoomToSelection(ids)` | Fit to one/many. |
+| `setRegionAttrs(ids, patch)` | Patch `owner` / `typeId` / `name` / `claimants` on many regions at once, undoably. The workhorse behind the inspector. |
+| `deleteRegions(ids)` | Remove regions. |
+| `mergeRegions(ids)` | Union ≥2 regions into the first; others removed. Uses `unionGeoms` (`geometry.js`). |
+| `copyRegions(ids)` | Duplicate with a view-scaled offset; new ids, `" copy"` name, carries typeId/owner/gid0/claimants. |
+| `getRegionSummary(id)` | `{ id, name, owner, typeId, country, claimants }`. |
+| `listOwners()` | Sorted unique owner names — backs the Country field's suggestions so re-owning offers existing names (avoids near-miss forks). |
+| `queryRegions(text, limit=200)` | Search id/name/owner. |
+| `countByType()` | Region count per typeId (Type Manager usage). |
+| `setLayerVisibility(key, visible)` | `regions` \| `labels` \| `features`. |
+| `locateFeature(coord)` | Fly to a lon/lat. |
+| `serializeRegions()` | Region geometry → GeoJSON FC (EPSG:4326, 5 decimals). Used on save/export. |
+| `loadRegions(fc)` | Replace the source from a FeatureCollection (ids pulled from `properties.id`). |
+| `reseedWorld()` | Load the stock world seed fresh. |
+| `reseedWorldWithOwners(overrides)` | Load stock world, then stamp `{regionId: ownerName}` overrides — how a tier-1 scenario opens. |
+| `undo()` / `redo()` | Drive the command stack. |
+| `restyle()` | Force `layer.changed()`. |
+
+Keyboard: **Ctrl/⌘+Z** undo, **Ctrl/⌘+Shift+Z / Ctrl+Y** redo, **Delete/Backspace** removes the selection — all suppressed while typing in an input (`:545`).
+
+---
+
+## 6. Tools (`Toolbar.jsx` + `OlMap.jsx` interaction effect)
+
+Single-choice; the active tool mounts/unmounts OL interactions in the `[activeTool]` effect (`src/Editor/OlMap.jsx:854`).
+
+| Tool | id | Interaction / behaviour |
+|---|---|---|
+| Select | `select` | Click = select region; Ctrl/Shift = additive; double-click = whole country. |
+| Lasso select | `lasso` | Freehand `Draw` polygon; on `drawend` selects every region whose interior point falls inside (`selectWithinPolygon`, `:868`). |
+| Pan | `pan` | No interaction added; default map drag. |
+| Draw region | `draw` | `Draw` (Polygon, `trace:true`, `traceSource:source`) + `Snap`. Clicking a border traces along it. **On `drawend` the new polygon is carved OUT of every region it overlaps** (`subtractFrom`, R-tree extent query for candidates) so no ground is owned twice; carved neighbours get `edited:true` (`:889`). Inside → hole; across an edge → bite; fully over → deletes the underlying region. |
+| Edit vertices | `modify` | `Modify` + `Snap`. On `modifyend` sets `edited:true` on dragged features (`:963`). |
+| Move | `move` | `Translate` on the region layer. |
+| Delete | `delete` | Click removes a region (a city hit under the cursor wins). |
+| Delete border (dissolve) | `dissolve` | Click a region; probes neighbouring pixels for the region across the nearest border and unions the two into one (`:428`). |
+| Paint owner | `paint` | Click stamps the current **Paint owner** value (a country NAME, trimmed, never case-folded) onto the clicked region (`:394`). A floating owner input + swatch appears at the top (`MapEditor.jsx:553`). |
+| City tool | `feature` | Click empty map → `onFeatureCreate` (drops a city + opens `CityPopup`); click a city → `onFeatureEdit`. Carries the underlying region's owner/regionId (`:410`). |
+| Undo / Redo / Fit | — | Toolbar buttons wired to `api.undo/redo/fitToData`. |
+
+The **`edited` flag** is the linchpin of tier-2 correctness: a reshaped GADM region's true geometry now lives in the exported GeoJSON while the stock tiles still hold its original shape. The exporter carries `edited:true` into the game so `Nations.jsx` renders it from the GeoJSON and excludes it from the stock-tile fill (otherwise the original shape repaints on top, darker — the "edited-region shade" bug).
+
+---
+
+## 7. Editing a region's attributes (`SelectionInspector.jsx`)
+
+Shown whenever ≥1 region is selected. Writes go straight through `api.setRegionAttrs(selection, patch)` (`:57`), which live-restyles. Fields:
+
+| Field | Applies | Notes |
+|---|---|---|
+| **Name** (single only) | `{ name }` | The region label. |
+| **Type** | `{ typeId }` | `— mixed —` shown when a multi-selection disagrees. |
+| **Country** (owner) | `{ owner: v.trim() \| null }` | Free-text country NAME, backed by a `<datalist>` of existing owners (`listOwners()`). **Typing a name that doesn't exist creates that country** — there is no separate "add country" step. Field keeps raw text but applies trimmed (`:118`). No case-folding. |
+| **Disputed by** (claimants) | `{ claimants }` | `TagField` of country names. Any claimant makes the region render **striped** (owner colour + each claimant's), here and in-game. |
+| **Colour** | `setColorOverride(owner, rgb)` | Only shown with an owner. **Reset** appears when an override exists (`colorOverrides[owner]`). |
+| **Flag** | opens `FlagPicker` via `onOpenFlagPicker(owner)` | Renders current flag thumbnail. |
+| **Tags** | `setTags(owner, next)` | `TagField` with `TAG_SUGGESTIONS`; free vocabulary. |
+
+Footer buttons: **Clear country** (`owner:null`), **Merge** (≥2), **Copy**, **Zoom**, **Delete**.
+
+Note the owner/colour/flag/tag edits are keyed to the *country name*, so editing one region's colour recolours the whole country everywhere.
+
+---
+
+## 8. Region types (`TypeManager.jsx`)
+
+A "type" carries render + gameplay settings and is referenced by each region's `typeId`. Seeded with `DEFAULT_TYPES` = Land + Coastal (`useMapDocument.js:18`). Editing a type live-restyles (OlMap restyles on the `types` prop). Type schema:
+
+| Field | Used by | Meaning |
+|---|---|---|
+| `id`, `name` | — | Identity. |
+| `opacity` | `olStyle.js` | Fill alpha for **owned** regions. |
+| `unownedOpacity` | `olStyle.js` | Fill alpha for unowned. |
+| `zIndex` | `olStyle.js` | Draw order. |
+| `strokeWidth`, `strokeColor`, `strokeOpacity` | `olStyle.js` | Border. |
+| `overrideColor` | `olStyle.js` | Force a fixed fill instead of the owner colour (`null` = off). |
+| `pathfindingSpeed`, `interactable`, `passable`, `showToDefaultPrompt` | game | Gameplay flags. |
+| `includedInLabels` | `OlMap` label layer | `false` suppresses the region label. |
+| `zoomSettings: [{minZoom,maxZoom}]` | `pickZoomBand` (`olStyle.js:88`) | Hides the type outside the zoom band. |
+
+At least one type must always exist (delete is disabled at length 1).
+
+---
+
+## 9. Cities / point features
+
+Point features (mostly cities) live in `doc.features`. Feature schema (`citiesImport.js:31`, `MapEditor.jsx` create paths):
+
+| Field | Meaning |
+|---|---|
+| `id` | `newId("feat")`. |
+| `name` | City name. |
+| `type` | `"Coordinate"`. |
+| `symbol` | `square` \| `circle` \| `triangle` \| `star`. |
+| `coord` | `[lon, lat]`. |
+| `country`, `owner`, `regionId` | Context of where it was dropped. |
+| `population` | Drives the prominence tier. |
+| `tags` | e.g. `["city"]`, `["city","capital"]`. |
+
+**Editing paths:**
+- **City tool + `CityPopup`** (`CityPopup.jsx`) — inline editor at the click. Name, **Size** select (Town 20k / City 250k / Major 1.5M — maps to population) and a **★ Capital** checkbox (toggles the `capital` tag). Enter/Esc closes.
+- **Feature Manager** (`FeatureManager.jsx`) — searchable list; per-feature name/symbol/tags, locate, delete, **Delete All**, and **Import all cities** / **Major only** which pull from `public/assets/cities-seed.json` (~70k, deduped by `name|coord`).
+- **Search bar** (`SearchBar.jsx`) — unified search over this map's cities, its regions, and the ~70k world place index; world results get a **＋ Add** button to drop them as a city.
+
+Prominence tier (`exportPreset.js:100`, `cityTier`): `capital`→4, ≥1M→3, ≥100k→2, else 1. This gates when a city label appears in-game (`Cities.jsx`).
+
+---
+
+## 10. Owner-name handling (names, not codes)
+
+This is the single most important invariant and the source of most historical bugs.
+
+**A region's `owner` is the owning country's DISPLAY NAME** ("Russia", "Roman Empire"), not a GADM code. So are the keys of `colorOverrides`, `flags`, and `tags`. The region **id** stays a GADM identifier (`DEU.2_1`) or an editor id (`reg_…`) and is the thing tier detection tests — it does **not** move with owner renames (`isGid1`, `exportPreset.js:21`).
+
+Where names come from and stay clean:
+
+1. **Seed load** (`regionImport.js:68`) — each stock region's owner is resolved from its `gid0` through `COUNTRY_NAMES` (`gid0 → name`), **not** the seed's own `country` string (which disagrees: "México" vs "Mexico", truncated names). The seed's `country` is unset after resolution so a second copy can't drift.
+2. **Paint / inspector** — owner text is trimmed but **never case-folded** (`OlMap.jsx:401`, `SelectionInspector.jsx:118`); a trailing space would fork a duplicate polity.
+3. **Legacy documents** — `migrateDocumentOwners` (§23) rekeys code→name on open.
+
+**Export polity logic** (`exportPreset.js:184`): `STOCK_COUNTRY_NAMES = new Set(Object.values(COUNTRY_NAMES))`. For each owner:
+- If the stock world already knows the name (`STOCK_COUNTRY_NAMES.has(owner)`) → no polity entry needed; the game names/colours/flags it itself.
+- Otherwise → emit a `polityOverrides[owner]` entry so the game and the model learn the country exists at all.
+- **Verbatim flag**: if the invented name *collides with a real GADM code* (`COUNTRY_NAMES[owner]` truthy — e.g. a map-maker literally names a country `"USA"`), the entry gets `verbatim: true` so the server's `resolveOwnerName` (`server/ownerMigration.js`) keeps it literal instead of canonicalising `"USA" → "United States"`. A plain invented name ("Freedonia") needs no flag — it already resolves to itself.
+
+Colours priority in the seed (`:181`): `colorOverrides[owner]` (a human's chosen colour, wins) → `palette[owner]` → `codeToColor(owner)` (deterministic hash, mirrors the game's fallback).
+
+---
+
+## 11. Region colours & disputed striping (`olStyle.js`)
+
+One style function for all regions, memoised per `typeId|owner|selected|zoomBand|claimants` (`makeRegionStyle`, `:102`). Fill = `type.overrideColor` → owner colour (`palette[owner] || codeToColor(owner)`) → neutral gray. Alpha switches on owned vs unowned; a selected region gets +0.22 alpha, an accent stroke, and zIndex 999. The palette-swap guard clears the cache when the palette identity changes (so a scenario's `colors.json` arriving late doesn't leave stale fills).
+
+**Disputed regions** with claimants get a diagonally striped `CanvasPattern` (`makeStripePattern`, `:48`): administrator colour first, then each deduped claimant, `(x+y) mod period` bands. Requires ≥2 distinct colours.
+
+---
+
+## 12. Flags (`FlagPicker.jsx`)
+
+A full-screen overlay (community-hub purple, not editor blue) mounted at `MapEditor`'s root — **not** inside the inspector, because the panel's `backdrop-filter` makes a containing block that would trap a `position:fixed` overlay (`FlagPicker.jsx:31`). Opened via `flagPickerFor` state, wired to `d.setFlag(flagPickerFor, value)`.
+
+Tabs:
+- **In the game** — *Already on this map* (flags already placed → reuse), *My flags* (saved to the library, reusable across maps), and *Built-in flags* (`listBuiltInFlags()`).
+- **Community** — fetched via the hub proxy; a single flag installs as a data URL, a scenario **flag pack** (`fromScenario`) installs wholesale into My flags (dedup by content hash).
+
+Upload (`fileToFlagDataUrl`, `FLAG_ACCEPT`) saves to the library first, then applies. **Remove** re-selects the standard code-derived flag (`pick(null)`). Values stored in `doc.flags` are downscaled PNG data URLs.
+
+---
+
+## 13. Basemaps & custom backgrounds
+
+### Built-in basemaps (`basemaps.js`)
+Ten token-free ESRI/ArcGIS presets (`EDITOR_BASEMAPS`): `ocean` (default), `imagery`, `streets`, `topo`, `terrain`, `shaded`, `natgeo`, `physical`, `light-gray`, `dark-gray`. XYZ template via `esriXyzUrl(service)`; picker previews use the z0 whole-world tile (`esriPreviewUrl`).
+
+### Custom backgrounds (`customBackground.js`, `BasemapPicker.jsx`)
+Uploaded via the **Basemap: …** button (bottom bar) → `BasemapPicker` overlay ("Built-in maps" / "Your basemaps" / Community). `loadBackgroundFile` dispatches by extension (`BACKGROUND_ACCEPT`):
+
+| Format | Result kind | Persisted? |
+|---|---|---|
+| `.geojson`/`.json` | `vector` (outline, or biome fill if features carry `fill`) | yes (GeoJSON) |
+| `.kml` / `.kmz` | `vector` | yes |
+| `.shp` / `.zip` | `vector` (via `shpjs`, dynamic import) | yes |
+| `.tif`/`.tiff` (GeoTIFF) | `raster` (WebGL) | **no** (session reference only) |
+| `.pmtiles` | `raster` | **no** |
+| `.png`/`.jpg`/`.svg` | `image` (data URL, stretched across the world) | yes |
+
+Heavy parsers (`shpjs`, `jszip`) are dynamically imported so they only load on demand. Persistable backgrounds (`vector`/`image`) are saved into `doc.metadata.customBackground` and rebuilt on open via `rebuildPersistedBackground(saved, {persisted})` — the `persisted` flag stops a restored background from re-dirtying the doc on load. In the game, a custom background **replaces Earth** and forces `world.customRegions` on (so the stock political overlay is hidden).
+
+---
+
+## 14. Reference image / tracing aid (`ReferencePanel.jsx` + OlMap ref-image effects)
+
+A semi-transparent image above the region fills (z40) that a map-maker aligns a source map to and traces over. Upload → placed at 60% of the view width; **Opacity**, **Visible**, **Center on view**, **Remove**. While the Reference panel is open, a dashed frame with corner handles appears (z41) — drag inside to move, drag a corner to resize (free aspect). **Session-only**: it lives entirely in component state (`refImage`) and a ref (`refImageExtentRef`), never saved to the document and never exported (`MapEditor.jsx:63`, `OlMap.jsx:1089`).
+
+---
+
+## 15. Fantasy Map Generator (`fmg/`)
+
+A right-edge **🗺 GENERATE** drawer (`FmgPanel.jsx`) with inputs: seed, landmass template (`continents`/`archipelago`/`pangea`/…), detail (points), countries, cultures, cities, and "regions from provinces". **Generate** calls `generateFromFmg` (`MapEditor.jsx:123`), which runs Azgaar's Fantasy Map Generator headlessly (`fmgDriver.js`, vendored FMG at `/fmg`) and converts the result via `fmgToEditorSeed`. The import: `api.loadRegions(seed.regions)`, cities → `doc.features`, `mergeColors(seed.colors)`, and the biome basemap saved as a vector custom background (also added to "Your basemaps"). Marks the doc dirty and fits the view.
+
+---
+
+## 16. Geometry operations (`geometry.js`)
+
+Boolean ops run directly on OL geometries in EPSG:3857 via `polygon-clipping` (no reprojection round-trip):
+
+| Fn | Use |
+|---|---|
+| `unionGeoms(geoms)` | Merge / dissolve. |
+| `subtractFrom(target, cutter)` | Draw-carve (returns survivor, `null` if swallowed whole, or unchanged if disjoint). Drawing inside leaves a hole (interior ring). |
+| `overlaps(a, b)` | Cheap intersection guard so draw only rewrites genuinely-overlapping neighbours. |
+| `splitByLine(olGeom, line)` | Buffer a drawn line into a thin cutter, subtract, group fragments onto the two sides, union each → `[{geom,area},…]` largest first. |
+| `translatedClone(g, dx, dy)` | Copy/paste offset. |
+
+---
+
+## 17. Persistence (`documentIO.js`, save flow)
+
+Server REST at `/api/mapeditor/documents` (web build routes through `runtime/web/editorStore.js`): `GET` list, `GET /:id`, `POST` create, `PUT /:id` update, `DELETE /:id`. `downloadJson` writes a local `.json`.
+
+`buildPayload()` (`MapEditor.jsx:180`) is a **strict whitelist** — `name, metadata, types, features, colorOverrides, flags, tags, ownerSchema, regions`. **Anything not named here is silently dropped on save**; a new document field appears to work until the first reload. `regions` = `api.serializeRegions()`.
+
+Save robustness:
+- **Debounced autosave** every 2s while `dirty`, keyed on `d.doc` (a fresh object per change) rather than a hand-listed field set — the old field list went stale and silently lost colour/flag/tag edits (`:289`).
+- **`beforeunload`** guard while `dirty`/`saving` (`:304`).
+- **`visibilitychange`/`pagehide` flush** via refs (avoids stale-closure loss on mobile suspend) (`:320`).
+- **Close** tries to save first and only prompts if the save fails (`:508`).
+
+---
+
+## 18. Exporting to a game seed (`exportPreset.js` → `buildGameSeed`)
+
+`buildGameSeed(doc, regionsFC, palette, {playerCountry})` (`:156`) is called for **Export for game** (download) and **Apply & Play**. Steps:
+
+1. Walk regions → build `regionOwnershipOverrides = {regionId: ownerName}`, collect owners, count custom-id regions.
+2. `detectCustomGeometry(regionsFC, kind)` (`:87`) → **tier 2** if `kind==="blank"`, or any region has a non-GADM id (`reg_…`), `mergedFrom`, or `edited`. Otherwise **tier 1**.
+3. `normalizeRegionsForGame` (`:43`) → rebuild an FC whose **properties** (MapLibre reads `["get","id"]`) carry `id, owner, gid0, name, typeId`, plus `claimants` and `edited` when present. Feature id is kept in properties only (a non-integer top-level id spams warnings).
+4. Build `colors`, `polityOverrides` (§10), cities (`buildCitiesForGame`), and background descriptor + heavy payload (`buildBackgroundForGame`).
+
+### Seed shape (return value)
+
+| Key | Contents |
+|---|---|
+| `name`, `kind`, `author`, `credit` | Identity. |
+| `hasCustomGeometry` | Tier flag. |
+| `stats` | `{ ownedRegions, owners, customGeometry }`. |
+| `world.regionOwnershipOverrides` | `{regionId: ownerName}`. |
+| `world.polityOverrides` | `{name:{name,aliases:[],color:'#hex',note:'',verbatim?}}`. |
+| `world.customRegions` | `hasCustomGeometry \|\| Boolean(background)`. |
+| `world.background` / `world.basemap` | Light background descriptor / chosen ESRI basemap id. |
+| `world.customCities` | `true` if authored cities exist or geometry is custom. |
+| `world.author`, `mapCredit`, `simulationRules`, `startingTimelineText` | Metadata. |
+| `colors` | `{ ...palette, ...colors, ...overrides }` — full palette so tier-1 keeps every stock country's colour. |
+| `game` | `{ country, startDate, gameDate }`. |
+| `flags` / `tags` | The doc's, or **`null`** when empty (null means "don't touch the scenario's file"). |
+| `regions` | Normalized game-ready FC (uploaded only when tier 2). |
+| `cities` | Authored `cities.geojson`. |
+| `backgroundData` | Heavy `{dataUrl}` / `{geojson}`, or `null`. |
+
+**Tier 1 vs tier 2 recap:** tier 1 = re-ownership only → the game renders shapes from `regions.pmtiles` and needs just `world.json` (`regionOwnershipOverrides`+`polityOverrides`) + `colors.json` (like the bundled WWII/Medieval presets). Tier 2 = new/split/merged/reshaped geometry → the exported `regions.geojson` carries the shapes and `world.customRegions` tells the game to render from the GeoJSON layer (`src/Game/Map/Nations.jsx`).
+
+---
+
+## 19. How edits reach the game — Apply & Play (`libraryBar.jsx` `applyMapToScenario`)
+
+In embedded mode, **▶ Apply & Play** calls `onApplyToScenario(seed)` (`MapEditor.jsx:198`), which runs `applyMapToScenario(scenario, seed)` (`libraryBar.jsx:1754`). It writes `world`/`game` via `saveScenario` (merging over the current world; sets `ownerCodes` for the start-country picker, `customRegions:true`) then uploads each seed piece as a scenario asset:
+
+| Seed field | Scenario asset | Empty behaviour |
+|---|---|---|
+| `colors` | `colors` | always written |
+| `flags` | `flags` | `clearScenarioAsset` when null |
+| `tags` | `tags` | `clearScenarioAsset` when null |
+| `regions` | `regionsGeojson` | always written |
+| `cities` | `citiesGeojson` | always written |
+| `backgroundData` | `backgroundData` | `clearScenarioAsset` when null |
+
+The `null`-means-clear contract is why hydration (§20) must reload the scenario's existing flags/tags/background — otherwise a round-trip that "loaded none" would clear the author's work. Finally it creates + activates a fresh game so the running map reflects the edit.
+
+---
+
+## 20. Opening a scenario's current map (hydration)
+
+When the editor opens from a scenario, `onOpenMapEditor` (`libraryBar.jsx:2511`) fetches the scenario's `regionsGeojson`, `citiesGeojson`, `colors`, `flags`, `tags`, and (if any) `backgroundData`, assembling `mapEditorSeed` = `{ name, author, ownershipOverrides, regions, cities, colors, flags, tags, background, basemap }`. `MapEditor`'s hydrate effect (`:339`, runs once) builds the base document, restores flags/tags/background/basemap, maps cities → features, then:
+- `api.loadRegions(initialMap.regions)` if the scenario has custom geometry, **else** `api.reseedWorldWithOwners(initialMap.ownershipOverrides)` (stock world + overrides = its tier-1 map).
+
+`scenarioMode` forces `seedKind="deferred"` so `OlMap` doesn't auto-seed the default world under the scenario's map.
+
+---
+
+## 21. Document migration (`documentMigration.js`)
+
+`migrateDocumentOwners(doc)` runs on every **open** (`MapEditor.openDoc`, `:245`). A doc is legacy while `ownerSchema < OWNER_SCHEMA`. Migration rekeys `colorOverrides`/`flags`/`tags` and every region `owner` from GADM code → name via `COUNTRY_NAMES` (`rekeyOwnerMap`), strips region `country`, and stamps `ownerSchema = OWNER_SCHEMA`. It lives in the editor (not the store) because a document is the one path where legacy owners can enter a scenario already wearing a "migrated" badge (an applied doc inherits the target's `ownerSchema`, so the store's migration would never run). No-op once migrated — safe to call every open.
+
+---
+
+## 22. Standalone editor repo & mirroring note
+
+The editor was split into a standalone repo (`Open-Historia/open-historia-map-editor`), but the game still **embeds its own copy** under `src/Editor/`. Edits to editor source generally need mirroring to both. Copying whole files wholesale between the two drifts app-only wiring (e.g. the game-embed props); prefer targeted edits. The FMG generator is vendored at `/fmg` (Azgaar v1.109).
+
+---
+
+## 23. Gotchas & invariants (quick reference)
+
+- **Owner is a NAME, everywhere.** Never re-introduce a code path or case-fold owner text (`OlMap.jsx:401`, `SelectionInspector.jsx:118`).
+- **`buildPayload` is a whitelist** — a new doc field that isn't listed silently fails to persist (`MapEditor.jsx:180`).
+- **`edited`/`mergedFrom`/non-GADM id ⇒ tier 2.** These are the only signals that ship geometry (`exportPreset.js:87`).
+- **`flags`/`tags`/`background` null = "clear the scenario asset."** Always re-hydrate them on open so a round-trip is a no-op (`MapEditor.jsx:352`, `libraryBar.jsx:2525`).
+- **`wrapX:false` + `VectorImageLayer`** are correctness+performance load-bearing; don't revert (`OlMap.jsx:232`,`:250`).
+- **Reference image is session-only** — never let it into saves or exports (`MapEditor.jsx:63`).
+- **Render-path changes must be verified by booting the app** — build+grep proves nothing (see the runtime-verification memory).
+- Region geometry is verified in-app; a headless WebGL context can't pixel-check the game map.
+
+Related: [World state](world-state.md) (`world.json` fields the seed writes — `regionOwnershipOverrides`, `polityOverrides`, `customRegions`, `countryTags`).

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -1,0 +1,336 @@
+# Android App (Embedded Server)
+
+The Android app is a [Capacitor](https://capacitorjs.com/) WebView that **runs the real Open Historia Node server in-process on the phone** via [`nodejs-mobile-cordova`](https://github.com/nodejs-mobile/nodejs-mobile-cordova) — no Termux, no separate machine, nothing to configure. A tiny boot shell (`mobile/www/index.html`) starts the embedded Node process, waits for it to answer on `127.0.0.1:3000`, then navigates the WebView into it same-origin so the game runs exactly as it does on desktop. First launch downloads ~200 MB of map binaries from a GitHub Release; the app also self-updates by comparing its stamped build number against the rolling release notes.
+
+It can still be pointed at a remote/LAN/Termux server on purpose — the embedded server is just the zero-setup default.
+
+---
+
+## Architecture at a glance
+
+```
+┌─────────────────────────────  APK  ──────────────────────────────┐
+│                                                                    │
+│  WebView                          nodejs-mobile (native libnode)   │
+│  mobile/www/index.html            mobile/nodejs-project/main.js    │
+│    boot screen / self-update  ──▶   1 pick writable OH_DATA_DIR    │
+│    startNode() → window.nodejs      2 seed from ./seed (first run) │
+│    waitForServer() polls   ◀──┐     3 fetchMapAssets (background)  │
+│    → location.replace(URL)    │     4 import ./server/server.js    │
+│                               │              │                     │
+│                        127.0.0.1:3000 ◀──────┘  (loopback bind)    │
+└────────────────────────────────────────────────────────────────────┘
+        │ first run                                    ▲ self-update check
+        ▼                                              │
+  GitHub Release "map-data"                     GitHub Release "android"
+  (~200 MB pmtiles/geojson)                     (pax-historia.apk + Build:N notes)
+```
+
+The WebView and the server share the **same origin** (`http://127.0.0.1:3000`). That loopback bind + same-origin is the entire security model — no cross-origin writes are possible, so the server keeps its normal (unauthenticated, single-user) behavior. See [World state](world-state.md) for what the server actually serves once the WebView is inside it.
+
+### Committed vs. assembled
+
+Only three files under `mobile/nodejs-project/` are source-controlled; everything else is **build output** produced by `scripts/build-mobile-server.mjs` and git-ignored (`mobile/nodejs-project/.gitignore`).
+
+| Path | Committed? | Role |
+|---|---|---|
+| `mobile/www/index.html` | ✅ source | Boot shell: embedded-server boot, manual-connect fallback, self-update UI |
+| `mobile/nodejs-project/main.js` | ✅ source | nodejs-mobile entry point (the file `nodejs.start("main.js", …)` runs) |
+| `mobile/nodejs-project/fetchMapAssets.mjs` | ✅ source | First-run map-binary download into the writable data dir |
+| `mobile/nodejs-project/.gitignore` | ✅ source | Marks the rest as build output |
+| `mobile/nodejs-project/server/` | assembled | Copied from repo `server/` (the real server) |
+| `mobile/nodejs-project/dist/` | assembled | Built game bundle (`vite build`), heavy tiles stripped |
+| `mobile/nodejs-project/public/lang/` | assembled | Server's read-only language fallback |
+| `mobile/nodejs-project/seed/` | assembled | Default scenarios + manifests, minus heavy map files |
+| `mobile/nodejs-project/node_modules/` | assembled | `express` only (~3.4 MB) — the server's sole npm runtime dep |
+| `mobile/nodejs-project/package.json` | assembled | `express`-only manifest, mirrors the root pin |
+| `mobile/nodejs-project/map-assets.json` | assembled | Copy of `scripts/map-assets.json` for the runtime fetch |
+| `mobile/nodejs-project/runtime-data/` | runtime | Default `OH_DATA_DIR` when the launcher doesn't override it |
+| `mobile/capacitor.config.json` | ✅ source | Capacitor app id / scheme config |
+| `mobile/package.json` | ✅ source | Capacitor CLI + `@capacitor/android` (see caveat: plugin not yet added) |
+| `mobile/android/` | ✅ source | Generated native Gradle project |
+| `mobile/assets/logo.png` | ✅ source | Icon/splash source for `@capacitor/assets` |
+
+---
+
+## The boot shell — `mobile/www/index.html`
+
+This is the Capacitor `webDir` entry: a self-contained HTML/CSS/JS boot screen (styled inline, dark `#0b1020`). It renders one of three "cards" and drives the whole launch flow before handing control to the on-device server.
+
+### The three cards (UI states)
+
+| Card id | Shown when | Contents |
+|---|---|---|
+| `booting` | Default launch; embedded server starting or a saved remote reconnecting | `Starting your server…` status, "First launch downloads the world map (~200 MB)" sub-note, hidden `useRemote` button |
+| `setup` | Embedded server unavailable, or user chooses "connect to a different server" | URL input (default `http://localhost:3000`), `Connect & Play`, `Use this phone's built-in server`, error line |
+| `update` | A newer build is published (see self-update) | `Download update` / `Continue without updating` |
+
+`show(el)` (`mobile/www/index.html`) toggles which card is `display:flex`.
+
+### Controls
+
+| Control | id | Handler | Effect |
+|---|---|---|---|
+| Connect & Play | `connect` | `connect(input.value)` | Probe the typed URL, save it, `location.replace` into it |
+| Use this phone's built-in server | `useEmbedded` | `startEmbeddedServer(true)` | Force the embedded boot path |
+| Connect to a different server instead | `useRemote` | `showSetup` | Abandon embedded boot, show manual connect |
+| Download update | `downloadUpdate` | `location.href = update.url` | Download `pax-historia.apk` from the release |
+| Continue without updating | `skipUpdate` | `startNormalFlow()` | Ignore the update, proceed to normal launch |
+| (server URL field) | `server` | Enter key → `connect` | Manual server address |
+
+### Key variables
+
+| Name | Value / source | Purpose |
+|---|---|---|
+| `KEY` | `"pax-server-url"` | localStorage key for the last chosen server URL |
+| `EMBEDDED_URL` | `"http://127.0.0.1:3000"` | Where the embedded server always listens — **must stay in sync with `main.js`'s `PORT` default** |
+| `APP_BUILD` | `"__APP_BUILD__"` (placeholder) | Stamped to `github.run_number` at CI build time; `"dev"` when unstamped |
+| `RELEASE_API` | `.../repos/Open-Historia/open-historia/releases/tags/android` | The release the self-update check reads |
+| `nodeStarted` | boolean | Guards against starting the Node process twice |
+| `autoTimer` | timeout handle | Delays auto-reconnect to a saved remote server |
+
+### Boot / launch flow
+
+1. **`checkForUpdate()`** runs first (see [Self-update](#self-update)). If an update is found it shows the `update` card and stops; otherwise it calls `startNormalFlow()`.
+2. **`startNormalFlow()`** (`mobile/www/index.html`):
+   - If a saved URL exists **and it is not** `EMBEDDED_URL` (i.e. the user deliberately picked a remote/LAN server before), it shows `booting`, "Connecting to <saved>…", and auto-connects after 1.2 s (`autoTimer`).
+   - Otherwise it calls `startEmbeddedServer(false)` — the default zero-setup path.
+3. **`startEmbeddedServer(forced)`**:
+   - `startNode()` grabs `window.nodejs` (exposed by nodejs-mobile-cordova) and calls `nodejs.start("main.js", cb, { redirectOutputToLogcat: true })`. `redirectOutputToLogcat` surfaces the embedded server's `console.log` in `adb logcat`. Guarded by `nodeStarted`.
+   - If `window.nodejs` is missing (an old build without the plugin), it falls back to the `setup` card.
+   - `waitForServer()` polls `probe(EMBEDDED_URL, 3000)` every 1.5 s until it answers, up to a **90 s deadline** (cold first start has to extract the project, seed, and start listening).
+   - On success: save `EMBEDDED_URL` to localStorage and `location.replace(EMBEDDED_URL)` — the WebView is now the game.
+   - On timeout: "The built-in server didn't respond." and reveal the `useRemote` escape hatch.
+4. **`connect(raw)`** (manual path): `normalize()` the URL (adds `http://`, strips trailing slashes), `probe()` it, save + `location.replace()` on success, else show `setup` with an error.
+
+### `probe()` — why native HTTP matters
+
+`probe(url, timeout)` hits `<url>/api/library`. It **prefers `window.Capacitor.Plugins.CapacitorHttp`** over `fetch`. Reason (documented inline at `mobile/www/index.html`): the WebView's `fetch` is subject to CORS and Chrome's **Private Network Access** rules for loopback targets, which would block probing `127.0.0.1`; native requests are not. Only the probe uses native HTTP — the subsequent `location.replace` navigation is unaffected. A native response counts as reachable when `100 ≤ status < 500`.
+
+---
+
+## The embedded entry — `mobile/nodejs-project/main.js`
+
+nodejs-mobile runs this file inside the app. It's plain Node + `fs`, so `node mobile/nodejs-project/main.js` on a desktop behaves identically (used for testing). It performs four steps, in order:
+
+| Step | What it does | Notes |
+|---|---|---|
+| 1. Writable data dir | `DATA_DIR = OH_DATA_DIR ?? <here>/runtime-data`, then sets `process.env.OH_DATA_DIR` **and** `process.env.PORT` (default `"3000"`) before importing the server | The bundled `server/data` is read-only inside the APK; the native launcher may override with e.g. the app's Documents dir. `mkdirSync(..., {recursive:true})`. |
+| 2. First-run seed | If `<DATA_DIR>/scenario-manifest.json` does **not** exist and `./seed` does, `fs.cpSync(seedDir, DATA_DIR, {recursive:true})` | "Already seeded" is detected purely by the presence of the scenario manifest. Failure is warned, not fatal (empty library). |
+| 3. Map assets (best-effort) | `import("./fetchMapAssets.mjs")` then `fetchMapAssets(DATA_DIR)` in the **background** (`.catch` only) | Never blocks server start; the map fills in as tiles land. A missing fetcher is warned and ignored. |
+| 4. Start the server | `await import("./server/server.js")` | The server reads `OH_DATA_DIR` + `PORT` from the env set in step 1. |
+
+Env contract set by `main.js`:
+
+| Env var | Set to | Read by |
+|---|---|---|
+| `OH_DATA_DIR` | resolved `DATA_DIR` | `server/dataDir.js` and every store |
+| `PORT` | existing value or `"3000"` | `server/server.js` |
+
+### The writable data dir — `server/dataDir.js`
+
+`server/dataDir.js` exports the single `DATA_DIR` that every server store (games, scenarios, basemaps, flags, map-editor docs, ui-settings, lang packs, hub cache) reads:
+
+```
+DATA_DIR = OH_DATA_DIR ? path.resolve(OH_DATA_DIR) : <server>/data
+```
+
+When `OH_DATA_DIR` is unset (desktop / Termux) the app is byte-identical to those builds; when the embedded server sets it, all writes go to the sandbox path instead of the read-only APK bundle.
+
+---
+
+## First-run map download — `mobile/nodejs-project/fetchMapAssets.mjs`
+
+The ~200 MB of pmtiles/geojson can't ship inside an APK, so they're downloaded on first run from the **`map-data` GitHub Release** (the same release + checksums the desktop `scripts/fetch-map-assets.mjs` uses). `fetchMapAssets(dataDir)` is idempotent and best-effort — it never throws in a way that stops the server.
+
+### Manifest — `scripts/map-assets.json` (copied to the project as `map-assets.json`)
+
+| Field | Value | Meaning |
+|---|---|---|
+| `owner` / `repo` | `Open-Historia` / `open-historia` | Release host |
+| `release` | `map-data` | Release tag the assets hang off |
+| `assets[]` | `{ path, asset, bytes, sha256 }` | Each map binary: repo-relative `path`, release `asset` filename, expected size + checksum |
+
+The fetcher builds `base = https://github.com/<owner>/<repo>/releases/download/<release>` and reads the manifest from `<here>/map-assets.json`, falling back to `../../scripts/map-assets.json` on desktop (`fetchMapAssets.mjs`).
+
+### Where each asset lands — `targetFor(dataDir, assetPath)`
+
+Every asset is routed into the **writable** `OH_DATA_DIR`, never the read-only bundle:
+
+| Manifest `path` prefix | Written to | Example |
+|---|---|---|
+| `server/data/…` | `<DATA_DIR>/…` | `server/data/scenarios/default/regions.geojson` → `<DATA_DIR>/scenarios/default/regions.geojson` |
+| `public/assets/…` | `<DATA_DIR>/assets/…` | `public/assets/regions.pmtiles` → `<DATA_DIR>/assets/regions.pmtiles` |
+| anything else | `<DATA_DIR>/<path>` verbatim | keeps it out of the read-only bundle |
+
+### Download algorithm (per asset)
+
+1. `stat(dst)` — if the file exists with the exact `bytes` **and** matching `sha256`, count it `present` and skip.
+2. Otherwise `fetch(<base>/<asset.asset>, {redirect:"follow"})`; non-2xx → error.
+3. Verify `sha256(buf) === asset.sha256` (checksum mismatch aborts that file).
+4. Write to `<dst>.download`, then atomically `rename` into place (`downloaded++`).
+5. Any failure logs a warning, unlinks the temp file, and continues (`failed++`) — one bad asset never stops the rest or the server.
+
+Summary line: `[embedded] map assets: N downloaded, M current, K failed`. Requires a `fetch` implementation (guards against too-old Node).
+
+### How the tiles reach the WebView — `resolveRuntimeBinaryAsset`
+
+The server's PMTiles route `GET/HEAD /api/runtime/pmtiles/:assetKey` (`server/server.js`) streams a binary resolved by `resolveRuntimeBinaryAsset(assetKey)` in `server/libraryStore.js`. Resolution order:
+
+1. A scenario-specific override upload, if present.
+2. **`<DATA_DIR>/assets/<file>`** — the copy `fetchMapAssets` downloaded (this is why embedded works).
+3. `public/assets/<file>` in the bundle — the desktop fallback (doesn't exist in the APK, since `build-mobile-server.mjs` strips it).
+
+So on the phone the fetched copy is preferred; on desktop the bundled copy is served, unchanged. `DATA_ASSETS_DIR = <DATA_DIR>/assets` is defined in `server/libraryStore.js`.
+
+---
+
+## Self-update
+
+The app updates itself by reading the rolling GitHub release on every launch — there's no store distribution.
+
+**Flow** (`checkForUpdate()` in `mobile/www/index.html`):
+
+1. If `APP_BUILD` isn't all digits (`/^\d+$/`), it's a dev build → return `null` (never self-updates).
+2. `fetch(RELEASE_API)` with a 4 s timeout, `Accept: application/vnd.github+json`.
+3. Parse the release `body` for `Build:\s*(\d+)` (case-insensitive). This "Build: N" line is written into the release notes by CI (see below).
+4. If `remoteBuild <= APP_BUILD` → no update. Otherwise find the asset named exactly **`pax-historia.apk`** and return `{ build, url: asset.browser_download_url }`.
+5. The `update` card's `Download update` sets `location.href` to that URL; Android downloads the APK and the user opens it to install over the existing app.
+
+A small build badge (`build <N>` or `build dev`) is pinned bottom-right for support/debugging.
+
+| Piece | Where |
+|---|---|
+| Build number placeholder | `APP_BUILD = "__APP_BUILD__"` in `index.html` |
+| Stamp step | `sed -i "s/__APP_BUILD__/${{ github.run_number }}/"` in `.github/workflows/android-apk.yml` |
+| Version signal | `Build: <run_number>` line appended to the release notes by the workflow |
+| Update artifact name | `pax-historia.apk` (matched exactly by `a.name === "pax-historia.apk"`) |
+
+---
+
+## Release channels — stable vs. beta
+
+The channel a build watches is determined **entirely by the `RELEASE_API` URL baked into `index.html`** (which repo + which release tag).
+
+| Channel | `RELEASE_API` repo | Release tag | Notes |
+|---|---|---|---|
+| Stable (this work-repo / upstream) | `Open-Historia/open-historia` | `android` | The committed value in `mobile/www/index.html` |
+| Fork build | `Tommi-K/pax-historia` | `android` | Same tag, different repo (seen in the fork worktree) |
+
+**Accuracy note:** in the current code there is a **single rolling `android` release**, and no `android-beta` tag or `android-apk-beta.yml` workflow exists anywhere in the repo — `RELEASE_API` and the workflow's `gh release` calls both hardcode `android`. A stable-vs-beta split for the Android app therefore means *pointing `RELEASE_API` at a different repo/tag* (as the fork already does), not a second workflow. If a dedicated `android-beta` channel is wanted, the pattern would mirror the app-bundle `app-stable`/`app-beta` releases: publish to an `android-beta` tag and stamp/read that tag in a parallel shell — but that is not yet implemented here. Do not assume an `android-beta` release exists.
+
+---
+
+## Build pipeline
+
+Two stages, both driven by `.github/workflows/android-apk.yml` (also runnable locally).
+
+### Stage 1 — assemble the Node project: `scripts/build-mobile-server.mjs`
+
+Run **after** `vite build` (it requires `dist/index.html`). It wipes and rebuilds the copied dirs each run, leaving the committed `main.js`/`fetchMapAssets.mjs` alone. Heavy files (`*.pmtiles`, `*.geojson`, `cities-seed.json`, matched by the `HEAVY` regex) are stripped everywhere — they're fetched at runtime instead.
+
+| Step | Action |
+|---|---|
+| guard | Die unless run from repo root (`server/server.js`) and `dist/index.html` exists |
+| 1 | Copy `server/` verbatim; copy `dist/` with `copyLight` (strips heavy tiles vite copied from `public/`) |
+| 2 | Copy `public/lang/` (server's read-only lang fallback); `public/assets` pmtiles are **not** copied |
+| 3 | Seed: copy `scenario-manifest.json`, `game-manifest.json`, `scenarios/` from `server/data` (heavy files stripped) into `seed/` |
+| 4 | Copy `scripts/map-assets.json` → `map-assets.json` |
+| 5 | Write an `express`-only `package.json` (mirrors the root's pinned express, default `^5.1.0`) |
+| 6 | `npm install --omit=dev` into the project (skippable with `--no-install`) so the APK bundles `node_modules` |
+
+Result: `mobile/nodejs-project/` ready for `cap sync` (dist ~21 MB, node_modules ~3.4 MB, seed carries no heavy files).
+
+### Stage 2 — build the APK: `.github/workflows/android-apk.yml`
+
+Triggers: `workflow_dispatch` or pushing an `android-v*` tag. `permissions: contents: write`.
+
+| Step | Command / purpose |
+|---|---|
+| Checkout / Node 20 / Java 21 (temurin) | Toolchain |
+| **Stamp the build number** | `sed` replaces `__APP_BUILD__` with `github.run_number` in `mobile/www/index.html` |
+| **Build game + assemble server** | `npm ci` → `npm run build` → `node scripts/build-mobile-server.mjs` |
+| **Build the APK** | `cd mobile` → `npm ci` → `npx cap sync android` → `./gradlew assembleDebug --no-daemon` |
+| **Collect** | `cp mobile/android/app/build/outputs/apk/debug/app-debug.apk pax-historia.apk` |
+| upload-artifact | `pax-historia-apk` |
+| **Publish** | `gh release create android` (or `edit` if it exists) with the `Build: <run_number>` notes, then `gh release upload android pax-historia.apk --clobber` |
+
+The APK is a **debug** build attached to the rolling `android` release; players download `pax-historia.apk` and sideload it.
+
+---
+
+## Capacitor config — `mobile/capacitor.config.json`
+
+| Field | Value | Meaning |
+|---|---|---|
+| `appId` | `io.github.arkniem.paxhistoria` | Android application id — **must never change** (see invariants) |
+| `appName` | `Open Historia` | Display name |
+| `webDir` | `www` | The boot shell (`mobile/www/index.html`) is the packaged web root |
+| `server.androidScheme` | `http` | WebView origin scheme (matches the `http://127.0.0.1` embedded server) |
+| `server.hostname` | `app.paxhistoria` | Base WebView origin before navigating into the server |
+| `server.cleartext` | `true` | Allow cleartext (loopback HTTP) |
+| `server.allowNavigation` | `["*"]` | Permit navigating to any host (embedded loopback, or a LAN/remote server) |
+| `android.allowMixedContent` | `true` | Allow mixed content in the WebView |
+
+`mobile/package.json` currently declares only `@capacitor/core` + `@capacitor/android` (deps) and `@capacitor/cli` + `@capacitor/assets` (dev). Scripts: `sync` (`cap sync android`), `open`, `apk`.
+
+---
+
+## nodejs-mobile-cordova ↔ Capacitor build caveats
+
+Combining a **Cordova** plugin (`nodejs-mobile-cordova`) with a **Capacitor** app is the fragile part of this build, and it is the one step **not yet committed**. The status list in `mobile/README-embedded-server.md` §"NOT yet done" and the note in the workflow's *Build the APK* step both flag it.
+
+**Not-yet-done manual step (the linchpin):**
+```sh
+cd mobile
+npm i nodejs-mobile-cordova     # adds the native libnode + window.nodejs bridge
+npx cap sync android            # copies mobile/nodejs-project into the app, wires the plugin
+```
+Until this is done and committed, `window.nodejs` is undefined and the boot shell falls back to the manual-connect card (`startEmbeddedServer`'s "This build has no built-in server" branch). Confirming evidence: `mobile/package.json` and `package-lock.json` list **no** `nodejs-mobile-cordova`, so the checked-in native project cannot yet boot an embedded server.
+
+| Caveat | Detail | Where it bites |
+|---|---|---|
+| **`www` folder** | Capacitor treats `webDir: "www"` as the web root and re-copies `mobile/www` into the native app's assets on every `cap sync`. The Cordova plugin's own convention is a Node project under `www/nodejs-project`. This repo deliberately keeps the Node project at `mobile/nodejs-project` (outside `webDir`) and assembles it with `build-mobile-server.mjs`, so `cap sync` must bundle it for the plugin without it being clobbered by web-asset syncing. Don't move the heavy Node project into `www`. |
+| **CMake / native libnode path** | `nodejs-mobile-cordova` compiles/links a native `libnode` per ABI through CMake/NDK during the Gradle build. This is where per-ABI size and path issues surface. `README-embedded-server.md` calls this out: *"nodejs-mobile adds a native libnode per ABI; check the APK size and split per-ABI if needed."* |
+| **Plugin must be committed for CI** | `.github/workflows/android-apk.yml` runs `cap sync` non-interactively; the plugin has to be present in `mobile/` (installed + native project regenerated) for `cap sync` to bundle it. The Cordova bridge is included via `:capacitor-cordova-android-plugins` (`mobile/android/settings.gradle`). |
+| **On-device verification pending** | Cold-start time, the 90 s `waitForServer` window, and the ~200 MB first-run download UX are only verifiable on a real device (per the README status). Desktop verification covers `dataDir.js`, `main.js` seeding, the assembly script, and the pmtiles route. |
+
+Debugging tip: `nodejs.start(..., { redirectOutputToLogcat: true })` sends the embedded server's `console.log` to `adb logcat`.
+
+---
+
+## Invariants that must never change
+
+| Constant | Value | Why it's load-bearing |
+|---|---|---|
+| `appId` | `io.github.arkniem.paxhistoria` | The Android package id. Changing it makes the self-update install a *second* app instead of upgrading in place, orphaning every existing install. |
+| Update asset name | `pax-historia.apk` | The self-update matches `a.name === "pax-historia.apk"` (`index.html`) and the workflow uploads exactly that name. A rename breaks self-update for everyone. |
+| Embedded port / URL | `PORT` default `3000` in `main.js` **and** `EMBEDDED_URL = http://127.0.0.1:3000` in `index.html` | These two are a matched pair — the boot shell polls and navigates to exactly what the server binds. Change one, change both. |
+| `Build: N` release-note format | regex `Build:\s*(\d+)` | The self-update parses the release body for this; the workflow must keep writing it. |
+
+---
+
+## Local development & testing
+
+```sh
+# from the repo root
+npm ci
+npm run build                 # produces dist/
+npm run build:mobile-server   # runs scripts/build-mobile-server.mjs (installs express)
+
+# exercise the embedded entry exactly as the phone will (desktop Node):
+OH_DATA_DIR=/tmp/oh PORT=3000 node mobile/nodejs-project/main.js
+#   → seeds /tmp/oh, downloads the map (~200 MB), serves http://127.0.0.1:3000
+
+# APK (after installing the plugin — the manual step above):
+cd mobile && npx cap sync android && cd android && ./gradlew assembleDebug
+```
+
+Because `main.js`, `fetchMapAssets.mjs`, and the server are all plain Node, the desktop run is a faithful rehearsal of the on-device boot — only the nodejs-mobile bridge and the native APK build differ.
+
+---
+
+## Related pages
+
+- [World state](world-state.md) — what the embedded server serves once the WebView navigates into `127.0.0.1:3000`.
+- The map editor and its asset pipeline share the `map-data` release and `resolveRuntimeBinaryAsset` path used here.

--- a/docs/runtime-services.md
+++ b/docs/runtime-services.md
@@ -1,0 +1,304 @@
+# Runtime Services
+
+The `src/runtime/` folder holds the framework-light services that sit between the server API and the React UI: the library/scenario/game catalog stores, the AI-powered UI translator and its language setting, the country-name resolver, and the small tag/label/flag/map-setting helpers. Most of these are plain modules with module-scope state plus a `useSyncExternalStore`/`useState` React hook, deliberately kept free of OpenLayers/heavy deps so the **editor**, the **game**, and the **server** can all import the same rules. This page maps each service, its exported API, and — most importantly — how data flows in from `/api/*` and back out to the components.
+
+Related pages: [World state](world-state.md) · [Game state](game-state.md) · [Assets](assets.md) · [AI system](ai-system.md)
+
+---
+
+## Module map
+
+| Service | File | Owns | Consumed by |
+|---|---|---|---|
+| Library store | `src/runtime/library.js` | games + scenarios + active-game catalog, country-name overrides | `src/App.jsx`, `src/Game/GameUI/libraryBar.jsx`, `scenarios.jsx` |
+| Scenario store | `src/runtime/scenarios.js` | scenario-only catalog (parallel, editor/standalone) | editor / scenario-picker contexts |
+| Country-name resolver | `src/runtime/assets.js` (+ `polityNames.js`) | code→display-name plumbing, runtime asset endpoints/token | every map/name renderer |
+| Language setting | `src/runtime/i18n.js` | UI language choice, `LANGUAGES`, RTL, `languageDirective` | Settings UI, `translator.js`, `callAI` |
+| Translator | `src/runtime/translator.js` | pre-translation pass + live DOM translation cache | `src/main.jsx` (boot), map labels |
+| Country tags | `src/runtime/countryTags.js` | tag normalization + author-vs-live resolution | editor, game, server, `promptContext.js` |
+| Country labels | `src/runtime/countryLabels.js` | map country-label GeoJSON (curved + point) | `src/Game/Map/Nations.jsx` |
+| Community flags | `src/runtime/communityFlags.js` | hub-hosted shared flags & flag packs | `src/Editor/FlagPicker.jsx` |
+| Map settings | `src/runtime/mapSettings.js` | localStorage map/AI toggles | map + settings components |
+
+---
+
+## Library store — `src/runtime/library.js`
+
+The single source of truth for the player's **games**, **scenarios**, and which of each is active. It holds one module-scope object (`libraryState`), exposes it through a `useSyncExternalStore` subscription, and wraps every catalog mutation as an `/api/*` call that refreshes the store afterwards.
+
+### State shape (`INITIAL_LIBRARY_STATE`, `library.js:13`)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `activeGame` | object \| null | The active game record (resolved from `games` by `activeGameId`) |
+| `activeGameId` | string \| null | Server-chosen active game, falls back to `games[0].id` |
+| `baseSaves` | array | Base-save descriptors returned by the catalog |
+| `countryNames` | object | Catalog-level country-name map (`{}` when absent) |
+| `error` | string \| null | Last catalog error message |
+| `games` | array | All game records |
+| `loaded` | boolean | Catalog has completed at least once |
+| `loading` | boolean | A catalog fetch is in flight |
+| `runtimeScenario` | object \| null | The scenario whose assets are currently live (drives overrides + token) |
+| `scenarios` | array | All scenario records |
+| `selectedScenario` / `selectedScenarioId` | object/string \| null | The scenario selected in the library UI |
+| `token` | string | Cache-busting asset token (`catalog.token` → `activeGame.cacheToken` → `""`) |
+
+`runtimeScenario` resolution (`library.js:119`) is layered: the scenario matching `catalog.runtimeScenario.id`, else the raw `catalog.runtimeScenario`, else the active game's `scenarioId` scenario. This is the scenario whose `countryNameOverrides` and `cacheToken` become live.
+
+### Store API
+
+| Export | Kind | Purpose |
+|---|---|---|
+| `getLibraryState()` | getter | Current `libraryState` snapshot |
+| `subscribeToLibraryState(listener)` | subscribe | Adds/removes a listener; returns unsubscribe |
+| `useLibraryState()` | React hook | `useSyncExternalStore` binding — components re-render on any state change |
+| `refreshLibraryCatalog({ force })` | async | GET `/api/library`, apply into state; de-dupes concurrent calls via `libraryCatalogRequest` unless `force` |
+| `ensureLibraryCatalog()` | async | Refresh only if not already `loaded` |
+
+`emitLibraryState()` fans out to the `listeners` Set; `setLibraryState()` is the choke point that (1) stores the new object, (2) calls `syncLibraryRuntime()`, then (3) emits — so the country-name resolver and asset token are **always re-wired before** React sees the new state.
+
+### Catalog mutations (each refreshes the store)
+
+All go through `requestJson()` (thin `fetch` + `parseApiResponse`, which throws `payload.error || payload.message || "HTTP <status>"`). Two patterns: functions that receive a fresh `catalog` in the response apply it directly via `applyLibraryCatalog`; the rest call `refreshLibraryCatalog({ force: true })` after mutating.
+
+| Export | HTTP | Route | Notes |
+|---|---|---|---|
+| `loadScenarioDetails(id)` | GET | `/api/scenarios/:id` | Returns details, no state change |
+| `createScenario(payload)` | POST | `/api/scenarios` | Then `enqueueContentStrings(payload)` + force refresh |
+| `saveScenario(id, payload)` | PUT | `/api/scenarios/:id` | Same translate-on-save + force refresh |
+| `selectScenario(id)` | PUT | `/api/scenarios/selected` | Body `{ scenarioId }`; applies returned catalog |
+| `removeScenario(id)` | DELETE | `/api/scenarios/:id` | Applies returned catalog |
+| `downloadScenarioJsonAsset(id, key)` | GET | `/api/scenarios/:id/assets/:key` | Returns `null` on 404/throw (missing = "use default") |
+| `uploadScenarioAsset(id, key, file)` | PUT | `/api/scenarios/:id/assets/:key` | Raw body via `toUploadBuffer`; force refresh |
+| `clearScenarioAsset(id, key)` | DELETE | `/api/scenarios/:id/assets/:key` | Force refresh |
+| `exportScenarioBundle(id, mode="light")` | GET | `/api/scenarios/:id/export?mode=` | Returns bundle JSON |
+| `importScenarioBundle(bundle)` | POST | `/api/scenarios/import` | New local scenario; force refresh |
+| `updateScenarioFromBundle(id, bundle)` | PUT | `/api/scenarios/:id/import` | Hub **Update** button — replaces content, **keeps the local id** so games keep working |
+| `loadGameDetails(id)` | GET | `/api/games/:id` | Returns details |
+| `createGame(payload)` | POST | `/api/games` | `enqueueContentStrings` + force refresh |
+| `saveGame(id, payload)` | PUT | `/api/games/:id` | `enqueueContentStrings` + force refresh |
+| `activateGame(id)` | PUT | `/api/games/active` | Body `{ gameId }`; applies returned catalog |
+| `removeGame(id)` | DELETE | `/api/games/:id` | Applies returned catalog |
+| `uploadGameAsset(id, key, file)` | PUT | `/api/games/:id/assets/:key` | Raw body; force refresh |
+| `clearGameAsset(id, key)` | DELETE | `/api/games/:id/assets/:key` | Force refresh |
+
+`toUploadBuffer()` (`library.js:235`) accepts `Blob`, `ArrayBuffer`, a typed-array view, or coerces anything else to a UTF-8 buffer, so callers can upload files or serialized JSON identically.
+
+### Country-name override resolver (in this module)
+
+`resolveCountryNameOverride(overrides, name, code)` (`library.js:41`) is the ordered lookup used to rename countries per-scenario. It reads `runtimeScenario.countryNameOverrides` and returns the first hit:
+
+1. by **code** (uppercased via `normalizeLookupKey`) — e.g. `overrides["RUS"]`
+2. by **exact name** — `overrides["Russia"]`
+3. by **normalized (uppercased) name** — `overrides["RUSSIA"]`
+4. otherwise the original `name`
+
+Two exits into the shared asset layer:
+
+- `syncLibraryRuntime()` (`library.js:68`) runs on every `setLibraryState` and once at module load (`library.js:388`). It pushes the token to `setRuntimeAssetEndpoints({ token })` and installs the resolver via `setCountryNameResolver((name, code) => resolveCountryNameOverride(runtimeScenario.countryNameOverrides, name, code))`. From then on every `resolveCountryDisplayName` call inside `assets.js`/`countryLabels.js`/`polityNames.js` honors the active scenario's renames.
+- `resolveScenarioCountryName(name, code)` (`library.js:385`) is the direct synchronous export for callers that already have a `name`/`code` pair.
+
+### Boot / data flow
+
+`src/App.jsx` calls `ensureLibraryCatalog()` and reads `useLibraryState()` (only `activeGameId` in that file). On any library mutation the token changes → `setRuntimeAssetEndpoints` sweeps and rotates all runtime URLs (see [resolver plumbing](#country-name-resolver-plumbing--srcruntimeassetsjs)) → components subscribed to the store re-render → asset fetches now carry the new `?v=<token>`.
+
+---
+
+## Scenario store — `src/runtime/scenarios.js`
+
+A **parallel, scenario-only** variant of the library store for contexts that have no concept of "games" (the editor / standalone scenario flows). Structurally it mirrors `library.js` — same `parseApiResponse`/`requestJson`/`toUploadBuffer`, same `resolveCountryNameOverride` (identical 3-step code→name→normalized lookup) — but its state centers on a single active scenario.
+
+### State (`INITIAL_SCENARIO_STATE`, `scenarios.js:9`)
+
+`activeScenario`, `activeScenarioId`, `baseSaves`, `error`, `loaded`, `loading`, `scenarios`, `token`. There is no `games`, `activeGame`, `countryNames`, `selectedScenario`, or `runtimeScenario`; the resolver and token both read from `activeScenario` instead.
+
+### API differences vs. library store
+
+| Export | HTTP | Route |
+|---|---|---|
+| `getScenarioState` / `subscribeToScenarioState` / `useScenarioState` | — | Store accessors (same pattern) |
+| `refreshScenarioCatalog({force})` / `ensureScenarioCatalog()` | GET | `/api/scenarios` |
+| `createScenario` / `saveScenario` | POST / PUT | `/api/scenarios`, `/api/scenarios/:id` (no `enqueueContentStrings` here) |
+| `activateScenario(id)` | PUT | `/api/scenarios/active` (body `{ scenarioId }`) — cf. library's `selectScenario` → `/selected` |
+| `removeScenario(id)` | DELETE | `/api/scenarios/:id` |
+| `uploadScenarioAsset` / `clearScenarioAsset` | PUT / DELETE | `/api/scenarios/:id/assets/:key` |
+| `resolveScenarioCountryName(name, code)` | — | Reads `activeScenario.countryNameOverrides` |
+
+`syncScenarioRuntime()` (`scenarios.js:59`) does the same `setRuntimeAssetEndpoints` + `setCountryNameResolver` wiring as the library store, keyed on `activeScenario`. Only one of the two stores should be driving `assets.js` at a time (whichever build is mounted), since both call the same global setters.
+
+---
+
+## Country-name resolver plumbing — `src/runtime/assets.js`
+
+Codes (`"RUS"`, `"KHAL"`) are the load-bearing identifiers in the data; the player must only ever see full names. The resolver is a single mutable function slot in `assets.js` that the library/scenario stores install into.
+
+| Export (`assets.js`) | Line | Role |
+|---|---|---|
+| `setCountryNameResolver(resolver)` | `284` | Installs the active resolver (`(name, code) => string`); non-functions reset to identity |
+| `resolveCountryDisplayName(name, code)` | `288` | The single call site used across the asset layer — delegates to the installed resolver |
+| `setRuntimeAssetEndpoints({ token })` | `204` | Rebuilds every `JSON_URLS.*` and `PMTILES_ARCHIVES.*` with `?v=<token>`, and **sweeps stale caches** on token change |
+
+Default resolver is identity (`countryNameResolver = (name) => name`, `assets.js:40`) until a store installs one. `loadCountryNames` (`assets.js:965`) and `loadRegionCatalog` decode the countries PMTiles z0 tile and run each raw `Country/NAME` through `resolveCountryDisplayName(name, code)`, so scenario renames flow into the country dropdowns and map labels without those modules knowing about scenarios.
+
+**Token sweep (memory + correctness).** When the token changes, `setRuntimeAssetEndpoints` deletes the previous generation's entries from `jsonValueCache`, `jsonRequestCache`, `jsonLoadedUrls`, the PMTiles archive/header/directory caches, and clears the key-based `runtimeJsonValueCache`/`runtimeJsonRequestCache` — **before** rebuilding the URLs, because the old URL strings are the only handles to those entries. This prevents both the ~190 MB-per-switch GeoJSON leak and serving one scenario's bytes under another's cached PMTiles header. See [Assets](assets.md) for the full cache model.
+
+### Sibling resolver — `src/runtime/polityNames.js`
+
+Where the override resolver renames by scenario, `polityNames.js` resolves a **code → era-polity or base name** for single values, cached for sync access.
+
+| Export | Purpose |
+|---|---|
+| `ensurePolityNames()` | Refreshes `nameByCode` if older than 15 s; merges `loadCountryNames()` with `world.polityOverrides` (era polity wins **only when it carries a name**) |
+| `polityDisplayName(code)` | Sync lookup, falls back to the code until a refresh has run |
+| `useCountryDisplayName(code)` | Hook: renders the code, then swaps to the resolved name after `ensurePolityNames()` |
+
+---
+
+## Language setting — `src/runtime/i18n.js`
+
+Owns the UI-language *choice* and static catalog. The choice is stored on the **server** (shared by every device — desktop browser and the Android app that play through the same server) and mirrored to `localStorage["ui_language"]` so boot doesn't wait on a fetch. `"en"` (the authored language) means no translation happens at all.
+
+| Export | Purpose |
+|---|---|
+| `DEFAULT_LANGUAGE` | `"en"` |
+| `LANGUAGES` | 50-entry array of `{ code, name, native }` (top-50 most-spoken, English name + endonym) |
+| `getLanguageOptions()` | Returns `LANGUAGES` |
+| `languageDisplayName(code)` | English display name, falls back to the code |
+| `getStoredLanguage()` | Reads localStorage; returns `DEFAULT_LANGUAGE` on miss/error |
+| `setStoredLanguage(code)` | Writes localStorage **and** PUT `/api/ui-settings` `{ language }` (offline-tolerant) |
+| `syncLanguageFromServer()` | GET `/api/ui-settings`; server wins; returns `true` if the local value changed (caller reloads) |
+| `isRtlLanguage(code)` | Membership in `RTL_LANGUAGES` = `{ ar, he, fa, ur }` |
+| `languageDirective()` | System-prompt fragment appended to every AI call so replies arrive natively in-language |
+
+Storage rule: writing `en` (or empty) **removes** the key rather than storing it (`writeLocalLanguage`, `i18n.js:81`), so "English" is represented by absence. `languageDirective()` returns `""` for English; otherwise it instructs the model to write all natural-language text in the target language while keeping JSON keys/ISO codes/date formats intact — this is why AI output does not need re-translation (see [AI system](ai-system.md)).
+
+---
+
+## Translator — `src/runtime/translator.js`
+
+Translates the running UI into the player's language using whichever AI provider is configured. Two layers:
+
+1. **One-time pre-translation pass** per language (on boot / after a switch): gathers every string the game *could* show, translates up front behind a progress pill, caches in localStorage.
+2. **A `MutationObserver`** that keeps applying the cache to new DOM synchronously (no English flash) and lazily translates the rare strings the pre-pass couldn't know.
+
+### Lifecycle
+
+| Export | Purpose |
+|---|---|
+| `startTranslator()` | Called once from `src/main.jsx:24`. Syncs language from server (reload if changed), returns early for English, sets `<html lang>` + RTL `direction`, loads localStorage cache + server pack, waits out the startup screen, then starts the observer and pre-translation pass |
+| `stopTranslator()` | Disconnects the observer, clears timers, removes the progress pill |
+
+Boot order inside `startTranslator` (`translator.js:587`): `syncLanguageFromServer()` (reload on change) → bail if `en` → set `lang`/`direction` → `loadCache()` → `loadServerPack()` → `whenStartupScreenGone()` (polls for `[data-startup-screen]`, 180 s cap) → activate observer + `scan()` → `collectCatalogStrings()` → show progress if >10 pending → `processQueue()`.
+
+### Public lookups (for callers/data outside the DOM)
+
+| Export | Purpose |
+|---|---|
+| `translateLabel(text)` | **Sync** best-effort translate for text drawn outside the DOM (map country labels). Returns cached translation, or the original while queuing the string + firing `i18n:updated` when it resolves |
+| `enqueueStrings(strings)` | Proactively queue an array of strings (e.g. freshly-fetched hub posts); only uncached ones cost a call |
+| `enqueueContentStrings(payload)` | Deep-walk a saved payload (≤6 deep) pulling human-readable fields (`CONTENT_TEXT_KEYS` + `aliases`), skipping `features`/`geometry`/`coordinates`, and enqueue them. Called by `library.js` on `createScenario/saveScenario/createGame/saveGame` so edited names/descriptions translate **and reach the server pack** the moment they're saved |
+
+`countryLabels.js` calls `translateLabel(...)` so map labels follow the UI language; when new translations land, the `"i18n:updated"` event (debounced in `announceUpdate`) tells label builders to rebuild.
+
+### Server language pack
+
+- `loadServerPack()` — GET `/api/lang/:language`, merges shipped + community-generated translations into the local cache without overwriting.
+- `syncEntriesToServer()` — debounced (2 s) PUT `/api/lang/:language` `{ entries }` pushing newly-generated translations so every device and future session reuses them instead of paying for the same AI call.
+
+### Translation engine + config
+
+`translateBatch()` (`translator.js:305`) late-imports `callAI` from `../Game/AI/main.jsx` and sends a strict JSON-array prompt (same length/order, keep numbers/emoji/placeholders, proper names unchanged). `processQueue()` runs up to `MAX_CONCURRENT_BATCHES` batches in parallel, writes results into both `cache` and `unsyncedEntries`, and backs off on repeated failure.
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `CACHE_PREFIX` | `i18n_cache_` | localStorage key prefix (`+language`) |
+| `CACHE_LIMIT` | `8000` | Max cached entries persisted (most-recent kept) |
+| `BATCH_SIZE` | `60` | Strings per AI call |
+| `MAX_CONCURRENT_BATCHES` | `3` | Parallel batches per pump |
+| `SCAN_DEBOUNCE_MS` | `350` | Debounce before a DOM scan |
+| `MAX_CONSECUTIVE_FAILURES` | `3` | Failures before a 60 s cooldown |
+| `TRANSLATED_ATTRIBUTES` | `placeholder, title, aria-label` | Attributes also translated |
+| `SKIP_SELECTOR` | `script, style, noscript, input, textarea, [contenteditable], [data-no-translate]` | Never-translated nodes; opt out with `data-no-translate` |
+
+The `nodeSources` WeakMap records the English source last seen at each text node, so re-renders that restore English are re-translated and the translator recognizes its own writes.
+
+---
+
+## Country tags — `src/runtime/countryTags.js`
+
+Short traits describing what a country *is* (`"socialist"`, `"authoritarian"`, `"anti-nato"`). The map-maker sets starting tags in the editor (`tags.json` on the scenario); the AI reads them as context and rewrites them into `world.countryTags`. This module owns the two rules both halves must agree on — normalization and which source wins — and **imports nothing** so editor, game, and server share it.
+
+| Export | Purpose |
+|---|---|
+| `MAX_TAGS` = 8 / `MAX_TAG_LEN` = 32 | Caps |
+| `TAG_SUGGESTIONS` | 30 suggested spellings (open vocabulary — suggestions only, so the model converges on one spelling) |
+| `normalizeTagList(list, {maxTags, maxLen})` | Trim, collapse whitespace, cap length, drop blanks/non-strings, dedupe case-insensitively, cap count |
+| `resolveCountryTags(baseTags, world, country)` | Tags in force **now** for one country: the AI's live list if it ever set one, else the author's list — **not a merge** |
+| `resolveAllCountryTags(baseTags, world)` | Same rule across every country that has tags; builds the world summary the model reads |
+
+**Keying gotcha (documented in-file):** tags are keyed by the country's **name, verbatim** — no uppercasing. The code used to uppercase (fine when owners were uppercase GADM codes); with names it looked up `baseTags["RUSSIA"]` against a `tags.json` keyed `"Russia"` and silently dropped every author tag. `resolveAllCountryTags` emits keys verbatim for the same reason (the model's world summary must match `polityOverrides` casing). Consumed by `src/Game/AI/promptContext.js`.
+
+---
+
+## Country labels — `src/runtime/countryLabels.js`
+
+Builds the GeoJSON that draws country **names** on the map (not the DOM). Reads the countries PMTiles z0 tile, decodes it, and produces two FeatureCollections: `curvedLabelData` (per-glyph point features following a computed spine for long/curved countries) and `pointLabelData` (a single centroid point for the rest). Consumed by `src/Game/Map/Nations.jsx`.
+
+| Export | Purpose |
+|---|---|
+| `loadCountryLabelCollections({ force, ownedCodes })` | Main entry: returns `{ curvedLabelData, pointLabelData }`, memoized + persisted |
+| `warmCountryLabelCollections(options)` | Preload helper returning `{ kind:"json", size, url }` for the warm-cache report |
+
+### How it connects
+
+- **Names** run through `translateLabel(resolveCountryDisplayName(rawName, code))` (`countryLabels.js:499`) — so labels honor both the scenario country-name overrides *and* the UI language.
+- **`ownedCodes`** (a `Set`): when non-empty, countries owning no territory in the scenario are skipped, so a nonexistent-era nation doesn't float its modern name over unclaimed land. A distinct owner set caches separately (owner-hash suffix on the cache key).
+- **Cache key** (`computeCountryLabelCacheKey`, `countryLabels.js:461`) folds tile-byte FNV hash + byte length + archive URL + **`getStoredLanguage()`**, so caches never leak across UI languages. Persisted via `writeRuntimeJson` / read via `readRuntimeJson` (see [Assets](assets.md)). Cache version is `country-labels-v3` (bumped to v3 when glyph `lat` was added for the globe text-size fix, issue #6).
+- **Empty-result guard** (`countryLabels.js:642`): an empty build is treated as a degraded z0 read — served once, never cached — so a transient miss can't poison every future boot.
+
+Geometry helpers (`getCentroid`, `getPrincipalAxisAngle`, `buildCurvedLabelPath`, `buildCurvedLabelGlyphFeatures`, `tileToLngLat`, …) convert tile coordinates to lng/lat and decide curved-vs-point; each glyph carries its own `lat` so `Nations.jsx` can correct globe-projection text inflation at high latitude.
+
+---
+
+## Community flags — `src/runtime/communityFlags.js`
+
+Reads flags shared by other players **straight from the hub repo's GitHub Issues** — the Issues API query *is* the index (no index file, no CI); a post is live the moment its author submits. Deliberately mirrors `communityBasemaps.js` and stays free of React/OpenLayers deps so the editor (`src/Editor/FlagPicker.jsx`) and game can both use it.
+
+| Constant | Value |
+|---|---|
+| Hub repo | `Open-Historia/Open-historia-scenarios` |
+| `HUB_API_FLAGS` | issues `?state=open&labels=flag&per_page=100` (label must exist in the repo or GitHub drops it) |
+| `HUB_API_SCENARIOS` | issues `?state=open&labels=scenario` — scanned for scenario posts carrying flags |
+| `CACHE_TTL_MS` | 5 min in-memory cache |
+
+| Export | Purpose |
+|---|---|
+| `fetchCommunityFlags({ force })` | Fetches both endpoints (scenarios best-effort), parses, filters to installable, caches. Returns `[...dedicatedFlagPosts, ...scenarioFlagPacks]` |
+| `flagPostInstallable(post)` | True if a payload can be extracted: `imageUrl` for a flag post, `packUrl` for a scenario pack |
+| `loadCommunityFlagDataUrl(post)` | Downloads a flag image **through the hub proxy** (`/api/hub/file?url=`, since GitHub attachments send no CORS) and returns a chunked base64 `data:` URL |
+| `loadCommunityFlagPack(post)` | Downloads a scenario bundle via the proxy, finds `scenario.json` (zip or bare JSON), returns custom `{ code, dataUrl }` flags from `assets.flags` (flagcdn/built-in URLs skipped) |
+| `communityFlagsHubUrl()` | Link to the filtered hub issue list |
+| `openFlagPublishForm({name, author, code})` | Opens the prefilled `flag.yml` issue form in a new tab (image left for the user to drag in) |
+
+**Two post shapes.** `parseFlagPost` turns a dedicated `[Flag]` issue into a card (`id, title, author, avatarUrl, url, createdAt, official, upvotes, code, imageUrl`); `parseScenarioAsFlagPack` turns a `scenario` issue that stamped a **`Flags-Count:` tag** into one installable pack card (`fromScenario: true, flagCount, packUrl`), so flags shared inside a scenario surface here without downloading every bundle. Regex contracts: `COVER_IMAGE_PATTERN` (inline markdown/`<img>`), `FILE_LINK_PATTERN` (GitHub file/user-attachment/raw links), `CODE_PATTERN` (`Flag-Code:`), `FLAGS_COUNT_PATTERN` (`Flags-Count:`). `OFFICIAL_ASSOCIATIONS` = `OWNER/MEMBER/COLLABORATOR` sets the `official` badge. `.zip` bundles are read with `unzipBundle`/`looksLikeZip` from `bundleZip.js`.
+
+---
+
+## Map settings — `src/runtime/mapSettings.js`
+
+Tiny localStorage-backed boolean toggles read reactively instead of threaded as props through `GameUI`/`main.jsx`. Same getter/setter pattern as `src/Game/AI/providerConfig.js`; the hook sits beside the data it subscribes to, mirroring `useCountryDisplayName`.
+
+| `MAP_SETTING_KEYS` key | localStorage key | Effect when ON |
+|---|---|---|
+| `hideCountryLabels` | `map_hide_country_labels` | Hide country name labels |
+| `disableIdleRotation` | `map_disable_idle_rotation` | Stop the idle globe spin |
+| `disableEventCamera` | `map_disable_event_camera` | Suppress event camera moves |
+| `limitAiGeneration` | `ai_limit_generation` | (Not a map setting) timeline-jump generation gets a 5-min deadline → canned-event fallback; OFF waits as long as the model needs |
+
+| Export | Purpose |
+|---|---|
+| `getMapSetting(key)` | `localStorage.getItem(key) === "1"` |
+| `setMapSetting(key, value)` | Writes `"1"`/`"0"` and dispatches a `mapSettings:updated` window event |
+| `useMapSetting(key)` | `useState` hook that re-reads on the `mapSettings:updated` event |
+
+Values are stored as `"1"`/`"0"` strings (absent = off). The custom `mapSettings:updated` event is the cross-component sync mechanism — any `setMapSetting` call updates every `useMapSetting(key)` subscriber in the same document.

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,304 @@
+# Server & API
+
+Open Historia ships with a small **Express** server (`server/server.js`) that is the single backend for the whole app: it serves the built SPA, exposes a JSON/binary REST API under `/api/*`, and reads/writes every piece of persistent state (scenarios, games, map-editor docs, basemaps, flags, language packs, UI settings) as plain files under one writable data directory. There is no database — the on-disk layout under `server/data/` *is* the data model, and each concern gets its own self-contained "store" module. The same `server.js` runs unchanged on desktop, Termux, and in-process inside the Android app (via `nodejs-mobile`); portability comes entirely from the `OH_DATA_DIR` indirection in `server/dataDir.js`.
+
+> This page documents the **game server** (`server/server.js`). A second, unrelated entry point — `server/node.js` — is the stateless content-node for the peer network (hash-addressed read-only bytes; run separately with `OH_NODE_PORT`). It is out of scope here beyond this note.
+
+---
+
+## Boot sequence & topology
+
+`server/server.js` is an ES module. On import it:
+
+1. Builds the Express `app`, reads `PORT` (default `3000`, `server/server.js:61`) and `distDir = ../dist` (the Vite build output).
+2. Installs a **blanket CORS** middleware (`server/server.js:73-89`) — `Access-Control-Allow-Origin: *`, all methods, and three deliberate extras: `Access-Control-Expose-Headers: Content-Range, Content-Length, Accept-Ranges` (so PMTiles range recovery can read `Content-Range` off a 416), and `Access-Control-Allow-Private-Network: true` (Chrome's Private Network Access preflight for loopback/LAN). `OPTIONS` short-circuits to `204`.
+3. Installs the **CSRF / cross-origin-write guard** (`server/server.js:112-128`, logic in `server/security.js`). See [Security guard](#security--path-safety).
+4. Calls `ensureScenarioStore()`, `ensureGameStore()`, `ensureMapEditorStore()`, `ensureBasemapStore()` — first-run seeding of `server/data/` (`server/server.js:91-94`).
+5. Registers all `/api/*` routes, then the `/fmg` static mount (if vendored), then `express.static(distDir)`, then the SPA catch-all `GET *splat → dist/index.html` (`server/server.js:813-820`).
+6. `app.listen(PORT)`; an `EADDRINUSE` is caught and turned into a human message instead of a raw stack (`server/server.js:828-836`).
+
+Route ordering matters: `/fmg/*` and `express.static` are mounted **before** the `*splat` fallback so real files aren't swallowed by `index.html`.
+
+| Concern | Module | What it owns |
+| --- | --- | --- |
+| HTTP routing, static serving, range streaming, AI relay, hub proxy, shutdown | `server/server.js` | The Express app and every route |
+| Scenario + game catalog, CRUD, runtime read/write, owner canonicalization, bundle import/export, asset serving | `server/libraryStore.js` | The bulk of the data model |
+| Owner-code → country-name schema-2 migration | `server/ownerMigration.js` | `resolveOwnerName` + record migrators |
+| Writable data-root resolution | `server/dataDir.js` | `DATA_DIR` |
+| Path containment, CSRF guard, range parsing, hub host allowlist | `server/security.js` | Pure, unit-tested helpers |
+| Map-editor documents | `server/mapEditorStore.js` | `/api/mapeditor/*` |
+| User basemap library ("Your basemaps") | `server/basemapStore.js` | `/api/basemaps/*` |
+| Saved flag library ("My flags") | `server/flagStore.js` | `/api/flags/*` |
+
+---
+
+## API route table
+
+All routes are JSON in / JSON out unless noted. Errors are `{ error: message }` with the status shown (via `sendError`, `server/server.js:96-99`). Body-size limits: `jsonParser` = 64 MB, `largeJsonParser` = 2048 MB, `uploadParser` (`express.raw`, any type) = 2048 MB (`server/server.js:64-66`).
+
+### Client preferences & language packs
+| Method | Path | Purpose | Handler |
+| --- | --- | --- | --- |
+| GET | `/api/ui-settings` | Global shared UI settings (currently `language`) — every device sees the same choice | `server/server.js:171` |
+| PUT | `/api/ui-settings` | Set the shared UI language | `server/server.js:236` |
+| GET | `/api/lang/:code` | Merged language pack: shipped `dist|public/lang/<code>.json` **under** saved `data/lang/<code>.json` (saved wins) | `server/server.js:197` |
+| PUT | `/api/lang/:code` | Append runtime-generated translations into `data/lang/<code>.json` (bounded per entry: source ≤3000, translation ≤6000 chars) | `server/server.js:205` |
+
+`code` must match `/^[a-z]{2,3}$/` or the route 400s (`isLangCode`, `server/server.js:195`).
+
+### Scenarios
+| Method | Path | Purpose | Handler |
+| --- | --- | --- | --- |
+| GET | `/api/scenarios` | Scenario catalog (`{ scenarios, selectedScenarioId, activeScenarioId }`) | `server/server.js:250` |
+| GET | `/api/library` | Combined catalog: scenarios + games + selected/active + `countryNames` registry | `server/server.js:258` |
+| GET | `/api/scenarios/:scenarioId` | One scenario's summary + all 7 core JSON assets | `server/server.js:266` |
+| POST | `/api/scenarios` | Create a scenario (optionally seeded from `seedScenarioId`) → 201 | `server/server.js:274` |
+| PUT | `/api/scenarios/active` | Set the selected scenario (alias of `selected`) | `server/server.js:282` |
+| PUT | `/api/scenarios/selected` | Set the selected scenario | `server/server.js:290` |
+| PUT | `/api/scenarios/:scenarioId` | Update meta / `world` / `game` / `prompts` / `storage.*` (full-replace or `*Patch` merge) | `server/server.js:298` |
+| GET | `/api/scenarios/:scenarioId/export` | Export a shareable bundle; `?mode=full` embeds PMTiles, default `light` | `server/server.js:306` |
+| POST | `/api/scenarios/import` | Import a bundle as a **new** scenario (auto-selects it) → 201 | `server/server.js:315` |
+| PUT | `/api/scenarios/:scenarioId/import` | Replace an existing scenario's content from a fresh bundle (hub "Update" button) | `server/server.js:325` |
+| GET | `/api/scenarios/:scenarioId/assets/:assetKey` | Stream a binary/JSON upload asset (range-capable) | `server/server.js:333` |
+| PUT | `/api/scenarios/:scenarioId/assets/:assetKey` | Upload a binary asset (raw body) | `server/server.js:342` |
+| DELETE | `/api/scenarios/:scenarioId/assets/:assetKey` | Remove one upload asset | `server/server.js:443` |
+| DELETE | `/api/scenarios/:scenarioId` | Soft-delete a scenario to `.trash` (blocked if games still use it) | `server/server.js:451` |
+
+### Games
+| Method | Path | Purpose | Handler |
+| --- | --- | --- | --- |
+| GET | `/api/games` | Game catalog (`{ games, activeGameId }`) | `server/server.js:360` |
+| GET | `/api/games/:gameId` | One game's summary + all 7 core JSON assets + its scenario summary | `server/server.js:368` |
+| POST | `/api/games` | Create a game from a scenario (or seed from `seedGameId`) → 201 | `server/server.js:376` |
+| PUT | `/api/games/active` | Set the active game (stamps `lastPlayedAt`/`playCount`) | `server/server.js:384` |
+| PUT | `/api/games/:gameId` | Update meta / `world` / `game` / `prompts` / `storage.*` | `server/server.js:392` |
+| GET | `/api/games/:gameId/assets/:assetKey` | Stream a game upload asset (only `cover`) | `server/server.js:400` |
+| PUT | `/api/games/:gameId/assets/:assetKey` | Upload a game asset (raw body) | `server/server.js:409` |
+| DELETE | `/api/games/:gameId` | Soft-delete a game to `.trash` | `server/server.js:427` |
+| DELETE | `/api/games/:gameId/assets/:assetKey` | Remove one game upload asset | `server/server.js:435` |
+
+### Runtime (what the running game polls)
+| Method | Path | Purpose | Handler |
+| --- | --- | --- | --- |
+| GET | `/api/runtime/json/:assetKey` | Read a JSON asset for the **active game** (falls back to its scenario, then defaults). `Cache-Control: no-store` | `server/server.js:459` |
+| PUT | `/api/runtime/json/:assetKey` | Write a JSON asset for the active game (auto-creates a session if none) | `server/server.js:470` |
+| GET | `/api/runtime/pmtiles/:assetKey` | Stream the active scenario's PMTiles archive (range-capable) | `server/server.js:481` |
+| HEAD | `/api/runtime/pmtiles/:assetKey` | Size probe for the PMTiles reader (`Content-Length`, `Accept-Ranges`) | `server/server.js:490` |
+
+`assetKey` for JSON is one of `world`, `game`, `prompts`, `actions`, `advisor`, `chat`, `events`, `colors`, `flags`, `tags`, `snapshots`, `regionsGeojson`, `citiesGeojson`, `backgroundData`; for PMTiles one of `cities`, `countries`, `regions`. See [Runtime asset resolution](#runtime-asset-resolution).
+
+### AI relay, hub proxy, telemetry, shutdown
+| Method | Path | Purpose | Handler |
+| --- | --- | --- | --- |
+| POST | `/api/ai/relay` | Server-to-server relay to a player-configured OpenAI-compatible endpoint (defeats the endpoint's missing CORS). Streams status/body back; aborts upstream if the client disconnects | `server/server.js:523` |
+| POST | `/api/server/shutdown` | Stop the process from the UI's ⏻ button (acks first, then `process.exit(0)`) | `server/server.js:559` |
+| GET | `/api/hub/file?url=` | Proxy-download a community bundle from GitHub only; manual redirect-following with per-hop allowlist re-check; on-disk cache keyed by URL SHA-256 | `server/server.js:575` |
+| POST | `/api/hub/import-log` | Best-effort import telemetry; one ping per scenario per install (atomic `wx` marker), forwarded to the counter Worker | `server/server.js:657` |
+| GET | `/api/hub/import-counts` | Read import counts back from the counter Worker (60 s in-memory cache) | `server/server.js:691` |
+
+### Map editor, flags, basemaps
+| Method | Path | Purpose | Handler |
+| --- | --- | --- | --- |
+| GET | `/api/mapeditor/documents` | List map-editor doc summaries | `server/server.js:708` |
+| POST | `/api/mapeditor/documents` | Create a map-editor doc → 201 | `server/server.js:716` |
+| GET | `/api/mapeditor/documents/:id` | Full doc (regions, features, types, colors, flags) | `server/server.js:724` |
+| PUT | `/api/mapeditor/documents/:id` | Update a doc | `server/server.js:732` |
+| DELETE | `/api/mapeditor/documents/:id` | Delete a doc | `server/server.js:740` |
+| GET | `/api/flags` | List saved flags ("My flags") | `server/server.js:751` |
+| POST | `/api/flags` | Save a flag (data-URL PNG; dedup by content hash) → 201 | `server/server.js:759` |
+| DELETE | `/api/flags/:id` | Delete a saved flag | `server/server.js:767` |
+| GET | `/api/basemaps` | Basemap catalog (light metadata only) | `server/server.js:776` |
+| POST | `/api/basemaps` | Create a basemap (image or vector; dedup by hash) → 201 | `server/server.js:784` |
+| GET | `/api/basemaps/:id/payload` | Heavy payload (`{ dataUrl }` or `{ geojson }`), fetched only when applied | `server/server.js:792` |
+| DELETE | `/api/basemaps/:id` | Delete a basemap | `server/server.js:800` |
+
+### Static / SPA
+| Path | Purpose | Handler |
+| --- | --- | --- |
+| `/fmg/*` | Vendored Fantasy Map Generator (`../fmg/dist`), mounted only if it exists | `server/server.js:813-814` |
+| `/*` (files) | `express.static(dist)` | `server/server.js:816` |
+| `GET *splat` | SPA fallback → `dist/index.html` | `server/server.js:818` |
+
+---
+
+## On-disk layout: `server/data/`
+
+Every store roots its files at `DATA_DIR` (see [Portability](#portability-the-writable-data-dir)). Default `DATA_DIR = server/data`. Verified layout:
+
+```
+server/data/
+  scenario-manifest.json         # { order[], selectedScenarioId, activeScenarioId, version:2 }
+  game-manifest.json             # { order[], activeGameId, version:2 }
+  ui-settings.json               # { language }
+  scenarios/
+    <scenarioId>/
+      scenario.json              # meta (name, hero*, accentColor, coverImageContentType,
+                                 #        countryNameOverrides, hubOrigin, playCount, timestamps)
+      world.json  game.json  prompts.json   # CORE_JSON_ASSET_FILES
+      colors.json flags.json tags.json       # OPTIONAL_JSON_ASSET_FILES
+      cover-image.bin            # uploaded cover (content type in scenario.json)
+      cities.pmtiles countries.pmtiles regions.pmtiles   # per-scenario PMTiles overrides
+      regions.geojson cities.geojson background.json      # custom map geometry
+      storage/
+        actions.json advisor.json chat.json events.json   # STORAGE_JSON_ASSET_FILES
+  games/
+    <gameId>/
+      game-instance.json         # meta (+ scenarioId, lastPlayedAt, playCount)
+      world.json game.json prompts.json colors.json flags.json tags.json
+      cover-image.bin
+      storage/
+        actions.json advisor.json chat.json events.json snapshots.json
+  assets/                        # embedded-server ONLY: PMTiles fetched into OH_DATA_DIR on first run
+  basemaps/  basemaps-manifest.json
+  mapeditor-documents/  mapeditor-manifest.json
+  flags-library.json
+  lang/<code>.json               # runtime-saved translations (survive app updates)
+  hub-cache/<sha256>.body|.type  # cached hub bundle downloads
+  import-pings/<sha256>          # one-per-scenario import telemetry markers
+  .trash/<kind>-<id>[-n]/        # soft-deleted scenarios/games (recoverable by hand)
+```
+
+Key path constants live at `server/libraryStore.js:19-35`: `SCENARIOS_DIR`, `GAMES_DIR`, `SCENARIO_MANIFEST_PATH`, `GAME_MANIFEST_PATH`, `DATA_ASSETS_DIR`, plus the read-only source roots `DIST_DIR`/`PUBLIC_DIR` and `PMTILES_ASSETS_DIR = public/assets`.
+
+### Asset-file groupings (the vocabulary of `assetKey`)
+Defined at `server/libraryStore.js:240-324`. These maps drive every read/write/serve path:
+
+| Group | Keys → files | Notes |
+| --- | --- | --- |
+| `CORE_JSON_ASSET_FILES` | `world`→`world.json`, `game`→`game.json`, `prompts`→`prompts.json` | Object-shaped; always seeded |
+| `STORAGE_JSON_ASSET_FILES` | `actions`,`advisor`,`chat`,`events` → `storage/*.json` | Array-shaped |
+| `JSON_ASSET_FILES` | CORE ∪ STORAGE | Copied into every new scenario/game |
+| `OPTIONAL_JSON_ASSET_FILES` | `colors`,`flags`,`tags` → `*.json` | Static author data kept **out** of the 5 s `world.json` poll |
+| `RUNTIME_ONLY_JSON_ASSET_FILES` | `snapshots`→`storage/snapshots.json` | Roll-back points; never copied/exported |
+| `PMTILES_ASSET_FILES` | `cities`,`countries`,`regions` → `*.pmtiles` | Per-scenario binary map overrides |
+| `SCENARIO_GEOJSON_ASSET_FILES` | `regionsGeojson`→`regions.geojson`, `citiesGeojson`→`cities.geojson`, `backgroundData`→`background.json` | Custom map geometry; always embedded in bundles |
+| `*_IMAGE_ASSET_FILES` | `cover`→`cover-image.bin` | Content type recorded in meta |
+| `UPLOADABLE_SCENARIO_ASSET_FILES` | image ∪ optional-JSON ∪ PMTiles ∪ geojson | The valid `:assetKey` set for scenario upload/serve/delete |
+| `UPLOADABLE_GAME_ASSET_FILES` | just `cover` | Games only accept a cover upload |
+
+`flags`/`tags` are separate JSON assets (not fields on `world.json`) specifically because `world.json` is re-polled every 5 s and a few hundred flags would be megabytes on every poll (`server/libraryStore.js:258-270`). See [World state](world-state.md).
+
+### Manifests & catalog cache
+- A **scenario/game manifest** is `{ order: id[], selected/active, version:2 }`. `resolveOrderedIds` (`server/libraryStore.js:1097`) reconciles the manifest order against directories actually present on disk, so a hand-added or hand-deleted directory self-heals.
+- `getScenarioCatalog`/`getGameCatalog` are **memoized** (`scenarioCatalogCache`, `gameCatalogCache`, `server/libraryStore.js:427-433`). A catalog build walks every directory and parses each meta file — the 5 s `world.json` poll used to cost ~139 sync file ops just to learn the active game. The cache is invalidated wholesale inside `writeJsonFile` (`server/libraryStore.js:408-416`), the single choke point every meta/manifest write passes through, so no call site has to remember to invalidate.
+
+### First-run seeding
+`ensureScenarioStore` → `ensureDefaultScenario` (`server/libraryStore.js:1004-1055`) seeds the built-in `default` scenario **only on a true first run** (no manifest yet). The default scenario is deletable and, once deleted, stays deleted across restarts. `ensureGameStore` seeds no game — the player starts their first game from a scenario; if every game is deleted the runtime falls back to the selected scenario's data, and the first stateful write auto-creates a session (`writeRuntimeJsonAsset`, `server/libraryStore.js:2321-2340`).
+
+---
+
+## Serving assets
+
+### JSON assets
+Read as parsed objects and re-serialized. Two families:
+- **Catalog/details reads** (`getScenarioDetails`/`getGameDetails`, `server/libraryStore.js:1327-1362`) return all 7 core assets inline in the HTTP JSON body.
+- **Runtime reads** (`/api/runtime/json/:assetKey`) go through `readRuntimeJsonAsset` and emit `res.send(JSON.stringify(data))` with `Cache-Control: no-store` and `application/json` (`server/server.js:459-468`). Scenario *upload* JSON assets (`colors`, geojson) served via `/assets/:assetKey` get `application/json; charset=utf-8` so the map editor can open a scenario's own map (`resolveScenarioUploadAsset`, `server/libraryStore.js:2009-2016`).
+
+### Binary assets & PMTiles byte-range
+All binary serving funnels through **`streamBinaryFile(req, res, sourcePath, contentType)`** (`server/server.js:130-156`):
+- Sets `Accept-Ranges: bytes`, the content type, and `Cache-Control: no-store`.
+- **No `Range` header** → full file, `Content-Length` set, `fs.createReadStream(...).pipe(res)`.
+- **With `Range`** → `parseByteRange(rangeHeader, totalSize)` (`server/security.js:59-79`):
+  - unsatisfiable/empty → `416` with `Content-Range: bytes */<size>`;
+  - otherwise `206` with `Content-Length` and `Content-Range: bytes start-end/total`, streaming just that slice.
+- `parseByteRange` correctly handles suffix ranges (`bytes=-N` = final N bytes) and clamps `start`/`end`; a first-byte-position past EOF is a `416`.
+
+PMTiles are served by `resolveRuntimeBinaryAsset` (`server/libraryStore.js:2371-2403`), which resolves in priority order: **(1)** the active scenario's own `<key>.pmtiles` override → **(2)** `DATA_ASSETS_DIR` (`OH_DATA_DIR/assets`, where the embedded Android server downloads them on first run) → **(3)** the shipped `public/assets/<key>.pmtiles`. The `HEAD` route replies with size and `Accept-Ranges` without streaming, for the pmtiles reader's initial probe (`server/server.js:490-502`).
+
+Upload assets are written straight from the raw request buffer (`uploadScenarioAsset`/`uploadGameAsset`, `server/libraryStore.js:1909-1972`); the `assetKey` is validated against the uploadable set before any filesystem touch, and a cover upload also records its normalized image content type in meta (PNG/JPEG/WEBP/GIF/AVIF only, `SUPPORTED_IMAGE_CONTENT_TYPES`).
+
+---
+
+## Runtime asset resolution
+
+`readRuntimeJsonAsset(assetKey)` (`server/libraryStore.js:2218-2312`) is the heart of what a playing client sees. The resolution ladder:
+
+1. Resolve the **active game** first (`getActiveGameSummary`) and run its owner-schema migration hook (`ensureGameOwnerSchema`) — this happens *above* the geojson branch on purpose, because `regions.geojson` returns early and is where `owner` physically lives.
+2. **`SCENARIO_GEOJSON_ASSET_FILES`** keys resolve from the active game's **scenario** directory. A scenario with no `regions.geojson` of its own borrows the built-in `default` Modern Day geometry (migrated as *default's* record, not the borrowing scenario's), so every scenario renders with the custom map style; missing cities stay absent.
+3. Otherwise, prefer the **active game's** own `<assetKey>` file if it exists.
+4. Else fall back to the **active scenario's** file.
+5. Else, for optional assets, `colors` alone has a built-in fallback (the shipped 293-country palette via `resolveColorsAssetFile`); everything else is `{}`.
+6. Else the type-appropriate default (`JSON_ASSET_DEFAULTS`, `server/libraryStore.js:326-336`).
+
+`world` gets `normalizeRuntimeWorld` applied on the way out (`server/libraryStore.js:2073-2078`): if `world.customRegions` is unset it is injected `true` in the *served* payload (never written to disk), so old/fresh worlds still render with the custom style.
+
+`writeRuntimeJsonAsset(assetKey, value)` (`server/libraryStore.js:2314-2369`) always writes to the **active game** (auto-creating a session from the selected scenario if there is no active game), canonicalizes owner references first (`world` → `canonicalizeWorldCountryRefs`, `game` → `canonicalizeGameCountry`, `colors` → `canonicalizeColorKeys`), writes via `writeJsonFile`, bumps game meta, and returns the freshly re-read asset.
+
+---
+
+## Owner canonicalization & the schema-2 migration
+
+Owners are identified by **country name** ("Russia"), not GADM code ("RUS"). Two cooperating mechanisms keep that invariant; both live at the persistence boundary so no reader ever has to normalize.
+
+### Write-time canonicalization (`server/libraryStore.js:69-200`)
+`resolveOwnerRef(value, world)` resolves any author/AI/legacy reference to the canonical name, in order: **verbatim** editor polity → the scenario's own polity name/alias (with a self-name guard that prevents `{"MNG":{name:"MNG"}}` from pinning "MNG" forever) → legacy-code key → the shipped `country-names.json` registry (`code → name`, loaded once into `COUNTRY_NAME_REGISTRY`) → else the token is its own identifier. `canonicalizeWorldCountryRefs` applies it across `regionOwnershipOverrides`, `ownerCodes`, `polityOverrides` (dropping the now-redundant `.code`), `units[].ownerCode`, `countryTags`, `internationalReputation`. **A legacy (unmigrated) world is returned untouched** — canonicalizing it would destroy the migration's rule 1 and mis-name every invented polity.
+
+### The schema-2 migration (`server/ownerMigration.js`)
+A **one-time, eager, on-disk** rewrite of a code-keyed record into a name-keyed one, gated on `world.ownerSchema` (`OWNER_SCHEMA = 2`; `needsMigration` = `ownerSchema < 2`). It is not a read transform because `owner` lives in `regions.geojson`, which the read path returns before any hook, and re-walking a 55 MB FeatureCollection per poll would be ruinous.
+
+`resolveOwnerName(token, ctx)` is the ordered resolver — the obvious "each region carries owner→country so it can self-migrate" answer is **false** for presets (a preset's `ROM` spans 36 modern `country` values), hence the rules:
+
+| # | Rule | Catches |
+| --- | --- | --- |
+| 0 | Editor-marked `verbatim` polity | Human-typed name colliding with a code ("USA") |
+| 1 | Scenario's own polity name (with `name !== token` guard) | `ROM`→"Roman Empire"; skips degenerate `{"Z01":{name:"Z01"}}` |
+| 2 | Legacy per-scenario `countryNameOverrides` label (read-only, being deleted) | wwii-1939 "Siam" |
+| 3 | Shipped GADM registry | The whole modern world; the accepted disputed-territory merges (Z01→India) |
+| 4 | Consensus of the regions the token owns, **only if unanimous** | Names an FMG world's polities |
+| 5 | Token is its own identifier | Custom polities |
+
+`migrateOwnerRecordAtPaths` (`server/libraryStore.js:2095-2152`) orchestrates it: build one `renames` map (`buildOwnerRenameMap`) so a record is resolved *consistently* across all sibling files, then rewrite `colors.json`, `flags.json`, `tags.json` (`rekeyOwnerMap`, which deterministically resolves the N-tokens-collide-on-one-name merges), `regions.geojson` (`migrateRegions` — `owner` only; `country` dropped, `gid0` kept as provenance), `storage/events.json` (`migrateEvents`), `storage/chat.json` (`migrateChat`), `game.json` (`migrateGame`); **discard** roll-back `snapshots.json` (blind-restored, unmarked, would re-inject codes); and write `world.json` **last** because it carries the marker — a crash mid-migration simply redoes the record. A game migrates against **its scenario's** context (`ensureGameOwnerSchema` migrates the parent scenario first, then the game with the scenario's `countryNameOverrides` + `regions.geojson` as read-only resolver context), so one token can't mean two things inside one running game. Each record is attempted once per process via the `ownerSchemaChecked` set, with the key removed on failure so the next read retries.
+
+The mirror of this logic for the web build is `src/runtime/web/ownerMigration.js` — keep them in step. Tests: `server/ownerMigration.test.js`.
+
+---
+
+## Scenario bundles (export / import / update)
+
+Bundles are the shareable unit strangers swap on the community hub. Schema string `pax-historia-scenario-bundle/2` is the **only** compatibility gate (`version` is written and read by nobody). `ACCEPTED_BUNDLE_SCHEMAS` also accepts the unversioned v1 string — old bundles import fine and get named by the migration on first read.
+
+- **Export** — `exportScenarioBundle(id, {mode})` (`server/libraryStore.js:2477`) returns `{ schema, scenario{meta}, data{7 core assets}, assets{...}, mode, exportedAt }`. `mode: "light"` embeds cover/colors/flags/tags/geojson/background but **not** PMTiles (they're huge and reconstructable); `mode: "full"` base64-embeds the PMTiles too. Custom geometry is always embedded even in light mode — a shared custom map is broken without it.
+- **Import** — `importScenarioBundle` (`server/libraryStore.js:2529`) creates a **new** scenario, writes its core data via `updateScenario`, lays down each embedded asset via `applyScenarioBundleAsset`, then stamps `hubOrigin` last (so the import's own meta writes don't clear it) and selects it.
+- **Update-in-place** — `updateScenarioFromBundle` (`server/libraryStore.js:2635`) is the hub card's "Update" button: it keeps the local `id` (games reference scenarios by id) and `createdAt`, replaces meta/world/assets from the new bundle, and visits **every** uploadable key so an asset the new version dropped doesn't linger. `hubOrigin` is re-stamped last so the card reverts to "New Game" after refresh.
+
+`hubOrigin` (`{ postId, bundleUrl, syncedAt }`, normalized at `server/libraryStore.js:575-585`) is provenance for hub imports. **Any meta write that doesn't explicitly carry `hubOrigin` clears it** (`writeScenarioMeta`, `server/libraryStore.js:639-641`) — a local edit forks the copy and stops offering overwrites. GitHub mints a new immutable attachment URL per re-upload, so `bundleUrl` inequality is itself the update signal (and the reason `/api/hub/file`'s disk cache can never go stale). See [Scenario hub](scenario-hub.md).
+
+---
+
+## Security & path safety
+
+`server/security.js` holds the pure, unit-tested guards (`server/security.test.js`):
+
+| Helper | Guarantees |
+| --- | --- |
+| `resolveChildPath(baseDir, name, label)` | `name` must resolve to a **direct child** of `baseDir` — rejects `../`, path separators (incl. the `%2f` Express decodes to `/`), and absolutes. Used by `getScenarioDirectory`/`getGameDirectory` and by every store's `docPath`/`metaPath`/`payloadPath`, so a route `:id` can't escape the data dir. Re-exported in `libraryStore.js` as `resolveWithinDirectory`. |
+| `crossOriginWriteAllowed({method,origin,host,remoteAddress,allowAll})` | The CSRF guard. Allows safe methods (GET/HEAD/OPTIONS); same-origin writes (`Origin` host === `Host`); and no-`Origin` writes **only from loopback**. A foreign `Origin`, or a no-`Origin` write from a non-loopback host, is `403`. Bypass with `OH_ALLOW_CROSS_ORIGIN=1`. Without it, the blanket CORS (needed so the Android connect screen can *probe*) would otherwise let any visited web page POST/DELETE to `localhost`. |
+| `isLoopbackAddress(addr)` | Unwraps IPv4-mapped IPv6 (`::ffff:127.0.0.1`); true for `::1`, `127.*`. |
+| `parseByteRange(header, size)` | Range parsing for `streamBinaryFile` (above). |
+| `isAllowedHubUrl(url, hosts)` | A hub download must be **https** and either on the fixed GitHub host set or any `*.githubusercontent.com`. Checked on the initial URL **and every redirect hop** in `/api/hub/file`, which follows redirects manually (`redirect: "manual"`) so a `github.com → attacker` redirect can't cause SSRF. |
+
+Additional hardening in the stores: content hashes for basemaps/flags are **always computed server-side** — trusting a client hash would let a caller poison the dedup index so a later genuine upload is silently discarded (`server/basemapStore.js:104-110`, `server/flagStore.js:33-35`). Deletes are **soft** (`moveDirectoryToTrash`, `server/libraryStore.js:1804-1842`) with a Windows-specific retry-then-copy fallback for locked directories.
+
+---
+
+## Portability: the writable data dir
+
+`server/dataDir.js` is the whole portability story:
+
+```js
+export const DATA_DIR = process.env.OH_DATA_DIR
+  ? path.resolve(process.env.OH_DATA_DIR)
+  : path.join(__dirname, "data");   // server/data
+```
+
+Every store imports this one constant, so a single env var relocates **all** writable state. Desktop and Termux leave it unset and use `server/data` (byte-identical to how they've always worked). The **embedded Android server** runs `server.js` in-process via `nodejs-mobile`, where the `server/data` shipped inside the APK is **read-only**; the app sets `OH_DATA_DIR` to a writable sandbox path, seeds first-run defaults there, and downloads PMTiles into `OH_DATA_DIR/assets` (which `resolveRuntimeBinaryAsset` prefers over the read-only shipped copies). Shipped-but-updatable content (`dist|public/lang/*.json`) stays under the app root and is *merged under* the writable `DATA_DIR/lang/*.json`, so runtime translations survive app updates that overwrite the app root.
+
+### Environment variables
+| Var | Default | Effect |
+| --- | --- | --- |
+| `PORT` | `3000` | Listen port (`server/server.js:61`) |
+| `OH_DATA_DIR` | `server/data` | Writable data root for every store (`server/dataDir.js`) |
+| `OH_ALLOW_CROSS_ORIGIN` | unset | `=1` disables the cross-origin-write guard (`server/server.js:111`) |
+| `OH_IMPORT_COUNTER_URL` | `https://oh-import-counter.…workers.dev` | Import-telemetry counter Worker; empty string disables pings (`server/server.js:653`) |
+
+Related sibling pages: [World state](world-state.md) · [Map editor](map-editor.md) · [Scenario hub](scenario-hub.md).

--- a/docs/web-build.md
+++ b/docs/web-build.md
@@ -1,0 +1,365 @@
+# Web Build (openhistoria.com)
+
+The web build is the browser-only edition of Open Historia served from the trusted central origin (openhistoria.com / the `/play/` site). It runs the **entire game client unchanged** with **zero server**: a `window.fetch` interceptor answers every same-origin `/api/*` call out of IndexedDB, heavy map tiles stream from a Cloudflare Worker proxy (or a hash-verified community node swarm), and optional magic-link/Google accounts sync your games as client-side-encrypted blobs. Everything in this page lives under `src/runtime/web/` and ships **only** in the web build — it is dynamically imported behind `import.meta.env.VITE_OH_WEB` so it is dead-code-eliminated from the local desktop/APK download, which keeps its real same-origin Express server.
+
+See also: [Server build](server-build.md) (the Express store this mirrors), [World state](world-state.md), [Assets & PMTiles](assets.md), [Scenario & game library](library.md), [Community hub](community-hub.md).
+
+---
+
+## 1. How it boots and how it is gated
+
+The whole web backend is behind one Vite mode flag. `.env.web` sets `VITE_OH_WEB=1`, and that file is loaded **only** by `vite build --mode web`. The normal `npm run build` never sees it, so `import.meta.env.VITE_OH_WEB` is `undefined` there and every `if (import.meta.env.VITE_OH_WEB)` branch — plus the dynamic imports it guards — is stripped by tree-shaking.
+
+| Step | Location | What happens |
+|---|---|---|
+| Gate | `src/main.jsx:28` | `if (import.meta.env.VITE_OH_WEB)` dynamically `import("./runtime/web/index.js")`, calls `installWebBackend()`, then `mount()`s the React app. Non-web builds just `mount()`. |
+| Entry | `src/runtime/web/index.js` | `installWebBackend()` — seed → install interceptor → accounts/sync → home page. |
+| Content fetch | `src/runtime/assets.js:855` | For pmtiles, dynamically imports `web/contentTrust.js` and tries `fetchVerifiedBuffer(url)` (node swarm) before the origin. |
+
+`installWebBackend()` (`src/runtime/web/index.js`) runs, in order:
+
+1. `await ensureSeeded()` — write the default scenario into IndexedDB before any `/api` call (`libraryStore.js`).
+2. `installWebApiRouter()` — monkey-patch `window.fetch` (`router.js`).
+3. If the URL carries `?magic=<token>`, `redeemMagicToken()` then race a `syncNow()` (12 s cap) **before first render** so a signed-in user's games are already present, then strip the token from the URL with `history.replaceState`.
+4. `initAccountWidget()` — the corner sign-in/sync chip (`accountWidget.js`).
+5. If `shouldShowHome()` (not yet "entered" this tab session) → `showHomePage()`; otherwise `connectBestNode()` in the background.
+
+Build scripts (`package.json`):
+
+| Script | Command |
+|---|---|
+| `build:web` | `node scripts/seed-web-defaults.mjs && vite build --mode web --outDir dist-web --emptyOutDir` |
+| `build:site` | same, but `--base /play/` + `scripts/assemble-site.mjs` (the GitHub-Pages parchment landing site wraps `/play/`). |
+
+`scripts/seed-web-defaults.mjs` regenerates `src/runtime/web/generated/defaultScenario.js` (auto-generated; the default scenario's meta + colors + base64 cover) so the seed is baked into the bundle.
+
+---
+
+## 2. Configuration (`.env.web`)
+
+Every URL points at the **registry Worker** (`open-historia-registry.nichojkrol.workers.dev`), which is the one piece of always-on server infrastructure.
+
+| Var | Value / default | Purpose | Read in |
+|---|---|---|---|
+| `VITE_OH_WEB` | `1` | Master flag; gates all web-mode code + dynamic imports. | `main.jsx`, `assets.js`, `libraryBar.jsx`, `settings.jsx` |
+| `VITE_OH_PMTILES_URL` | Worker `/content` | CORS+range proxy for the 60–100 MB pmtiles (Cloudflare Pages caps at 25 MB/file). Also the base for `default-regions.geojson`. Falls back to `/assets` (local dev). | `router.js:55`, `libraryStore.js:325` |
+| `VITE_OH_DIRECTORY_URL` | Worker `/node-directory.json` | The **signed** live node directory (updates as nodes are accepted/paused/banned). | `contentTrust.js:17` |
+| `VITE_OH_HUB_URL` | Worker root | Community-hub GitHub proxy (`/hub/*`), because GitHub attachments send no CORS. | `router.js:109` |
+| `VITE_OH_ACCOUNT_URL` | Worker root | Accounts (`/account/*`) + encrypted sync (`/sync/*`). | `account.js:11` |
+| `VITE_OH_GOOGLE_CLIENT_ID` | Google OAuth client id | Public client id for "Sign in with Google". Empty ⇒ Google button hidden (accounts effectively disabled). | `account.js:77` |
+| `VITE_OH_MANIFEST_URL` | *(unset)* → `/content-manifest.json` | Signed asset→hash manifest; ships with the build, same-origin default. | `contentTrust.js:18` |
+
+---
+
+## 3. The fake backend: the `/api` fetch interceptor (`router.js`)
+
+There is no Express server. `installWebApiRouter()` (`router.js:138`) replaces `window.fetch` once (`installed` guard). The wrapper:
+
+- Resolves the request URL against `location.href`. **Only** same-origin requests whose path starts with `/api/` are intercepted; everything else (AI providers, GitHub API, ESRI tiles, static assets, Google Identity, node URLs) passes straight to the saved `originalFetch`.
+- Builds a real `Request`, dispatches to `route(request, url)`, and returns a real `Response` — so all the existing client code (`src/runtime/library.js`, `src/runtime/assets.js`, `documentIO.js`, `basemapLibrary.js`) runs **unchanged**.
+- On throw: `SyntaxError` (bad JSON body) → `400`, anything else → `500` (mirrors Express body-parser behavior).
+
+> **Important boundary:** only `window.fetch` is patched. `<img src>`, `<link>`, XHR, `EventSource`, and PMTiles' own range reads that don't go through `fetch` all **bypass** the interceptor. This is exactly why cover images are embedded as `data:` URLs (see §6) rather than served as `/api/...` paths.
+
+### `route()` dispatch
+
+`route()` (`router.js:38`) splits the path into `["api", domain, ...segments]` and dispatches on `domain`. Each handler returns a `Response` or `null` (fall through).
+
+| `domain` (+ path shape) | Handler | Store file |
+|---|---|---|
+| `runtime/pmtiles/<key>` | inline (scenario override → else proxy) | `libraryStore.getScenarioPmtilesOverride` |
+| `runtime/json/<key>` | `handleRuntimeJson` | `libraryStore.js:1110` |
+| `mapeditor/*` | `handleMapEditor` | `editorStore.js` |
+| `basemaps/*` | `handleBasemaps` | `basemapStore.js` |
+| `flags/*` | `handleFlags` | `flagStore.js` |
+| `library` | `handleLibrary` | `libraryStore.js:1036` |
+| `scenarios/*` | `handleScenarios` | `libraryStore.js:1042` |
+| `games/*` | `handleGames` | `libraryStore.js:1076` |
+| `ui-settings/*` | `handleUiSettings` | `settingsStore.js:82` |
+| `lang/*` | `handleLang` | `settingsStore.js:44` |
+| `hub/*` | inline proxy → Worker / node | (see below) |
+| *(anything else)* | `errorResponse("Unknown web-mode endpoint", 404)` | `util.js` |
+
+### Body handling (`readBody`, `router.js:20`)
+
+- `GET`/`HEAD` → no body.
+- **Asset uploads** (`isAssetUpload`: `scenarios`|`games` + an `assets` segment + `PUT`) are forced to **raw bytes** regardless of `Content-Type`, because colors/geojson arrive as `application/json` but must be stored **verbatim** (the server's `express.raw` does the same).
+- Otherwise: `application/json` → `JSON.parse`; everything else → raw `Uint8Array`.
+
+### The two branches that are *not* pure IndexedDB
+
+- **`runtime/pmtiles/<key>`** (`router.js:51`): first ask `getScenarioPmtilesOverride(key, range)` (a scenario may carry its own pmtiles in IndexedDB); otherwise proxy `${VITE_OH_PMTILES_URL||/assets}/<key>.pmtiles` with the incoming `Range`/method.
+- **`hub/*`** (`router.js:108`): forward to `${VITE_OH_HUB_URL}/hub/<segments>`. For a bundle download (`hub/file?url=…`, GET) it **prefers the connected content node** (`getConnected()` → `node.url/oh/v1/hub`) to offload the central proxy, falling back to the Worker. `POST`s (import counters) attach `Authorization: Bearer <session>` when signed in so imports dedup by **account** instead of by IP.
+
+---
+
+## 4. IndexedDB layer (`idb.js`)
+
+A dependency-free promise wrapper. Database `open-historia-web`, `DB_VERSION = 2`. Adding a store means bumping the version; `onupgradeneeded` creates only what is missing (additive — nobody's data is touched). An `onversionchange` handler closes this connection when another tab opens a newer version, so a second tab's upgrade isn't blocked.
+
+| Store (`STORES`) | keyPath | Mirrors server on-disk store |
+|---|---|---|
+| `scenarios` | `id` | one record per scenario (meta + json + assets) |
+| `games` | `id` | one record per game |
+| `mapeditorDocs` | `id` | map-editor documents |
+| `basemapMeta` | `id` | basemap metadata |
+| `basemapPayload` | `id` | basemap binary payloads |
+| `flags` | `id` | flag records |
+| `kv` | `key` | small singletons (manifests, ui-settings, `seeded`, sync versions, account session/DEK) |
+
+Helpers: `idbGet`, `idbGetAll`, `idbPut`, `idbDelete`, `idbUpdate` (read-modify-write one record), and kv-specific `kvGet(key, fallback)`, `kvPut`, `kvUpdate`. `runTx` resolves on transaction **commit** (via `oncomplete`), not merely on request success, so writes are durable before a caller reads back.
+
+---
+
+## 5. The library store (`libraryStore.js`) — the heart of the fake backend
+
+A byte-faithful browser port of `server/libraryStore.js`. Backs `/api/library`, `/api/scenarios*`, `/api/games*`, `/api/runtime/json*`, `/api/runtime/pmtiles*`.
+
+### Record shapes (all live in one IndexedDB record)
+
+```
+scenario:  { id, meta, json:{actions,advisor,chat,events,game,prompts,world},
+             colors?, flags?, geojson:{regionsGeojson,citiesGeojson,backgroundData},
+             pmtiles:{cities,countries,regions}, cover?:{contentType,bytes} }
+game:      { id, meta, json:{…7…}, colors?, flags?, snapshots?, cover?:{contentType,bytes} }
+```
+
+Unlike the server (which splits a scenario across many files on disk), a web record holds `world`/`game`/`colors`/`geojson` together, so owner migration is **synchronous and in-place** — nothing to keep in step across files.
+
+### Manifests (in `kv`)
+
+| kv key | Shape | Meaning |
+|---|---|---|
+| `scenario-manifest` | `{ order[], selectedScenarioId }` | scenario order + which is selected |
+| `game-manifest` | `{ activeGameId, order[] }` | game order + which is active |
+| `seeded` | `boolean` | one-time seed flag |
+
+### Catalog composition
+
+- `getLibraryCatalog()` (`:245`) is what `/api/library` returns: `{ activeGame, activeGameId, activeScenarioId, countryNames, games, runtimeScenario, scenarios, selectedScenario, selectedScenarioId, token }`. `token` is a cache key combining the active game's + runtime scenario's `updatedAt`.
+- `getScenarioCatalog()` / `getGameCatalog()` compose per-item summaries (spread `readScenarioMeta`/`readGameMeta`, `assetStatus`, `cacheToken = ${id}-${updatedAt}`, `coverImageUrl`, usage counts). Order comes from `resolveOrderedIds` (manifest order, then extras, default id unshifted first).
+- A game summary also carries `country`, `currentDate`, `round`, `eventCount`, `pendingActions` (non-`resolved` actions), `scenarioName`, `scenarioAccentColor`, and both `coverImageUrl` (own → falls back to its scenario's) and `ownCoverImageUrl`.
+
+### Runtime JSON read/write (what the running game hits every turn)
+
+`readRuntimeJsonAsset(key)` (`:416`) resolves an asset by precedence: **active game record → active runtime scenario → fallback default**. Special cases:
+
+- `SCENARIO_GEOJSON_ASSET_KEYS` (`regionsGeojson`/`citiesGeojson`/`backgroundData`) come from the scenario; a scenario without its own `regionsGeojson` **borrows Modern Day's** (migrated as *default's* record, since those owners live in default's owner-space).
+- The default scenario's `regionsGeojson` (~12 MB) is **not** in the seed — `fetchDefaultRegionsGeojson()` (`:327`) pulls `${VITE_OH_PMTILES_URL}/default-regions.geojson` once per session (never pinning an empty/failed result, so a transient miss retries). Without it the political map renders blank.
+- `colors` falls back to the immutable app palette (`generated/fallbackColors.js`), **not** the mutable default-scenario colors.
+
+`writeRuntimeJsonAsset(key, value)` (`:481`) writes onto the active game (auto-creating one from the selected scenario if none exists), canonicalizing country refs on the way in: `world`→`canonicalizeWorldCountryRefs`, `game`→`canonicalizeGameCountry`, `colors`→`canonicalizeColorKeys`. `flags` are **not** canonicalized (a flag key is always the raw code the editor painted).
+
+### Owner-schema migration (`ensureOwnerSchema`, `:357`)
+
+Rewrites a record whose owners are GADM codes into one keyed by country **names**. It *imports* `server/ownerMigration.js` (pure ESM, so Vite bundles it) rather than re-implementing it — one resolver, no drift. Runs lazily on read, once per `kind:id` (`migratedRecords` set), and discards roll-back `snapshots` (they predate the rename and are blind-written back with no staleness marker).
+
+### Export / import bundles
+
+- `exportScenarioBundle(id, mode)` (`:858`) — `mode:"light"` drops pmtiles overrides; `"full"` embeds them base64. Schema `pax-historia-scenario-bundle/2`.
+- `importScenarioBundle` / `updateScenarioFromBundle` accept any schema in `ACCEPTED_BUNDLE_SCHEMAS` (v1 + v2). Note the **JSON-descriptor gotcha** (`:915`): `colors`/`flags`/`tags` descriptors carry the **object itself** in `descriptor.data`, not base64 — passing them through `base64ToBytes` (as geojson/pmtiles do) made `atob` throw and broke import of every flag/tag-carrying preset (e.g. WWII).
+- Hub provenance (`hubOrigin = { postId, bundleUrl, syncedAt }`) is stamped **last** and survives only when a write explicitly carries it — any other meta write forks the copy and stops offering hub updates.
+
+### Seeding (`ensureSeeded`, `:1024`)
+
+If the `seeded` kv flag is unset and no `default` scenario exists, write `defaultScenarioSeedRecord()` (built from `generated/defaultScenario.js`: meta, colors, base64 cover) and add it to the manifest. Idempotent.
+
+---
+
+## 6. Cover images — and why they differ from the server
+
+`COVER_IMAGE_ASSET_KEY = "cover"`; a cover is stored on the record as `{ contentType, bytes:Uint8Array }`. The **displayed** cover in a catalog summary differs by build:
+
+| | Server build | Web build |
+|---|---|---|
+| `coverImageUrl` value | a **fetchable path** via `buildScenarioAssetUrl(id,"cover",token)` → `/api/scenarios/:id/assets/cover?token=…` (`server/libraryStore.js:1173`) | a **base64 `data:` URL** via `coverDataUrl(record.cover)` (`libraryStore.js:60`, used at `:181`, `:222`, `:229`) |
+
+**Why:** the library UI renders the cover in an `<img src>`. On the server that `src` is a normal HTTP URL the browser fetches directly. In the web build there is no server, and — critically — an `<img>` load does **not** pass through the patched `window.fetch`, so a `/api/scenarios/:id/assets/cover` `src` would hit the network and 404 to the SPA fallback instead of reaching the interceptor. Embedding the bytes as a `data:<contentType>;base64,…` URL makes the image render with **zero network round-trip**, straight from the IndexedDB record. (The interceptor *does* still serve a direct `GET /api/scenarios/:id/assets/cover` — `scenarioAssetResponse`, `:817` — for code paths that go through `fetch`, e.g. export; it's only the `<img>` display path that needs the data URL.)
+
+Cover uploads/removals (`uploadScenarioAsset`/`uploadGameAsset`, `:783`/`:838`) validate the content-type against `SUPPORTED_IMAGE_CONTENT_TYPES` (avif/gif/jpeg/png/webp) and mirror the bytes + `coverImageContentType` meta.
+
+---
+
+## 7. Store models & country resolution (`models.js`)
+
+A faithful mirror of the constants and pure helpers in `server/libraryStore.js`.
+
+### Asset-key sets
+
+| Set | Members |
+|---|---|
+| `STORAGE_JSON_ASSET_KEYS` | `actions, advisor, chat, events` |
+| `CORE_JSON_ASSET_KEYS` | `game, prompts, world` |
+| `OPTIONAL_JSON_ASSET_KEYS` | `colors, flags, tags` |
+| `PMTILES_ASSET_KEYS` | `cities, countries, regions` |
+| `SCENARIO_GEOJSON_ASSET_KEYS` | `regionsGeojson, citiesGeojson, backgroundData` |
+| `UPLOADABLE_SCENARIO_ASSET_KEYS` | `cover` + optional + pmtiles + geojson |
+| `UPLOADABLE_GAME_ASSET_KEYS` | `cover` only |
+
+`SCENARIO_BUNDLE_SCHEMA = "pax-historia-scenario-bundle/2"` — the **only** compatibility gate on a file strangers swap; the schema string moves with the owner rename so an old build can't silently mis-resolve a name-keyed bundle.
+
+### `resolveOwnerRef(value, world)` (`:87`)
+
+Resolves an owner token to its canonical **name**. Precedence:
+
+1. A `polityOverrides[value]` marked `verbatim` (a human-named polity whose text collides with a GADM code like "USA") → honored literally.
+2. Any polity whose `name`/`aliases`/key matches (case-insensitive), skipping self-named entries so `{MNG:{name:"MNG"}}` doesn't pin `MNG` forever.
+3. `COUNTRY_NAME_REGISTRY[value]` (legacy code or alias → name).
+4. Otherwise the raw value.
+
+`canonicalizeWorldCountryRefs` / `canonicalizeGameCountry` / `canonicalizeColorKeys` apply it across `regionOwnershipOverrides`, `ownerCodes`, `polityOverrides` (rekeyed by name, `.code` dropped), `units`, `countryTags`, `internationalReputation`, and color/game country fields. `readScenarioMeta`/`readGameMeta` apply defaults + normalize `coverImageContentType`, `hubOrigin`, `playCount`, `lastPlayedAt`.
+
+---
+
+## 8. Heavy content: PMTiles, the node swarm, and the trust model
+
+Heavy map tiles never touch IndexedDB by default; they stream from the network. Integrity comes from **hashes and signatures, never from trusting a node**.
+
+### The fetch path (`assets.js` → `contentTrust.js`)
+
+`assets.js:855` (web only): for a pmtiles URL, try `fetchVerifiedBuffer(url)` first; on any miss/failure fall through to the origin (via `router.js`'s pmtiles proxy branch → the Worker). A node outage is therefore invisible.
+
+`fetchVerifiedBuffer(url)` (`contentTrust.js:122`):
+
+1. Map the URL to a content-manifest asset id (`countries.pmtiles`, etc.).
+2. Load the **signed** content manifest (asset→`{sha256,bytes}`) and the active node list.
+3. For each candidate node (connected node first, then a per-asset rotation): `GET <node>/oh/v1/content/<sha256>`, reject on wrong byte length, **recompute SHA-256 and compare** — a tampered node is skipped with a warning.
+4. Return the verified `ArrayBuffer`, or `null` so the caller uses the canonical origin.
+
+### Node directory: signed control doc + live addresses
+
+`loadDirectoryNodes()` (`contentTrust.js:88`) combines two sources:
+- The **signed** directory (`VITE_OH_DIRECTORY_URL`) — an auto-accept **deny-list / control doc**: nodes marked `banned`/`paused` are excluded and rate-limit/cap overrides applied.
+- The **unsigned** live list (`nodes-live.json`, same origin) — actual current URLs (`{id,url,status}`), so a node restarting on a new URL needs no admin re-sign.
+
+Because every byte is hash-verified, an un-vetted node can at worst be useless; a bad actor is removed by an admin ban published to the signed directory.
+
+### Signature verification (`trust.js` + `trust/pinned-key.js`)
+
+`fetchSignedJson(url)` (`trust.js:41`) fetches `url` and `url.sig`, verifies the **detached Ed25519 signature over the exact served bytes** against the pinned root key(s), and enforces `keyid` + `expires`. Returns `{valid, data, reason}`; any of unsigned / bad-signature / expired / keyid-unknown ⇒ `valid:false` and the client simply **doesn't use nodes** and falls back to the origin — a broken trust chain degrades safely.
+
+- `verifyDetached` uses `@noble/ed25519`.
+- `PINNED_ROOT_KEYS` (`trust/pinned-key.js`) — currently one key `oh-root-1` — is compiled into both the client and the node software; the private key is offline. Rotation = ship both keys for one release, then drop the old one.
+
+### Connecting to a node (`nodeConnect.js`)
+
+`connectBestNode()` (`:89`) probes every directory node's `/oh/v1/status` (4 s timeout), picks reachable + `active` + not `full` with the **lowest latency**, and makes content fetches prefer it (`setPreferredNode`).
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/oh/v1/status` | GET | probe: liveness, region, user counts, `full` |
+| `/oh/v1/ping` | GET | count toward the node's live user tally; heartbeat health check |
+| `/oh/v1/leave` | GET (keepalive, `pagehide`) | drop out of the node's player count immediately |
+| `/oh/v1/content/<sha256>` | GET | fetch a hash-addressed content blob |
+| `/oh/v1/hub?url=…` | GET | node-served community bundle download |
+
+A 20 s heartbeat re-selects a node if the current one goes draining/full/unreachable. `reportPresence(nodeId)` (`account.js:48`) tells the **registry** (not the node) which node a **signed-in** player is on so the admin panel can show connectivity — a node itself never learns a player's identity; signed-out players report nothing.
+
+---
+
+## 9. Home / connect screen (`homePage.js`)
+
+A full-screen parchment/Roman overlay injected over the already-mounted game on first entry per tab session (`sessionStorage["oh:entered"]`). Pure DOM (no React), scoped under `.oh-home`. It auto-connects the best node and renders live stats.
+
+| Control | Behavior |
+|---|---|
+| Connection panel | "Finding the nearest node…" → connected node card (**anonymous node id only**, region, latency, `players/max` bar) or "Connected via the origin" fallback. Fed by `connectBestNode()` → `renderConnection`. |
+| Account section | Google sign-in button (via Google Identity Services), or "Signed in as …" + Sign out. Hidden if `!accountConfigured()` or no `googleClientId()`. |
+| **⚔ Enter Open Historia** | `enter()` — sets the `oh:entered` flag and removes the overlay. |
+| Footer links | GitHub, Discord, Host a node. |
+
+---
+
+## 10. Accounts + end-to-end-encrypted sync
+
+Optional, web-only. The registry Worker only ever stores **ciphertext** and the wrapped data key — it never sees plaintext saves.
+
+### `account.js` — identity + client crypto
+
+- **Session** lives in `kv` (`account:session`) so it survives reloads; email in `account:email`; the raw 32-byte **DEK** cached in memory + `kv` (`account:dek`), **never uploaded** in the clear.
+- Sign-in: magic link (`requestMagicLink` → email; `redeemMagicToken` from `?magic=`) or Google (`signInWithGoogle` hands the GIS credential to `/account/google`). Both establish a session then `ensureDek(session, hasKey)`.
+- `ensureDek`: existing account → pull the DEK from `/account/key`; first sign-in ever → generate `crypto.getRandomValues(32)` and register it. The Worker stores it wrapped under (a) the **offline admin master key** (recovery) and (b) a Worker secret (cross-device delivery).
+- **Crypto:** `encryptRecord`/`decryptRecord` are AES-256-GCM to/from `base64(iv‖ciphertext)`. `encodeRecord`/`decodeRecord` preserve binary fields (`Uint8Array`/`ArrayBuffer` → `{__u8:base64}`) so a full record with cover/pmtiles bytes round-trips through JSON.
+- **Fingerprint:** `recordFingerprint` hashes a `syncHashView` that **excludes** `lastPlayedAt`/`playCount` (`VOLATILE_META_FIELDS`) — merely *opening* a game bumps those, and hashing them would re-upload heavy blobs for a stat tick nobody edited. The ciphertext still encodes the full record, so stats ride along on the next genuine edit.
+
+### `sync.js` — the reconciliation engine
+
+Full-scan model (compare local SHA-256 vs last-synced version), so no write can be missed. **v1 scope = games + scenarios + their catalog manifests** (map-editor docs and basemaps wait for R2). Each record → one blob (`games:<id>`, `scenarios:<id>`, `kv:<manifest>`).
+
+- `syncNow()` (`:128`) runs `pull` then `push`, persisting `sync:versions` (`{blob_id:{version,sha?,deleted?}}`, device-local, never synced). Emits `oh:sync` events (`syncing`/`ok`/`error`) — but only flashes "Syncing…" once **real** work starts, so an empty 20 s poll doesn't look like a phantom upload.
+- `pull`: apply any server blob newer than known version (decrypt → `idbPut`/`kvPut`), or tombstone deletions. A single bad blob is caught per-item so it can't red-line the whole sync.
+- `push`: upload locally-changed records (`sha` differs); on **409 conflict** it's **last-writer-wins = take the server copy**; `413` = too large (waits for R2); then tombstone records gone locally.
+- `startSync()` runs `syncNow` immediately, every 20 s, and on tab `visibilitychange`→hidden.
+
+### Transport endpoints (session-authed, `Bearer <session>`)
+
+| Endpoint | Method | Returns |
+|---|---|---|
+| `/account/request` | POST | send magic link (`{ok, devLink?}`) |
+| `/account/verify` | POST | `{email, session, hasKey}` |
+| `/account/google` | POST | `{email, session, hasKey}` |
+| `/account/key` | GET / POST | fetch / register the DEK |
+| `/account/presence` | POST | report `{nodeId}` (admin visibility) |
+| `/sync/manifest` | GET | `[{blob_id, version, deleted}]` |
+| `/sync/blob?id=` | GET | `{ciphertext, sha256, version, deleted}` |
+| `/sync/blob?id=` | PUT | `200 {version}` \| `409 {conflict,current}` \| `413` |
+| `/sync/blob?id=` | DELETE | tombstone |
+
+### `accountWidget.js` — the corner chip
+
+A fixed top-right sign-in/sync control (DOM, not React). A colored dot shows sync state (idle/ok=green/syncing=amber/error=red); the panel offers Google sign-in when signed out, or **Sync now** / **Sign out** when signed in. Listens for `oh:sync` (status) and `oh:auth` (start/stop `startSync`) events.
+
+---
+
+## 11. Secondary stores (brief)
+
+The interceptor also answers these through the same `ctx` handler pattern (return `Response` or `null`):
+
+| Domain | Handler | Notes |
+|---|---|---|
+| `mapeditor/*` | `handleMapEditor` (`editorStore.js`) | map-editor documents in the `mapeditorDocs` store |
+| `basemaps/*` | `handleBasemaps` (`basemapStore.js`) | basemap meta + payload (two stores) |
+| `flags/*` | `handleFlags` (`flagStore.js`) | flag records |
+| `ui-settings/*` | `handleUiSettings` (`settingsStore.js:82`) | UI settings persisted in `kv` |
+| `lang/*` | `handleLang` (`settingsStore.js:44`) | language packs: IndexedDB overrides merged over the static `/lang/*.json` Vite copies to the site |
+
+---
+
+## 12. Key differences vs the server build
+
+| Aspect | Server build | Web build |
+|---|---|---|
+| Backend | real Express server, same-origin | `window.fetch` interceptor (`router.js`), no server |
+| Persistence | files on disk (`server/libraryStore.js` etc.) | one IndexedDB record per item (`idb.js`) |
+| Record layout | scenario split across many files | `world`/`game`/`colors`/`geojson`/`cover` in **one** record |
+| Owner migration | must keep files in step; async | synchronous, in-place; **imports** `server/ownerMigration.js` |
+| Cover image URL | fetchable `/api/.../assets/cover?token=` | base64 `data:` URL (bypasses the fetch interceptor) — see §6 |
+| PMTiles hosting | served by the server | Worker CORS+range proxy + hash-verified node swarm; default `regions.geojson` fetched from the content origin, not seeded |
+| Default scenario | full data on disk | seeded from `generated/defaultScenario.js`; big geometry fetched on demand |
+| Accounts / sync | n/a | magic-link/Google + AES-256-GCM E2E sync (`account.js`/`sync.js`) |
+| Community bundle download | direct | proxied via Worker `/hub/file` or a connected node (CORS) |
+| Code shipped | this whole tree stripped out | this whole tree, behind `VITE_OH_WEB` |
+
+---
+
+### File index
+
+| File | Role |
+|---|---|
+| `src/runtime/web/index.js` | boot entry (`installWebBackend`) |
+| `src/runtime/web/router.js` | `/api` fetch interceptor + dispatch |
+| `src/runtime/web/idb.js` | IndexedDB primitives + `STORES` |
+| `src/runtime/web/libraryStore.js` | scenarios/games/runtime store + handlers |
+| `src/runtime/web/models.js` | constants, `resolveOwnerRef`, meta readers |
+| `src/runtime/web/util.js` | response builders, base64, SHA-256, range serving |
+| `src/runtime/web/account.js` | session, DEK, AES-GCM, sync transport |
+| `src/runtime/web/sync.js` | pull/push reconciliation engine |
+| `src/runtime/web/accountWidget.js` | corner sign-in/sync chip |
+| `src/runtime/web/homePage.js` | entry/connect overlay |
+| `src/runtime/web/contentTrust.js` | verified node-swarm content fetch |
+| `src/runtime/web/trust.js` | Ed25519 signed-manifest verification |
+| `src/runtime/web/nodeConnect.js` | node selection + heartbeat + presence |
+| `src/runtime/web/settingsStore.js` | ui-settings + language handlers |
+| `src/runtime/web/basemapStore.js` / `flagStore.js` / `editorStore.js` | secondary store handlers |
+| `trust/pinned-key.js` | pinned root public key(s) |
+| `.env.web` | web-mode build config |

--- a/docs/world-state.md
+++ b/docs/world-state.md
@@ -1,0 +1,251 @@
+# World State & Turn Model
+
+Open Historia keeps a running game in five plain-JSON documents served from a per-scenario/per-game runtime endpoint. The largest and most important is **`world.json`** — the political map plus everything the AI has changed since the scenario began (region ownership, polities, colors, tags, reputation, units, structures, catalyst, history). The **turn loop** is a "time jump": the AI returns a batch of `events`, each carrying machine-readable `impacts`, and `applyEventImpactsToWorld` folds those impacts into world state before it is persisted; the map re-renders because `useWorldState` polls `world.json` every 5 seconds.
+
+Core files: `src/runtime/gameState.js` (state shape, normalizers, impact application), `src/Game/Map/useWorldState.js` (the poll), `src/Game/Map/unitsController.js` (the units peer-poll), `src/runtime/countryTags.js` (tag rules), `src/runtime/assets.js` (read/write/cache plumbing), `src/Game/AI/gameplay.js` (`applySimulationResult`, the turn writer).
+
+Related pages: [Country tags](country-tags.md) · [Map rendering & Nations layer](nations-layer.md) · [Units & combat](units.md) · [AI turn / time jump](ai-turn.md) · [Scenario library](library.md).
+
+---
+
+## 1. Storage model: the runtime JSON assets
+
+All mutable game state lives behind a small set of URLs built in `src/runtime/assets.js:63` (`JSON_URLS`) and rebuilt on every scenario/game switch by `setRuntimeAssetEndpoints` (`src/runtime/assets.js:204`). Each URL carries a `?v=<token>` cache-buster; changing the token (a library mutation) sweeps the in-memory value caches so the next read re-fetches (`src/runtime/assets.js:218`).
+
+| Asset key | URL (path) | Read / write helpers (`gameState.js`) | Holds |
+|---|---|---|---|
+| `world` | `/api/runtime/json/world` | `readWorldState` / `writeWorldState` (`:985`,`:988`) | The political map + AI-mutated state (this page). |
+| `game` | `/api/runtime/json/game` | `readGameData` / `writeGameData` (`:997`,`:1000`) | Player country, clock, round, difficulty (§6). |
+| `events` | `/api/runtime/json/events` | `readEventsState` / `writeEventsState` (`:1009`,`:1012`) | Timeline of AI/scenario events, each with `impacts`. |
+| `actions` | `/api/runtime/json/actions` | `readActionsState` / `writeActionsState` (`:1003`,`:1006`) | Player/queued orders awaiting the next jump. |
+| `chat` | `/api/runtime/json/chat` | `readChatsState` / `writeChatsState` (`:1019`,`:1022`) | Diplomacy conversation threads. |
+| `colors` | `/api/runtime/json/colors` | plain `writeJson(JSON_URLS.colors, …)` / `getNationColors` (`assets.js:900`) | `code → [r,g,b]` palette (sibling of `world`, not inside it). |
+| `flags` | `/api/runtime/json/flags` | `getNationFlags` (`assets.js:949`) | Author flags `code → PNG data URL`. |
+| `tags` | `/api/runtime/json/tags` | `getNationTags` (`assets.js:933`) | Author STARTING country tags (§10). |
+| `regionsGeojson` / `citiesGeojson` | `/api/runtime/json/regionsGeojson` … | via `loadRegionCatalog` (`assets.js:1036`) | Custom drawn geometry (never value-cached, see `isNoStoreJsonUrl` `:158`). |
+
+`readGameStateBundle` (`src/runtime/gameState.js:1025`) reads `actions`, `chats`, `events`, `game`, `world` in one `Promise.all` and is the standard "load everything" entry point.
+
+### Games vs scenarios
+
+The same asset keys are served from two different server roots (`src/runtime/library.js:10`):
+
+- **Scenarios** — `/api/scenarios/*`. The immutable authored seed (WWII preset, a hub download, an editor export). `world.json` here is the STARTING position produced by the editor (`src/Editor/exportPreset.js:220`).
+- **Games** — `/api/games/*`. A live playthrough. Selecting a scenario spawns a game whose `world.json` starts as a copy of the scenario's and is then mutated in place by every jump.
+
+Only a **game's** `world.json` is written during play; the scenario copy stays pristine so the same scenario can seed many games. `setRuntimeAssetEndpoints` points `JSON_URLS.*` at whichever is active (the runtime token encodes it). `saveGame` in `src/Game/GameUI/libraryBar.jsx:1180` writes `world` **whole** (never a shallow `worldPatch`, which would drop `polityOverrides`/`ownerCodes`/`regionOwnershipOverrides` and wipe the map).
+
+---
+
+## 2. `world.json` shape — field table
+
+`WORLD_DEFAULTS` (`src/runtime/gameState.js:15`) is the authoritative default object; `normalizeWorldState` (`:815`) spreads `{ ...WORLD_DEFAULTS, ...world }` and then re-derives the structured fields. Anything **not** in `WORLD_DEFAULTS` (e.g. `customRegions`, `basemap`, `ownerCodes`) passes through untouched from the stored document — these are scenario-authored or game-appended fields the normalizer never rewrites.
+
+### 2a. Core political-map fields
+
+| Field | Type | Default | Meaning / data flow |
+|---|---|---|---|
+| `regionOwnershipOverrides` | `{ regionId: ownerCode }` | `{}` | THE re-ownership map: which polity owns each region above the base tiles. Written by AI `regionTransfers` (§8) and by cheats. Read by the Nations layer to paint fills, and by `isPolityLandless` (`:917`). Normalized to string→string, blanks dropped (`:823`). |
+| `polityOverrides` | `{ code: {code,name,aliases[],color,note,verbatim?} }` | `{}` | Declared/renamed polities: new countries, renames, colors, alt-names. Written by AI `polityChanges` and the editor. `enqueueContentStrings` translates names on write (`:993`). Normalized by `normalizePolityOverride` (`:758`). Feeds `loadCountryNames` (`assets.js:1004`) and every name/flag resolver. |
+| `regionClaimants` | `{ regionId: string[] }` (≤4) | `{}` | Marks a region DISPUTED — striped in the administrator's + claimants' colors. World-data equivalent of a `claimants` list on the geojson feature, and WINS over feature props. Normalized `:829` (sliced to 4). |
+| `ownerCodes` | `string[]` | *(not defaulted; pass-through)* | The playable factions list — who can be picked/played, including landless ones. Appended by `saveGame` (`libraryBar.jsx:1197`), read by cheats (`cheats.jsx:120`) to enumerate owners. |
+| `customRegions` | `boolean` | *(pass-through)* | When true, render political fills/borders/labels from the scenario's `regions.geojson` instead of the stock modern overlay. Set by the editor export (`exportPreset.js:227`) — forced on whenever there's custom geometry OR a custom background. Read in `useWorldState` and the Nations layer. |
+| `customCities` | `boolean` | *(pass-through)* | Render authored cities instead of the modern city set (`exportPreset.js:239`). Surfaced by `useWorldState` (`:87`). |
+| `basemap` | `string \| null` | *(pass-through)* | ESRI basemap preset id (`ESRI_BASEMAPS`, `assets.js:82`); falls back to `ocean` in-game. |
+| `background` / `backgroundData` | `string \| null` / payload | *(pass-through)* | Custom map background (image-by-extent or vector overlay) that replaces Earth; heavy payload rides in a separate scenario asset (`exportPreset.js:228`). |
+
+### 2b. AI-evolved diplomacy / identity fields
+
+| Field | Type | Default | Meaning / data flow |
+|---|---|---|---|
+| `internationalReputation` | `{ code: 0–100 }` | `{}` | Per-polity reputation, authoritative (not the on-demand stat sheet it was first read from). Evolved by AI `polityChanges.reputation` each turn (`:1081`) and fed back into prompts. Normalized/clamped to `[0,100]` int (`:838`). Keyed by country NAME verbatim. |
+| `countryTags` | `{ country: string[] }` | `{}` | Per-country tags the AI has CHANGED since the scenario started. Wins over the author's `tags.json` where present (see `resolveCountryTags`, `countryTags.js:55`). Keyed by country NAME verbatim (same namespace as reputation/colors — see the desync warning at `:845`). Normalized via `normalizeTagList` (`:850`). |
+| `notes` | `string` | `""` | Free-form world notes. |
+
+### 2c. Country-label styling (§ read by the map)
+
+Empty string = defaults (Impact, white letters, half-black outline). The font renders from the PLAYER's local fonts — MapLibre v5 rasterizes each glyph client-side using the stack as a CSS `font-family` (there is no glyphs endpoint). Set in scenario settings; surfaced to the map by `useWorldState`.
+
+| Field | Type | Default | Notes (`gameState.js`) |
+|---|---|---|---|
+| `labelFont` | `string` | `""` | CSS font-family stack for country labels (`:31`, normalized `:864`). |
+| `labelTextColor` | `string` | `""` | Label fill color (`:33`). |
+| `labelHaloColor` | `string` | `""` | Label outline color (`:32`). |
+
+### 2d. Simulation config & timeline text
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `simulationRules` | `string` | `""` | Author house-rules injected into the AI prompt (`exportPreset.js:242`). |
+| `startingTimelineText` | `string` | `""` | Author-written opening timeline shown pre-game (`exportPreset.js:243`). |
+| `language` | `string` | `"English"` | UI/content language for translation (`:34`, `:867`). |
+| `allowedUnitTypes` | `string[]` | *(pass-through)* | Scenario whitelist of deployable troop types; `null`/empty = all allowed (read in `unitsController.js:81`). |
+
+### 2e. Units and markers (ride inside world state)
+
+Stored in world so they share every read/write/poll/normalize path with no server change.
+
+| Field | Type | Default | Element shape (normalizer) |
+|---|---|---|---|
+| `units` | `Unit[]` | `[]` | `normalizeUnitEntry` (`:475`): `{id,name,type,ownerCode,strength,lng,lat,regionId,status,note,source,orderId,createdAt,updatedAt}`. |
+| `markers` | `Marker[]` | `[]` | `normalizeMarkerEntry` (`:518`): built structures — `{id,name,kind,ownerCode,lng,lat,note,foundedAt,createdAt}`. |
+
+`Unit` enums (`:60`–`:64`): `type ∈ {infantry,armor,air,naval,artillery,garrison}` (default `infantry`); `status ∈ {idle,moving,engaged,defeated,pending}` (default `idle`; `pending` = a player deploy awaiting AI resolution, rendered translucent); `source ∈ {player,ai,scenario}` (default `scenario`). `strength` is clamped to `[0,1000]` by `clampUnitStrength` (`:71`). `marker.kind` is free-form (lowercased for stable styling), default `landmark`.
+
+### 2f. Turn machinery & narrative history
+
+| Field | Type | Default | Meaning (normalizer) |
+|---|---|---|---|
+| `activeCatalyst` | `Catalyst \| null` | `null` | A running branching scenario prompt: `{title,premise,opening,choices[],history[]}` (`normalizeCatalyst` `:264`). Advanced by `advanceActiveCatalyst` (`gameplay.js:1701`). |
+| `actionSuggestions` | `Topic[]` | `[]` | AI-proposed action topics `{id,title,description,actions[]}` (`:777`); cleared each jump (`gameplay.js:1339`). |
+| `simulationHistory` | `Turn[]` | `[]` | Last ≤12 turns: `{catalyst,date,eventIds[],fallbackReason,fromDate,mode,plannedActions[],round,summary,source,toDate}` (built `gameplay.js:1343`, normalized `:875`). |
+| `consolidatedHistory` | `Summary[]` | `[]` | Compacted older-turn summaries `{summary,chatIds[],throughDate,throughEventId,throughRound,source,createdAt}` (`normalizeConsolidatedHistory` `:796`) — produced by `compactHistoryIfNeeded`. |
+| `lastJumpMode` | `string` | `""` | Mode of the most recent jump (`jump`/`auto`/…) (`:867`). |
+| `lastJumpSummary` | `string` | `""` | One-line summary of the last jump. |
+| `lastJumpTargetDate` | `string` | `""` | Target date the last jump advanced to. |
+
+> `ownerSchema` is a **document/editor** marker (`src/Editor/documentMigration.js:27`), not a runtime `world.json` field — it gates the editor's owner-code→name migration. A game's `world.json` inherits it only as an inert pass-through if the seed carried it.
+
+---
+
+## 3. `normalizeWorldState` — the single normalizer
+
+`normalizeWorldState(world)` (`src/runtime/gameState.js:815`) is called on **every** read and write of `world.json`, so no downstream code has to defend against missing/malformed fields. Behavior:
+
+1. Spread defaults then the raw doc: `{ ...WORLD_DEFAULTS, ...nextWorld, … }` (`:856`). Unknown fields (scenario extras) survive; known fields are then overwritten by their normalized versions.
+2. Rebuild the maps with blank-key/blank-value filtering: `regionOwnershipOverrides`, `polityOverrides`, `regionClaimants` (≤4), `internationalReputation` (clamped ints), `countryTags` (via `normalizeTagList`).
+3. Normalize the arrays: `units`, `markers`, `actionSuggestions`, `simulationHistory`, `consolidatedHistory`, and singletons `activeCatalyst`, label config, `notes`, `language`, `simulationRules`, `startingTimelineText`.
+
+`writeWorldState` (`:988`) normalizes, calls `enqueueContentStrings(polityOverrides)` to translate edited names on write, then `writeJson(JSON_URLS.world, …, { pretty:true })`.
+
+**Namespace caution (`:845`):** `countryTags`, `internationalReputation`, `polityOverrides`, and `colors` are all keyed by country **NAME verbatim**. An earlier version uppercased `countryTags` keys only, so a single `change.code` could land under two keys (`countryTags["RUSSIA"]` vs `internationalReputation["Russia"]`) — harmless while owners were uppercase GADM codes, a silent desync once owners are names. Keep the casing consistent.
+
+---
+
+## 4. `isPolityLandless` — "does this polity hold territory?"
+
+`isPolityLandless(world, code)` (`src/runtime/gameState.js:917`) is the single source of truth for "landless" (a government-in-exile, movement, or stateless person), used by both the AI prompt (`buildPlayerPolityRegionsText`) and the flag resolvers (a landless polity must NOT borrow the code-derived country flag). The subtlety: owning a region via an override = has land; but a scenario that ships **no** `regionOwnershipOverrides` at all means every polity owns its country through the base map tiles (a stock modern map), which is NOT landless (`:928`).
+
+---
+
+## 5. AI "impacts" — the mutation vocabulary
+
+Every event may carry an `impacts` object (`normalizeEventImpacts`, `src/runtime/gameState.js:669`) whose five arrays are the ONLY way the AI mutates world state. Each is independently normalized and invalid entries are dropped.
+
+| Impact array | Element normalizer | Applied by | Effect on `world.json` |
+|---|---|---|---|
+| `regionTransfers` | `normalizeRegionTransfer` (`:420`) → `{regionId,toCode,fromCode,regionName,note}` | inline loop (`:1048`) | `regionOwnershipOverrides[regionId] = toCode`. |
+| `polityChanges` | `normalizePolityChange` (`:442`) → `{code,name,color,aliases[],note,reputation,tags}` | inline loop (`:1052`) | Upserts `polityOverrides[code]`; also writes `colors[code]` (§7), `internationalReputation[code]`, `countryTags[code]`. |
+| `unitOps` | `normalizeUnitOp` (`:592`) → `spawn\|move\|strength\|remove` | `applyUnitOps` (`:638`) | Rewrites `world.units`. |
+| `markerOps` | `normalizeMarkerOp` (`:549`) → `build\|remove` | `applyMarkerOps` (`:575`) | Rewrites `world.markers`. |
+| `createdChats` | `normalizeChats` (`:415`) | turn writer (`gameplay.js:1364`) | New diplomacy threads pushed into `chat.json` (not `world`). |
+| `actionIds` | string list (`:683`) | turn writer | Which queued actions this event resolves. |
+
+### `normalizePolityChange` semantics (`:442`)
+
+- `reputation`: parsed and clamped to `[0,100]` int, else `null` ("unchanged").
+- `tags`: `Array.isArray` → `normalizeTagList`; otherwise `null`. This distinction is load-bearing — the AI sends the COMPLETE new tag list, so `[]` means "this country now has no defining tags" (must drop them) while `null`/undefined means "unchanged" (`:459`). `applyEventImpactsToWorld` deletes the key on `[]` and sets it on a non-empty list (`:1089`).
+
+### `applyUnitOps` (`:638`) — pure
+
+`spawn` (marks `source:"ai"`) pushes; `move` sets `lng/lat/regionId`, `status:"moving"`; `strength` clamps and marks `defeated` at ≤0; `remove` filters by id. Ops on unknown ids are silently ignored; the final list drops any unit with `strength ≤ 0` or `status === "defeated"` (`:666`).
+
+### `applyMarkerOps` (`:575`) — pure
+
+`build` replaces any existing marker of the same name (case-insensitive) rather than stacking duplicates; `remove` matches by id first, then exact name (the AI usually knows the name, rarely the id).
+
+---
+
+## 6. `game.json` — the clock (`GAME_DEFAULTS`)
+
+`GAME_DEFAULTS` (`src/runtime/gameState.js:6`), normalized by `normalizeGameData` (`:956`):
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `country` | `string` | `""` | The player's owner code/name. |
+| `difficulty` | `string` | `"standard"` | Feeds `difficultyDirective` in the prompt. |
+| `gameDate` | `string` | `""` | Current in-game date (`YYYY-MM-DD`), advanced each jump to `result.stopDate`. |
+| `startDate` | `string` | `""` | Scenario start date. |
+| `language` | `string` | `"English"` | UI/content language. |
+| `round` | `int > 0` | `1` | Turn counter, `+1` each jump (`gameplay.js:1324`). |
+
+`canonicalizeDateString` (`:939`) repairs `gameDate`/`startDate` from loose formats (`"2016-12-31T00:00:00.000Z"`, `"December 31, 2016"`) back to strict `YYYY-MM-DD`. Without it, `addIsoDays` rejects the value and every jump computes `target == origin`, freezing the clock while the model re-simulates the past. Deliberately non-Gregorian dates (`"1200 BCE"`) don't parse and pass through untouched.
+
+---
+
+## 7. `colors.json` — the palette (a sibling, not a world field)
+
+Colors live in a separate asset (`code → [r,g,b]`), not inside `world.json`. `applyEventImpactsToWorld` takes `colors` as an input and returns the mutated palette alongside the world (`:1043`, `:1107`): when a `polityChange` carries a 6-hex `color`, it is parsed to `[r,g,b]` and written to `nextColors[change.code]` (`:1067`). The turn writer persists both in the same `Promise.all` (`gameplay.js:1402`). A colors write invalidates the memoized `getNationColors` cache and dispatches `oh:colors-updated` so the map repaints mid-session without a reload (`assets.js:177`).
+
+---
+
+## 8. `applyEventImpactsToWorld` — folding impacts into state
+
+`applyEventImpactsToWorld({ colors, events, world })` (`src/runtime/gameState.js:1043`) is a **pure** function returning `{ colors, world }`. It clones the inputs, normalizes the world and the events, then for each event applies (in order): region transfers → polity changes (name/color/reputation/tags + palette) → unit ops → marker ops. It does NOT persist — the caller writes. Two callers:
+
+1. **The turn writer** — `applySimulationResult` (`src/Game/AI/gameplay.js:1305`). It builds the next world (merging `activeCatalyst`, `lastJump*`, and the new `simulationHistory` head), calls `applyEventImpactsToWorld` with the generated events (`:1333`), optionally compacts history, then persists everything in one `Promise.all`: `writeActionsState`, `writeChatsState`, `writeEventsState`, `writeGameData`, `writeJson(colors)`, `writeWorldState` (`:1397`). It then captures a rollback snapshot of the pre-jump state (`captureRollbackSnapshot`, `:1407`).
+2. **The staged reveal** — `src/Game/GameUI/time.jsx:1617`. As a turn's events are revealed one at a time, it re-applies impacts up to the last revealed event onto `stagedBase.world` and calls `setWorldStateOverride(stagedWorld)` / `setUnitsOverride(...)` so the map shows the world as of that event. It passes `colors: {}` because it only needs the world, not the palette. When staging ends (or on unmount) both overrides are cleared to `null` (`:1612`, `:1629`).
+
+---
+
+## 9. The 5-second poll — `useWorldState`
+
+`src/Game/Map/useWorldState.js` is a **singleton** poll shared by all map consumers (it replaced 4 redundant `world.json` requests).
+
+| Piece | Location | Behavior |
+|---|---|---|
+| `POLL_MS` | `:7` | 5000 ms interval. |
+| `sharedState` / `pollTimer` / `subscribers` | `:8`–`:10` | One interval, one result set, a `Set` of subscriber callbacks. |
+| `poll()` | `:31` | `readJson(JSON_URLS.world, { defaultValue:{}, force:true })`, then notifies subscribers. `force:true` bypasses the value cache; concurrent forced reads to the same URL are still batched into one fetch (`assets.js:560`). On error → `{}`. |
+| `startPolling` / `stopPolling` | `:40`,`:46` | First subscriber starts the timer (immediate `poll()` then interval); last unsubscribe clears it (`:79`). |
+| `overrideState` / `setWorldStateOverride` | `:17`,`:25` | Staged-reveal override. `effectiveState() = overrideState ?? sharedState` (`:19`). The poll keeps running underneath — `world.json` stays authoritative — and clearing to `null` snaps consumers back to live state. |
+| `getWorldStateSnapshot` | `:23` | Read-only accessor of the effective state (peer of `unitsController.getUnits`). |
+
+### Content-compare / referential-identity guard (`:83`–`:124`)
+
+`useWorldState` derives a small object of the fields the map cares about (`worldState`, `worldKnown`, `customRegions`, `customCities`, `basemap`, `background`, `regionOwnershipOverrides`, `regionClaimants`, `polityOverrides`, `markers`, `labelFont`, `labelHaloColor`, `labelTextColor`) and, if it is **content-equal** to the previous derived object, RETURNS THE PREVIOUS OBJECT REFERENCE. This keeps `useMemo`/`useEffect` consumers from re-running every 5 seconds when nothing meaningful changed. Comparison strategy:
+
+- Scalars (`basemap`, `background`, label config, booleans): `===`.
+- `regionOwnershipOverrides`, `polityOverrides`: `areEqualShallow` (`:56`) — key count + per-key `===` (values are strings/stable object refs).
+- `regionClaimants` and `markers`: `JSON.stringify` content-compare (`:113`,`:115`) — their values are fresh arrays/objects every poll, so reference equality would churn every 5 s; the payloads are tiny. `EMPTY_MARKERS` (`:54`) is a stable `[]` so a marker-less world never churns the memo.
+
+`worldState` itself is the raw polled object (still replaced each poll), but the sibling derived fields drive the map layers and are identity-stable.
+
+### Units peer-poll — `unitsController.js`
+
+`src/Game/Map/unitsController.js` runs its OWN 5-second `setInterval` (`startUnitsSync`, `:90`) that force-reads `world.json` + `game.json` and republishes `world.units` to a pub/sub (`:70`). Player mutations (deploy/move/attack) apply optimistically in memory and `commit` (`:101`) does a read-modify-write of `world.units` **preserving the rest of world state** (`{ ...world, units: nextUnits }`), guarded by a `busy` flag so the poll doesn't clobber a mid-commit write (`:31`,`:71`). Deploy/move/attack that exceed the era/type leash also `queueOrder` (an action) so the AI honors/contests them on the next jump (`:121`); each queued order carries a `unitRevert` describing how to undo it if the player deletes the action first (`:118`, and `normalizeUnitRevert` in `gameState.js:127`). It exposes its own `setUnitsOverride`/`getUnits` (`:53`,`:58`) mirroring the world-state override for staged reveals.
+
+---
+
+## 10. Country tags — `src/runtime/countryTags.js`
+
+A dependency-free module (imported by the editor, the game, and the server) that owns the two rules both halves must agree on: how a tag list is normalized and which source wins.
+
+| Export | Location | Purpose |
+|---|---|---|
+| `MAX_TAGS` / `MAX_TAG_LEN` | `:12`,`:13` | 8 tags, 32 chars each. |
+| `TAG_SUGGESTIONS` | `:19` | Open-vocabulary suggestions (`socialist`, `authoritarian`, `nato-aligned`, …) so common cases converge on one spelling. |
+| `normalizeTagList(list, opts)` | `:32` | Trim, collapse whitespace, cap length, drop blanks, dedupe case-insensitively, cap count. Non-strings dropped (a stray number means a palette `[r,g,b]` leaked in). |
+| `resolveCountryTags(baseTags, world, country)` | `:55` | The tags in force NOW for one country: the AI's live `world.countryTags[name]` if it has ever set one, ELSE the author's `tags.json` list. **Not a merge** — a revolution that dropped "socialist" must not have it restored by the scenario file underneath. Keyed by country NAME verbatim. |
+| `resolveAllCountryTags(baseTags, world)` | `:65` | Every tagged country, live winning over author, for the world summary the model reads. Emits keys verbatim (no uppercasing — see the desync note). |
+
+Author starting tags come from `getNationTags` (`assets.js:933`, the scenario's `tags.json`); live changes land in `world.countryTags` via `polityChanges.tags` (§5/§8). See [Country tags](country-tags.md).
+
+---
+
+## 11. Read / write API surface (`gameState.js`)
+
+| Function | Line | Notes |
+|---|---|---|
+| `readWorldState({force})` | `:985` | `readJson(world)` → `normalizeWorldState`. |
+| `writeWorldState(world, opts)` | `:988` | normalize → `enqueueContentStrings(polityOverrides)` → `writeJson(pretty)`. |
+| `readGameData` / `writeGameData` | `:997`,`:1000` | `normalizeGameData` on both ends. |
+| `readActionsState` / `writeActionsState` | `:1003`,`:1006` | `normalizeActions`. |
+| `readEventsState` / `writeEventsState` | `:1009`,`:1012` | `normalizeEvents`; write enqueues content strings. |
+| `readChatsState` / `writeChatsState` | `:1019`,`:1022` | `normalizeChats`. |
+| `readGameStateBundle` | `:1025` | `Promise.all` of all five. |
+| `applyEventImpactsToWorld` | `:1043` | Pure fold of impacts → `{colors, world}`. |
+| `applyUnitOps` / `applyMarkerOps` | `:638`,`:575` | Pure list mutators. |
+| `isPolityLandless` | `:917` | Territory check. |
+
+All reads/writes route through `src/runtime/assets.js` `readJson`/`writeJson`, which layer value-caching, request batching, Cache-Storage persistence with a HEAD freshness check, and derived-cache invalidation (`invalidateDerivedCachesForWrite`, `assets.js:177`) on top of the raw `/api/runtime/json/*` endpoints.


### PR DESCRIPTION
A `docs/` folder that explains how the whole codebase works, organized so it's easy to find things. 16 pages, ~5,000 lines, written from the current source (each page cites `file:line` and cross-links).

**Index:** [`docs/README.md`](docs/README.md) — grouped, linked table of contents with a "Start here" pointer.

**Pages**
- *Getting started:* Architecture Overview · Contributing & Conventions
- *Game:* Game Map & Rendering · In-Game UI (every panel/button) · World State & Turn Model
- *AI & Prompts:* AI System Overview · **Prompt-Making Guide** · AI Return Schemas & Validation
- *Editor:* Map Editor
- *Backend & Data:* Server & API · Map Data & Assets · Runtime Services
- *Web & Mobile:* Web Build · Android App
- *Delivery:* Delivery, Deploy & Releases

**The Prompt-Making Guide** ([`docs/ai-prompts.md`](docs/ai-prompts.md)) is the requested centerpiece: a full table of every `${…}` template variable/insert and what it inserts, all 16 AI tasks (jumpForward, autoJumpForward, the catalyst chain, countryStatSheet, idleDiplomacy, advisor/leader roots, …), how a final prompt is assembled end-to-end (task/root prompt → variable substitution → call-time directives like the language & difficulty directives), the override/frozen-prompt model, and recipes for adding a new variable or task.

Docs only — no code changes. Targeted at `main` as the canonical reference (say the word if you also want it on alpha/beta).