### PR TITLE
Clear the previous round's actions from the panel after a jump

### DIFF
--- a/src/Game/GameUI/actions.jsx
+++ b/src/Game/GameUI/actions.jsx
@@ -236,6 +236,7 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
     const [isImproving, setIsImproving] = React.useState(false);
     const [isSuggesting, setIsSuggesting] = React.useState(false);
     const inputRef = React.useRef(null);
+    const lastRoundRef = React.useRef(null);
 
     React.useEffect(() => {
         if (!isOpen) {
@@ -266,6 +267,19 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
 
                 if (data.gameDate) {
                     setGameDate(dayjs(data.gameDate).format("MMMM Do, YYYY"));
+                }
+
+                // After a jump, applySimulationResult re-marks last round's actions
+                // "resolved" (submittedActions filters those out) — but this panel never
+                // re-read the store, so they lingered. Reload when the round advances so
+                // the previous turn's actions clear automatically. First tick just seeds
+                // the ref (no spurious reload); a freshly queued next-turn action is
+                // already persisted, so the reload keeps it.
+                if (typeof data.round === "number") {
+                    if (lastRoundRef.current !== null && data.round !== lastRoundRef.current) {
+                        loadActions().then((saved) => { if (!cancelled) setActions(saved); });
+                    }
+                    lastRoundRef.current = data.round;
                 }
             })
             .catch(() => {});


### PR DESCRIPTION
Your report: after a turn's events generate, the previous round's actions stay in the Actions panel and aren't cleared.

**Cause:** the data layer is already correct — a jump re-marks last round's planned actions `resolved` and `submittedActions` filters those out — but the panel's 5-second poll only re-read country/date, never the actions store. So the old actions lingered until you reopened the panel.

**Fix (`actions.jsx` only):** reload the actions in the same poll when the round advances (a reliable per-jump signal). UI-only, reaches every game, no schema/prompt change. A freshly queued next-turn action is already persisted, so the reload keeps it.