### PR TITLE
Cut web-build menu lag and memory pressure (backend-only, no visual change)

### DIFF
--- a/src/Game/Map/World.jsx
+++ b/src/Game/Map/World.jsx
@@ -128,15 +128,6 @@ const buildWorldStyle = (basemapId, customBg, backgroundDeclared, isGlobe) => {
       maxzoom: 5,
       tileSize: 256,
     },
-    "hillshade-source": {
-      type: "raster-dem",
-      tiles: [
-        TERRAIN_TILE_TEMPLATE,
-      ],
-      encoding: "terrarium",
-      maxzoom: 5,
-      tileSize: 256,
-    },
   },
   layers: [
     {
@@ -154,7 +145,7 @@ const buildWorldStyle = (basemapId, customBg, backgroundDeclared, isGlobe) => {
     {
       id: "hills",
       type: "hillshade",
-      source: "hillshade-source",
+      source: "terrain-source",
       paint: {
         "hillshade-exaggeration": 0.1,
         "hillshade-shadow-color": "#000",

--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -160,11 +160,11 @@ const ensureUniqueId = async (requested, kind) => {
 };
 
 // --- Catalog composition (mirror getScenarioCatalog/getGameCatalog/getLibraryCatalog) ---
-const getScenarioCatalog = async () => {
+const getScenarioCatalog = async (scenarioRecords, gameRecords) => {
   const manifest = await getScenarioManifest();
-  const records = await idbGetAll(STORES.scenarios);
+  const records = scenarioRecords ?? await idbGetAll(STORES.scenarios);
   const byId = new Map(records.map((r) => [r.id, r]));
-  const usage = await getScenarioUsageCounts();
+  const usage = await getScenarioUsageCounts(gameRecords);
   const orderedIds = resolveOrderedIds(manifest.order, new Set(byId.keys()), DEFAULT_SCENARIO_ID);
 
   const scenarios = orderedIds.map((id) => {
@@ -191,20 +191,20 @@ const getScenarioCatalog = async () => {
   return { activeScenarioId: selectedScenarioId, scenarios, selectedScenarioId };
 };
 
-const getScenarioUsageCounts = async () => {
+const getScenarioUsageCounts = async (gameRecords) => {
   const counts = new Map();
-  for (const game of await idbGetAll(STORES.games)) {
+  for (const game of gameRecords ?? await idbGetAll(STORES.games)) {
     const scenarioId = readGameMeta(game.id, game.meta ?? {}).scenarioId;
     counts.set(scenarioId, (counts.get(scenarioId) ?? 0) + 1);
   }
   return counts;
 };
 
-const getGameCatalog = async () => {
-  const scenarioCatalog = await getScenarioCatalog();
-  const scenarioLookup = new Map(scenarioCatalog.scenarios.map((s) => [s.id, s]));
+const getGameCatalog = async (scenarioCatalog, gameRecords) => {
+  const catalog = scenarioCatalog ?? await getScenarioCatalog();
+  const scenarioLookup = new Map(catalog.scenarios.map((s) => [s.id, s]));
   const manifest = await getGameManifest();
-  const records = await idbGetAll(STORES.games);
+  const records = gameRecords ?? await idbGetAll(STORES.games);
   const byId = new Map(records.map((r) => [r.id, r]));
   const orderedIds = resolveOrderedIds(manifest.order, new Set(byId.keys()), DEFAULT_GAME_ID);
 
@@ -243,8 +243,13 @@ const getGameCatalog = async () => {
 };
 
 const getLibraryCatalog = async () => {
-  const scenarioCatalog = await getScenarioCatalog();
-  const gameCatalog = await getGameCatalog();
+  // Read each heavy store ONCE and thread the rows through — otherwise
+  // getScenarioCatalog() + getGameCatalog() each re-read them (scenarios x2, games x3),
+  // deserializing every full record (incl. any embedded assets) 2-3x per menu build.
+  const scenarioRecords = await idbGetAll(STORES.scenarios);
+  const gameRecords = await idbGetAll(STORES.games);
+  const scenarioCatalog = await getScenarioCatalog(scenarioRecords, gameRecords);
+  const gameCatalog = await getGameCatalog(scenarioCatalog, gameRecords);
   const selectedScenario = scenarioCatalog.scenarios.find((s) => s.id === scenarioCatalog.selectedScenarioId) ?? scenarioCatalog.scenarios[0] ?? null;
   const activeGame = gameCatalog.games.find((g) => g.id === gameCatalog.activeGameId) ?? gameCatalog.games[0] ?? null;
   const runtimeScenario = activeGame && activeGame.scenarioId

--- a/src/runtime/web/sync.js
+++ b/src/runtime/web/sync.js
@@ -25,6 +25,22 @@ const blobIdParts = (blobId) => {
   return { kind: blobId.slice(0, i), id: blobId.slice(i + 1) };
 };
 
+// Fingerprinting a record base64-encodes and SHA-256s its ENTIRE content (world,
+// events, snapshots, any embedded assets) on the main thread — expensive. The full
+// scan runs every ~20s, so re-hashing records that have NOT changed is the dominant
+// sync cost and the "menu lags much more when logged in" symptom. Every content write
+// bumps meta.updatedAt (writeGameMeta/writeScenarioMeta in libraryStore), so memoize
+// the hash on it: an unchanged record reuses its last hash and skips the re-encode.
+const fingerprintCache = new Map(); // blobId -> { updatedAt, sha }
+const cachedFingerprint = async (blobId, rec) => {
+  const updatedAt = rec?.meta?.updatedAt;
+  const hit = fingerprintCache.get(blobId);
+  if (hit && updatedAt != null && hit.updatedAt === updatedAt) return hit.sha;
+  const sha = await recordFingerprint(rec);
+  fingerprintCache.set(blobId, { updatedAt: updatedAt ?? null, sha });
+  return sha;
+};
+
 // Read every syncable local record as blob_id → { rec, sha }.
 const collectLocal = async () => {
   const local = new Map();
@@ -32,7 +48,7 @@ const collectLocal = async () => {
     for (const rec of await idbGetAll(store)) {
       // Skip (don't abort the whole sync over) a record that can't be
       // fingerprinted, e.g. one holding a value JSON can't serialize.
-      try { local.set(prefix + rec.id, { rec, sha: await recordFingerprint(rec) }); }
+      try { local.set(prefix + rec.id, { rec, sha: await cachedFingerprint(prefix + rec.id, rec) }); }
       catch (e) { console.warn(`[sync] skip local ${prefix}${rec.id}: ${e.message}`); }
     }
   }


### PR DESCRIPTION
Reduces the website's main-menu lag (reported worse when signed in, and on a large laptop viewport vs a phone) and the tab's memory pressure. Root-caused with a 13-agent adversarially-verified investigation, which found **no classic leak** — the cost is redundant heavy main-thread work + a viewport-scaled GPU floor.

**All three changes are backend-only / invisible** — the menu and map look and behave pixel-for-pixel identically.

## Fixes
- **`sync.js` — the "logged-in" stall.** The ~20s encrypted-sync scan base64-encoded + SHA-256'd *every* record on the main thread each cycle, even unchanged ones. Now the fingerprint is memoized on `meta.updatedAt` (stamped on every content write by `writeGameMeta`/`writeScenarioMeta`), so only records that actually changed get re-hashed. A real change always bumps `updatedAt`, so nothing is ever missed.
- **`libraryStore.js` — menu-open work.** `getLibraryCatalog` re-read the scenarios store **2×** and the games store **3×** per build (each a full structured-clone of every record). Now each store is read once and threaded through the builders. The builders keep optional self-read fallbacks, so other callers are unaffected.
- **`World.jsx` — duplicate DEM.** `terrain-source` and `hillshade-source` were **byte-identical** raster-dem sources, so the terrarium DEM tiles were fetched, decoded, and GPU-uploaded twice. The hillshade layer now reads `terrain-source` and the duplicate is removed — halves DEM memory/decode with identical output.

## Verification
- Web build (`build:web`) passes.
- App boots with **no map-style/source error** (MapLibre accepts `hills`→`terrain-source`) and no render crash.
- Sync memoization is correctness-safe by construction: every content write bumps `updatedAt` (verified: `writeGameMeta(activeGame, {})` on every asset write), so the cache invalidates on any real change.
- The full memory-profile delta (GB → flat) needs a real browser with the ~200 MB map assets + a large viewport — not reproducible in the sandbox; the code paths are reviewed.

## Deliberately NOT done (per "no quality change")
- Lowering map render resolution / tile cache on high-DPI — the biggest *viewport* lever, but it softens the map. Left out.
- Card `React.memo` — needs `useCallback` across ~8 menu handlers; getting deps wrong risks stale-closure behavior bugs, and it only helps editor-typing (not a reported symptom). Deferred.
- The deeper OOM cure — a lean catalog that never materializes embedded scenario binaries (a separate asset store + migration) — is backend-only but a larger refactor; worth doing if the crash persists for users with imported full-mode scenarios.
