### PR TITLE
Add an in-app update banner that scales to many players

### DIFF
--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -84,27 +84,16 @@
       <button class="ghost" id="cancel">Change server</button>
     </div>
 
-    <div class="card" id="update" style="display: none">
-      <h1>Update available</h1>
-      <p id="updateInfo">
-        A newer version of the app is available. Tap below to download
-        <b>pax-historia.apk</b>, then open the finished download to install it
-        and reopen the app.
-      </p>
-      <button id="downloadUpdate">Download update</button>
-      <button class="ghost" id="skipUpdate">Continue without updating</button>
-    </div>
+    <!-- The update prompt now lives INSIDE the app as a top banner
+         (src/runtime/AppUpdateBanner.jsx, backed by the on-device server's
+         /api/app-update), so this boot screen no longer gates on updates. -->
+
 
     <script>
       const KEY = "pax-server-url";
       // Stamped with the CI run number at build time; hand-built ("dev")
       // copies skip the update check entirely.
       const APP_BUILD = "__APP_BUILD__";
-      // Self-update polls the organisation repository's rolling "android"
-      // release (the android-apk.yml workflow publishes there) — the asset
-      // name pax-historia.apk must never change (installed apps look for
-      // exactly that name).
-      const RELEASE_API = "https://api.github.com/repos/Open-Historia/open-historia/releases/tags/android";
       const setup = document.getElementById("setup");
       const connecting = document.getElementById("connecting");
       const input = document.getElementById("server");
@@ -197,46 +186,13 @@
         }
       };
 
-      // APK self-update: every launch compares this build against the rolling
-      // "android" release; a newer one auto-downloads (the native download
-      // listener hands the APK to the system browser). Only the app does this
-      // — the regular web version never ships this page.
-      const checkForUpdate = async () => {
-        if (!/^\d+$/.test(APP_BUILD)) return null; // dev build
-        try {
-          const response = await fetch(RELEASE_API, {
-            headers: { Accept: "application/vnd.github+json" },
-            signal: AbortSignal.timeout(4000),
-          });
-          if (!response.ok) return null;
-          const release = await response.json();
-          const remote = String(release.body || "").match(/Build:\s*(\d+)/i);
-          if (!remote || Number(remote[1]) <= Number(APP_BUILD)) return null;
-          const asset = (release.assets || []).find((a) => a.name === "pax-historia.apk");
-          return asset ? { build: remote[1], url: asset.browser_download_url } : null;
-        } catch {
-          return null; // offline / rate-limited — just play
-        }
-      };
-
-      checkForUpdate().then((update) => {
-        if (!update) {
-          startNormalFlow();
-          return;
-        }
-        setup.style.display = "none";
-        connecting.style.display = "none";
-        document.getElementById("update").style.display = "flex";
-        // Explicit button — the reliable path. (The download is handed to the
-        // system browser by the native download listener.)
-        document.getElementById("downloadUpdate").addEventListener("click", () => {
-          window.location.href = update.url;
-        });
-        document.getElementById("skipUpdate").addEventListener("click", () => {
-          document.getElementById("update").style.display = "none";
-          startNormalFlow();
-        });
-      });
+      // Update checking moved INTO the app (a top banner backed by /api/app-update,
+      // which the on-device server answers and caches). The boot screen no longer
+      // polls the GitHub REST API on every launch: that call is rate-limited at 60/hr
+      // per IP, and many players share one carrier IP (CGNAT), so at scale the check
+      // began failing for whole carriers. The in-app banner reads a tiny release
+      // ASSET via the server instead, which is a CDN download with no such limit.
+      startNormalFlow();
 
       // Which build is this? Shown in the corner so bug reports can say.
       const badge = document.createElement("div");

--- a/server/server.js
+++ b/server/server.js
@@ -262,6 +262,49 @@ app.get("/api/library", (_req, res) => {
   }
 });
 
+// Native-app update check. The app polls THIS instead of hitting GitHub directly:
+// the game runs at the embedded-server origin, so a client-side fetch to a GitHub
+// release asset is CORS-blocked — and doing it here lets us cache the lookup so
+// thousands of clients polling don't each hit GitHub. We read the tiny latest.json
+// release asset (a CDN download, not the rate-limited REST API) for the app's track.
+const APP_UPDATE_MANIFESTS = {
+  stable: "https://github.com/Open-Historia/open-historia/releases/download/android/latest.json",
+  beta: "https://github.com/Open-Historia/open-historia/releases/download/android-beta/latest.json",
+};
+const APP_UPDATE_TTL_MS = 3 * 60 * 1000;
+const appUpdateCache = new Map(); // track -> { at, data }
+
+app.get("/api/app-update", async (req, res) => {
+  const track = String(req.query.track || "stable");
+  const manifestUrl = APP_UPDATE_MANIFESTS[track];
+  if (!manifestUrl) {
+    res.json({}); // unknown track -> no update info, never an error
+    return;
+  }
+  const cached = appUpdateCache.get(track);
+  if (cached && Date.now() - cached.at < APP_UPDATE_TTL_MS) {
+    res.json(cached.data);
+    return;
+  }
+  try {
+    const response = await fetch(manifestUrl, { signal: AbortSignal.timeout(6000) });
+    if (!response.ok) {
+      res.json(cached ? cached.data : {}); // stale-if-error, else empty
+      return;
+    }
+    const raw = await response.json();
+    const data = {
+      build: Number(raw && raw.build) || 0,
+      apk: typeof (raw && raw.apk) === "string" ? raw.apk : "",
+      notes: typeof (raw && raw.notes) === "string" ? raw.notes : "",
+    };
+    appUpdateCache.set(track, { at: Date.now(), data });
+    res.json(data);
+  } catch {
+    res.json(cached ? cached.data : {}); // offline / timeout -> fail-open
+  }
+});
+
 app.get("/api/scenarios/:scenarioId", (req, res) => {
   try {
     res.json(getScenarioDetails(req.params.scenarioId));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import UI from "./Game/GameUI/main.jsx";
 const MapEditor = lazy(() => import("./Editor/MapEditor.jsx"));
 import StartupScreen from "./runtime/StartupScreen.jsx";
 import ErrorBoundary from "./runtime/ErrorBoundary.jsx";
+import AppUpdateBanner from "./runtime/AppUpdateBanner.jsx";
 import {
   STARTUP_TIME_BUDGET_MS,
   createInitialStartupState,
@@ -209,9 +210,12 @@ function App() {
   // screen instead of unmounting to a blank page. Wrapping <GameApp/> at this level
   // (rather than inside GameApp's return) also catches GameApp's own render throws.
   return (
-    <ErrorBoundary>
-      <GameApp />
-    </ErrorBoundary>
+    <>
+      <AppUpdateBanner />
+      <ErrorBoundary>
+        <GameApp />
+      </ErrorBoundary>
+    </>
   );
 }
 

--- a/src/runtime/AppUpdateBanner.jsx
+++ b/src/runtime/AppUpdateBanner.jsx
@@ -1,0 +1,142 @@
+/*! Open Historia — in-app update banner © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+import { useEffect, useRef, useState } from "react";
+import {
+  APP_UPDATE_CHECK_INTERVAL_MS,
+  APP_UPDATE_REFOCUS_THROTTLE_MS,
+  isUpdateAvailable,
+  parseUpdateManifest,
+} from "./appUpdate.js";
+
+// Stamped into the native app build by the APK workflow (VITE_APP_BUILD / _TRACK).
+// Web, desktop and dev builds have no stamp, so the banner is a no-op there.
+const APP_BUILD = Number(import.meta.env.VITE_APP_BUILD);
+const APP_TRACK = String(import.meta.env.VITE_APP_TRACK || "stable");
+const DISMISS_KEY = "oh-update-dismissed-build";
+
+const bar = {
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  zIndex: 10060,
+  display: "flex",
+  alignItems: "center",
+  gap: "0.75rem",
+  padding: "0.55rem max(0.9rem, env(safe-area-inset-left)) 0.55rem max(0.9rem, env(safe-area-inset-right))",
+  paddingTop: "max(0.55rem, env(safe-area-inset-top))",
+  background: "linear-gradient(180deg, #12172b, #0d1122)",
+  borderBottom: "1px solid rgba(212,175,55,0.35)",
+  color: "#f4ead0",
+  font: "600 0.85rem/1.3 system-ui, sans-serif",
+  boxShadow: "0 6px 20px rgba(0,0,0,0.45)",
+};
+const text = { flex: 1, minWidth: 0 };
+const sub = { display: "block", fontWeight: 400, fontSize: "0.72rem", color: "rgba(244,234,208,0.6)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" };
+const btn = {
+  flex: "0 0 auto",
+  background: "linear-gradient(180deg, #d4af37, #b8901f)",
+  border: "1px solid rgba(212,175,55,0.6)",
+  borderRadius: "9px",
+  color: "#1a1206",
+  cursor: "pointer",
+  font: "700 0.82rem system-ui, sans-serif",
+  padding: "0.45rem 0.9rem",
+};
+const dismissBtn = {
+  flex: "0 0 auto",
+  background: "transparent",
+  border: "none",
+  color: "rgba(244,234,208,0.6)",
+  cursor: "pointer",
+  fontSize: "1.1rem",
+  lineHeight: 1,
+  padding: "0.2rem 0.35rem",
+};
+
+export default function AppUpdateBanner() {
+  // Only native app builds carry a numeric build stamp; everything else no-ops.
+  const supported = Number.isFinite(APP_BUILD) && APP_BUILD > 0;
+  const [latest, setLatest] = useState(null);
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return Number(localStorage.getItem(DISMISS_KEY)) || 0;
+    } catch {
+      return 0;
+    }
+  });
+  const [updating, setUpdating] = useState(false);
+  const lastRefocusRef = useRef(0);
+
+  useEffect(() => {
+    if (!supported) return undefined;
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const res = await fetch(`/api/app-update?track=${encodeURIComponent(APP_TRACK)}`, {
+          signal: AbortSignal.timeout(6000),
+        });
+        if (!res.ok) return;
+        const manifest = parseUpdateManifest(await res.json());
+        if (!cancelled && manifest) setLatest(manifest);
+      } catch {
+        /* fail-open: a failed check simply shows no banner */
+      }
+    };
+    check();
+    const interval = setInterval(check, APP_UPDATE_CHECK_INTERVAL_MS);
+    const onVisibility = () => {
+      if (document.visibilityState !== "visible") return;
+      const now = Date.now();
+      if (now - lastRefocusRef.current < APP_UPDATE_REFOCUS_THROTTLE_MS) return;
+      lastRefocusRef.current = now;
+      check();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [supported]);
+
+  if (!supported) return null;
+  if (!isUpdateAvailable(APP_BUILD, latest)) return null;
+  if (latest.build <= dismissed) return null;
+
+  const onUpdate = () => {
+    if (!latest.apk) return;
+    setUpdating(true);
+    // Downloads the new APK; Android then prompts to install it and reopen the app.
+    window.location.href = latest.apk;
+  };
+  const onDismiss = () => {
+    setDismissed(latest.build);
+    try {
+      localStorage.setItem(DISMISS_KEY, String(latest.build));
+    } catch {
+      /* ignore: dismissal just won't persist across launches */
+    }
+  };
+
+  return (
+    <div style={bar} role="status" aria-live="polite">
+      <div style={text}>
+        A new version of Open Historia is ready.
+        <span style={sub}>
+          {updating
+            ? "Downloading… open the finished download to install and reopen."
+            : latest.notes || `Build ${latest.build} · tap Update to download and install.`}
+        </span>
+      </div>
+      {latest.apk ? (
+        <button type="button" style={btn} onClick={onUpdate} disabled={updating}>
+          {updating ? "Downloading…" : "Update now"}
+        </button>
+      ) : null}
+      <button type="button" style={dismissBtn} onClick={onDismiss} aria-label="Dismiss update notice">
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/runtime/appUpdate.js
+++ b/src/runtime/appUpdate.js
@@ -1,0 +1,51 @@
+/*! Open Historia — in-app update-check helpers © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Pure, dependency-free so the version comparison is unit-tested without a browser
+// or a running server. The banner (AppUpdateBanner.jsx) is the only consumer.
+//
+// Why the check goes through the app's OWN server (/api/app-update) rather than
+// fetching GitHub from the client: the game runs at the embedded server's origin
+// (127.0.0.1:3000), NOT the Capacitor origin, so it has no native-HTTP bridge and a
+// direct fetch to a GitHub release asset is subject to WebView CORS. The server
+// fetches server-side (no CORS) and caches the result for the same window below, so
+// thousands of clients polling every few minutes still hit GitHub only ~20x/hour per
+// device — against a CDN release asset, never the 60/hour REST API. That keeps it
+// safe even behind shared carrier IPs.
+
+// Effective poll cadence (the server caches for the same window, so this is also the
+// real GitHub lookup rate per device).
+export const APP_UPDATE_CHECK_INTERVAL_MS = 3 * 60 * 1000;
+// A re-check when the app regains focus, throttled so rapid focus flips can't hammer it.
+export const APP_UPDATE_REFOCUS_THROTTLE_MS = 60 * 1000;
+
+// A positive integer build number, or null for anything else (dev/web/desktop have
+// no stamped build, so they can never see an "update available").
+export const toBuild = (value) => {
+  // Number(symbol) throws; guard so a hostile/unexpected value can never crash a check.
+  if (value == null || typeof value === "symbol") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : null;
+};
+
+// Normalize an /api/app-update payload into { build, apk, notes }, or null if it
+// carries no usable build number.
+export const parseUpdateManifest = (data) => {
+  if (!data || typeof data !== "object") return null;
+  const build = toBuild(data.build);
+  if (build == null) return null;
+  return {
+    build,
+    apk: typeof data.apk === "string" ? data.apk.trim() : "",
+    notes: typeof data.notes === "string" ? data.notes.trim() : "",
+  };
+};
+
+// True only when `latest` is a well-formed manifest describing a build strictly newer
+// than the running one. A null/invalid current build (dev, web, desktop) is never an
+// update.
+export const isUpdateAvailable = (currentBuild, latest) => {
+  const current = toBuild(currentBuild);
+  const manifest = parseUpdateManifest(latest);
+  if (current == null || !manifest) return false;
+  return manifest.build > current;
+};

--- a/src/runtime/appUpdate.test.js
+++ b/src/runtime/appUpdate.test.js
@@ -1,0 +1,58 @@
+/*! Open Historia — update-check helper tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Run: node --test src/runtime/appUpdate.test.js
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { toBuild, parseUpdateManifest, isUpdateAvailable } from "./appUpdate.js";
+
+test("toBuild accepts positive integers (number or string)", () => {
+  assert.equal(toBuild(5), 5);
+  assert.equal(toBuild("42"), 42);
+});
+test("toBuild floors fractional values", () => {
+  assert.equal(toBuild(7.9), 7);
+});
+test("toBuild rejects zero, negatives, NaN, null, undefined, junk", () => {
+  for (const v of [0, -1, NaN, null, undefined, "", "abc", {}, []]) assert.equal(toBuild(v), null);
+});
+
+test("parseUpdateManifest normalizes a full payload", () => {
+  assert.deepEqual(
+    parseUpdateManifest({ build: "12", apk: " https://x/a.apk ", notes: " hi " }),
+    { build: 12, apk: "https://x/a.apk", notes: "hi" },
+  );
+});
+test("parseUpdateManifest defaults apk/notes to empty strings", () => {
+  assert.deepEqual(parseUpdateManifest({ build: 3 }), { build: 3, apk: "", notes: "" });
+});
+test("parseUpdateManifest returns null without a usable build", () => {
+  for (const v of [null, undefined, "nope", 5, {}, { build: 0 }, { build: "x" }, { apk: "a" }]) {
+    assert.equal(parseUpdateManifest(v), null);
+  }
+});
+test("parseUpdateManifest ignores non-string apk/notes", () => {
+  assert.deepEqual(parseUpdateManifest({ build: 1, apk: 9, notes: {} }), { build: 1, apk: "", notes: "" });
+});
+
+test("isUpdateAvailable true when latest build is strictly newer", () => {
+  assert.equal(isUpdateAvailable(10, { build: 11 }), true);
+});
+test("isUpdateAvailable false when equal", () => {
+  assert.equal(isUpdateAvailable(10, { build: 10 }), false);
+});
+test("isUpdateAvailable false when latest is older", () => {
+  assert.equal(isUpdateAvailable(10, { build: 9 }), false);
+});
+test("isUpdateAvailable false when current build is unknown (dev/web/desktop)", () => {
+  for (const c of [null, undefined, 0, NaN, "x"]) assert.equal(isUpdateAvailable(c, { build: 999 }), false);
+});
+test("isUpdateAvailable false when manifest is missing/invalid", () => {
+  for (const m of [null, undefined, {}, { build: 0 }, "nope"]) assert.equal(isUpdateAvailable(5, m), false);
+});
+test("isUpdateAvailable accepts string build numbers on both sides", () => {
+  assert.equal(isUpdateAvailable("10", { build: "11" }), true);
+});
+test("isUpdateAvailable never throws on hostile input", () => {
+  assert.doesNotThrow(() => isUpdateAvailable({}, []));
+  assert.doesNotThrow(() => isUpdateAvailable(Symbol.iterator, () => {}));
+});


### PR DESCRIPTION
Adds the in-app "update available" banner you asked for, designed to stay free at thousands of players.

## What it does
A slim top banner in the app's theme — **"A new version of Open Historia is ready"** + **Update now** (downloads the APK → Android installs it) + dismiss. It checks on launch, every ~3 minutes, and when the app regains focus. Dismissing hides it and persists per build; a *newer* build re-shows.

![banner](does-not-embed)

## Why it scales (no rate-limit / no LFS cost)
- The APK and map data are GitHub **Release assets** (CDN, free) — never LFS.
- The old boot screen polled the GitHub **REST API** on every launch (60/hr **per IP**), which fails for whole carriers behind shared NAT. **Removed.**
- Instead, the app polls its **own on-device server** (`/api/app-update`, localhost — zero external cost). That server fetches the tiny `latest.json` **release asset** at most once per ~3-min window and caches it: ~20 lookups/hr/device against a CDN asset, safe even behind shared carrier IPs. Doing it server-side also sidesteps WebView CORS (the game runs at the embedded-server origin, not the Capacitor origin).

## Verification
- `appUpdate.test.js` — 14 unit tests on the build-comparison / manifest logic.
- Booted the app: banner renders correctly, **Update now** wired, **dismiss persists across reload**, and the endpoint **fails open to `{}`** when `latest.json` is absent / offline / unknown track (so nothing shows until a build actually publishes one).
- Full `vite build` passes.

## Scope
Targets the embedded-server ("node") app — the one that builds/serves the game bundle and runs the on-device server. The legacy thin-client stable APK doesn't show the banner (by decision).

## Separate follow-up (needs `workflow` scope)
The two Android workflow changes — publish `latest.json` and bake `VITE_APP_BUILD` / `VITE_APP_TRACK` into the build — are delivered separately because this token can't push `.github/workflows/`. **Until those land the banner stays inert** (the endpoint fails open, nothing shows), so this PR is safe to merge on its own.
