### PR TITLE
Remove the AI output-token cap so long turns aren't truncated (#511)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -455,13 +455,12 @@ const runJsonTask = async (taskKey, {
   try {
     for (let outputAttempt = 1; outputAttempt <= 2; outputAttempt += 1) {
       const response = await callAI(systemPrompt, history, {
+        // No output-token cap. A long/action-heavy turn's JSON must not be truncated
+        // mid-response — a cut-off response won't parse, so runJsonTask fell back to
+        // canned events that carry NO regionTransfers and NO diplomacy, which is why
+        // the map never changed and no chats opened. main.jsx now lets each provider
+        // use its own model maximum when no maxTokens is passed.
         deadline,
-        // One request budget for every task. This is only a per-response output
-        // ceiling for providers that take one (OpenAI-compatible/Anthropic
-        // floor it at 8192 in main.jsx; Gemini sends no cap at all and ignores
-        // this value entirely) — jump tasks used to request 16384, which only
-        // raised that ceiling on capped providers.
-        maxTokens: 8192,
         signal: controller.signal,
         tool,
       });

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -635,7 +635,7 @@ async function callOpenAIStyleChatCompletions({
     tool,
     onChunk,
     allowJsonSchemaFallback = false,
-    maxTokens = 8192,
+    maxTokens,
     tokenLimitField = "max_tokens",
 }) {
     let structuredMode = tool ? "tool" : "text";
@@ -678,7 +678,9 @@ async function callOpenAIStyleChatCompletions({
                 // unknown parameters. Sent only when the toggle is ON so a
                 // server-side --enable-thinking default is never overridden.
                 ...(streamLocalEndpoint && getReasoningEnabled() && !disableToolReasoning ? { enable_thinking: true } : {}),
-                [tokenLimitField]: Math.max(8192, Number(maxTokens) || 0),
+                // No cap unless a caller asked for a specific budget: omit the field so
+                // the provider uses the model's own maximum (long turns aren't truncated).
+                ...(Number(maxTokens) > 0 ? { [tokenLimitField]: Number(maxTokens) } : {}),
                 ...requestCustomParams,
                 ...(structuredMode === "tool" && disableToolReasoning ? { reasoning_effort: "none" } : {}),
                 ...(structuredMode === "tool" ? {
@@ -855,9 +857,17 @@ async function callOpenAICompatible(systemPrompt, history, opts = {}) {
     });
 }
 
+// Anthropic REQUIRES max_tokens and 400s if it exceeds the model's ceiling (the error
+// states that ceiling). Since the output cap was removed on purpose, request the model's
+// maximum: start high, and on that 400 learn + cache the model's real ceiling so later
+// calls use it directly (no repeated 400s). A high start lets capable models use their
+// full range while low-ceiling models self-correct on the first call.
+const ANTHROPIC_MAX_OUTPUT = 64000;
+const anthropicModelMax = new Map(); // model -> learned output ceiling
+
 async function callAnthropic(systemPrompt, history, {
     deadline,
-    maxTokens = 8192,
+    maxTokens,
     onChunk,
     retries = 3,
     retryDelay = 15000,
@@ -889,7 +899,10 @@ async function callAnthropic(systemPrompt, history, {
     // by extractAnthropicText, which only reads text blocks.
     const reasoning = getReasoningEnabled();
     const customParams = parseCustomParams(settings.customParams, "Anthropic");
-    const requestedMaxTokens = Math.max(8192, Number(maxTokens) || 0, Number(customParams.max_tokens) || 0);
+    // Uncapped by default -> the model's own maximum (learned from a prior 400).
+    let requestedMaxTokens = Number(maxTokens) > 0
+        ? Number(maxTokens)
+        : Math.max(Number(customParams.max_tokens) || 0, anthropicModelMax.get(model) || ANTHROPIC_MAX_OUTPUT);
     delete customParams.max_tokens;
 
     for (let attempt = 1; attempt <= retries; attempt++) {
@@ -927,7 +940,17 @@ async function callAnthropic(systemPrompt, history, {
 
         if (!response.ok) {
             const payload = await readErrorPayload(response);
-            throw new Error(extractErrorMessage(payload, `Anthropic request failed (${response.status})`));
+            const message = extractErrorMessage(payload, `Anthropic request failed (${response.status})`);
+            // The cap was removed on purpose; honor the MODEL's own ceiling. Anthropic 400s
+            // "max_tokens: <sent> > <max>, ..." — learn <max>, cache it, and retry at it.
+            const capMatch = /max_tokens:\s*\d+\s*>\s*(\d+)/i.exec(message);
+            if (response.status === 400 && capMatch && Number(capMatch[1]) > 0
+                && Number(capMatch[1]) < requestedMaxTokens && attempt < retries) {
+                anthropicModelMax.set(model, Number(capMatch[1]));
+                requestedMaxTokens = Number(capMatch[1]);
+                continue;
+            }
+            throw new Error(message);
         }
 
         if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {
@@ -954,7 +977,7 @@ async function callAnthropic(systemPrompt, history, {
 
 async function callAnthropicCompatible(systemPrompt, history, {
     deadline,
-    maxTokens = 8192,
+    maxTokens,
     onChunk,
     retries = 3,
     retryDelay = 15000,
@@ -987,7 +1010,10 @@ async function callAnthropicCompatible(systemPrompt, history, {
 
     const reasoning = getReasoningEnabled();
     const customParams = parseCustomParams(settings.customParams, "Anthropic Compatible");
-    const requestedMaxTokens = Math.max(8192, Number(maxTokens) || 0, Number(customParams.max_tokens) || 0);
+    // Uncapped by default -> the model's own maximum (learned from a prior 400).
+    let requestedMaxTokens = Number(maxTokens) > 0
+        ? Number(maxTokens)
+        : Math.max(Number(customParams.max_tokens) || 0, anthropicModelMax.get(model) || ANTHROPIC_MAX_OUTPUT);
     delete customParams.max_tokens;
 
     for (let attempt = 1; attempt <= retries; attempt++) {
@@ -1019,7 +1045,16 @@ async function callAnthropicCompatible(systemPrompt, history, {
 
         if (!response.ok) {
             const payload = await readErrorPayload(response);
-            throw new Error(extractErrorMessage(payload, `Anthropic-compatible request failed (${response.status})`));
+            const message = extractErrorMessage(payload, `Anthropic-compatible request failed (${response.status})`);
+            // Honor the model's own max_tokens ceiling (the cap was removed on purpose).
+            const capMatch = /max_tokens:\s*\d+\s*>\s*(\d+)/i.exec(message);
+            if (response.status === 400 && capMatch && Number(capMatch[1]) > 0
+                && Number(capMatch[1]) < requestedMaxTokens && attempt < retries) {
+                anthropicModelMax.set(model, Number(capMatch[1]));
+                requestedMaxTokens = Number(capMatch[1]);
+                continue;
+            }
+            throw new Error(message);
         }
 
         if (onChunk && !tool && String(response.headers.get("content-type") || "").includes("text/event-stream")) {


### PR DESCRIPTION
Fixes #511 — and very likely the "map never changes / countries aren't annexed / nobody opens diplomacy" reports, which trace to the same root cause.

## Root cause
`runJsonTask` hardcoded an **8192 max-output-token cap** on every AI turn (`gameplay.js`). A month-long or action-heavy turn asks for up to ~37 events with full impacts + chat bodies; that JSON blows past 8192 tokens, the provider **truncates it mid-response**, it won't parse, and the game **falls back to canned events** — which contain **no region transfers and no diplomacy**.

So the same cap explains all of it:
- **#511** — the "Response did not contain parseable JSON or tool arguments" fallback on long turns.
- **Map never changes / no annexations** — the real `regionTransfers` were in the truncated output that got discarded.
- **No diplomacy after invasions** — the real `createdChats`/`diplomaticOutreach` were discarded too.

The prompt/vocabulary fixes in #499-501 only apply *if the output parses*, which it wasn't.

## Fix — no cap; each provider uses its own model maximum
- **`gameplay.js`** — `runJsonTask` no longer passes `maxTokens`.
- **`main.jsx`** — providers stop flooring at 8192:
  - **OpenAI / OpenAI-compatible** — omit the token-limit field → the provider uses the model's maximum.
  - **Gemini** — the tool (jump) path already sent no cap; unchanged.
  - **Anthropic** — `max_tokens` is *required* and the API 400s above the model's ceiling, so it requests the model's max and, on that 400 (whose message states the ceiling), **learns + caches the model's real limit and retries at it**. Capable models use their full range; low-ceiling models self-correct on the first call.

Reaches every existing campaign immediately (live call path, independent of the frozen per-game prompts). Cost is unchanged — providers bill actual output, not the requested max.

## Verification
Build passes. This is provider-call code, so the "long turn no longer falls back" behavior needs a real API key + a genuinely large turn to confirm at runtime (not reproducible in the sandbox). Worth a spot-check on OpenAI/Anthropic/Gemini keys.

Delivered as its own PR (per the plan) so a provider-path change stays isolated from the schema/UI work for the other reported items (actions-not-clearing, city rename, stat persistence), which follow separately.
