### PR TITLE
Let the AI rename cities and structures (#510)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -427,6 +427,9 @@ const runJsonTask = async (taskKey, {
     // re-narrated under each new turn's date) that a de-dup can't catch. Appended at
     // call time so existing frozen-prompt campaigns get it too.
     systemPrompt = `${systemPrompt}\n\n[New Developments Only]\nThe events shown to you above have ALREADY happened and appear only as context. Do NOT restate, rephrase, re-report, or re-narrate them. Emit ONLY genuinely NEW developments that occur during THIS period. If an ongoing situation (a war, a crisis, an occupation) has no new development this period, do not emit an event for it.`;
+    // Place renaming: appended at call time so existing frozen-prompt campaigns get it
+    // too; the markerOps rename op ships via the LIVE tool schema either way.
+    systemPrompt = `${systemPrompt}\n\n[Place Renaming]\nYou may rename places when the story warrants it (a city renamed after a leader or ideology, a capital re-designated, a colonial name replaced, a conquered city given the conqueror's name). Emit an impacts.markerOps entry {"op":"rename","name":"<current name>","newName":"<new name>","note":"<why>"}. This works on structures you built AND on existing map cities. Do it sparingly and only when a real event motivates it.`;
   }
 
   // Reputation context: how the world currently regards the player, and how the

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -254,7 +254,7 @@ const markerSchema = {
 };
 
 const markerOpSchema = {
-  description: "A structure mutation. Use op build or remove and fill the fields that op needs.",
+  description: "A structure/place mutation. Use op build, remove, or rename and fill the fields that op needs.",
   anyOf: [
     {
       type: "object",
@@ -274,6 +274,18 @@ const markerOpSchema = {
         note: textSchema("Brief explanation of the removal."),
       },
       required: ["op", "name"],
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      properties: {
+        op: { type: "string", enum: ["rename"] },
+        markerId: textSchema("Existing marker identifier, when known."),
+        name: nonEmptyTextSchema("Current name of the structure or city to rename."),
+        newName: nonEmptyTextSchema("New display name."),
+        note: textSchema("Brief explanation of the rename."),
+      },
+      required: ["op", "name", "newName"],
       additionalProperties: false,
     },
   ],

--- a/src/Game/Map/Cities.jsx
+++ b/src/Game/Map/Cities.jsx
@@ -43,7 +43,19 @@ const customTierFilter = [
 
 const customSortKey = ["-", ["+", ["*", ["get", "tier"], 1000000000], ["get", "population"]]];
 
-const StockCities = () => (
+// Stock/custom city labels come from the immutable PMTiles/geojson "city" property.
+// AI renames (world.cityRenames) are applied as a client-side match override so a
+// renamed city shows its new name without touching the tiles.
+const cityLabelExpr = (renames) => {
+    const pairs = Object.entries(renames || {});
+    if (!pairs.length) return ["get", "city"];
+    const expr = ["match", ["downcase", ["get", "city"]]];
+    for (const [from, to] of pairs) expr.push(from, to);
+    expr.push(["get", "city"]);
+    return expr;
+};
+
+const StockCities = ({ label }) => (
     <Source id="cities-source" type="vector" url={PMTILES_PROTOCOL_URLS.cities}>
     <Layer
     id="cities-shapes"
@@ -95,7 +107,7 @@ const StockCities = () => (
     filter={populationFilter}
     layout={{
         "symbol-sort-key": ["-", ["get", "population"]],
-        "text-field": ["get", "city"],
+        "text-field": label,
         "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
         "text-padding": 5,
         "text-radial-offset": 0.7,
@@ -117,7 +129,7 @@ const StockCities = () => (
 
 // Same visual language as the stock layers (★/◆/■ markers, haloed labels), but
 // fed from the scenario's cities.geojson and gated by the authored tier.
-const CustomCities = ({ data }) => (
+const CustomCities = ({ data, label }) => (
     <Source id="cities-source" type="geojson" data={data}>
     <Layer
     id="cities-shapes"
@@ -154,7 +166,7 @@ const CustomCities = ({ data }) => (
     filter={customTierFilter}
     layout={{
         "symbol-sort-key": customSortKey,
-        "text-field": ["get", "city"],
+        "text-field": label,
         "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
         "text-padding": 5,
         "text-radial-offset": 0.7,
@@ -178,9 +190,10 @@ const Cities = () => {
     // world.customCities marks scenarios whose maps carry their own era-accurate
     // city set (presets, editor maps). Consumed from the shared world-state hook
     // so the map doesn't fire its own independent 5s poll.
-    const { customCities: customFlag } = useWorldState();
+    const { customCities: customFlag, cityRenames } = useWorldState();
     const [customData, setCustomData] = useState(null);
     const citiesGeojsonUrl = JSON_URLS.citiesGeojson;
+    const label = React.useMemo(() => cityLabelExpr(cityRenames), [cityRenames]);
 
     // The city set itself is static per scenario — fetched once when the flag (or
     // the runtime token behind the URL) changes.
@@ -207,9 +220,9 @@ const Cities = () => {
     // the custom set is still loading, show nothing rather than flash modern names.
     if (customFlag) {
         if (!customData || !customData.features.length) return null;
-        return <CustomCities data={customData} />;
+        return <CustomCities data={customData} label={label} />;
     }
-    return <StockCities />;
+    return <StockCities label={label} />;
 };
 
 export default Cities;

--- a/src/Game/Map/useWorldState.js
+++ b/src/Game/Map/useWorldState.js
@@ -91,6 +91,7 @@ export function useWorldState() {
     regionClaimants: state?.regionClaimants ?? {},
     polityOverrides: state?.polityOverrides ?? {},
     markers: Array.isArray(state?.markers) ? state.markers : EMPTY_MARKERS,
+    cityRenames: state?.cityRenames ?? {},
     labelFont: state?.labelFont ?? "",
     labelHaloColor: state?.labelHaloColor ?? "",
     labelTextColor: state?.labelTextColor ?? "",
@@ -113,6 +114,7 @@ export function useWorldState() {
     JSON.stringify(prev.regionClaimants) === JSON.stringify(derived.regionClaimants) &&
     // Markers are an array of small objects; same content-compare reasoning.
     JSON.stringify(prev.markers) === JSON.stringify(derived.markers) &&
+    JSON.stringify(prev.cityRenames) === JSON.stringify(derived.cityRenames) &&
     areEqualShallow(prev.polityOverrides, derived.polityOverrides)
       ? prev
       : derived;

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -25,6 +25,10 @@ export const WORLD_DEFAULTS = {
   // tags.json holds the map-maker's STARTING tags; this holds every change since,
   // and wins where present (see resolveCountryTags).
   countryTags: {},
+  // AI renames of STOCK map cities (which live in PMTiles, not world.markers):
+  // lowercased original city name -> new display name. world.markers cities are
+  // renamed in place by applyMarkerOps; this is the override layer for the rest.
+  cityRenames: {},
   // Country-label styling, set in the scenario settings. Empty = the defaults
   // (Impact, white letters, half-black outline). The font renders from the
   // PLAYER's local fonts — the style has no glyphs endpoint, so MapLibre v5
@@ -567,6 +571,14 @@ const normalizeMarkerOp = (entry) => {
     return { op: "remove", markerId, name, note: normalizeOptionalString(entry.note) };
   }
 
+  if (op === "rename") {
+    const markerId = normalizeOptionalString(entry.markerId || entry.id);
+    const name = normalizeOptionalString(entry.name || entry.from || entry.oldName);
+    const newName = normalizeOptionalString(entry.newName || entry.to);
+    if ((!markerId && !name) || !newName) return null;
+    return { op: "rename", markerId, name, newName, note: normalizeOptionalString(entry.note) };
+  }
+
   return null;
 };
 
@@ -584,6 +596,11 @@ export const applyMarkerOps = (markers, ops) => {
     } else if (op.op === "remove") {
       next = next.filter((marker) =>
         op.markerId ? marker.id !== op.markerId : marker.name.toLowerCase() !== op.name.toLowerCase());
+    } else if (op.op === "rename") {
+      next = next.map((marker) =>
+        (op.markerId ? marker.id === op.markerId : marker.name.toLowerCase() === (op.name || "").toLowerCase())
+          ? { ...marker, name: op.newName }
+          : marker);
     }
   }
   return next;
@@ -902,6 +919,13 @@ export const normalizeWorldState = (world) => {
       })
       .filter(Boolean),
     markers: normalizeMarkers(nextWorld.markers),
+    // Explicit (not via the ...WORLD_DEFAULTS spread) so this new field survives every
+    // write path — the documented new-world-field trap.
+    cityRenames: Object.fromEntries(
+      Object.entries(nextWorld.cityRenames && typeof nextWorld.cityRenames === "object" ? nextWorld.cityRenames : {})
+        .map(([key, value]) => [normalizeString(key).toLowerCase(), normalizeString(value)])
+        .filter(([key, value]) => key && value),
+    ),
     simulationRules: normalizeOptionalString(nextWorld.simulationRules),
     startingTimelineText: normalizeOptionalString(nextWorld.startingTimelineText),
     units: normalizeUnits(nextWorld.units),
@@ -1106,7 +1130,20 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
     }
 
     if (event.impacts.markerOps?.length) {
+      const before = normalizeMarkers(nextWorld.markers);
       nextWorld.markers = applyMarkerOps(nextWorld.markers, event.impacts.markerOps);
+      // A rename that matched no existing structure is a STOCK-map city rename (stock
+      // cities live in PMTiles, not world.markers) — record it as an override layer so
+      // the label layer can show the new name (see Cities.jsx / cityRenames).
+      for (const raw of normalizeArray(event.impacts.markerOps)) {
+        const op = normalizeMarkerOp(raw);
+        if (!op || op.op !== "rename" || !op.name) continue;
+        const matched = before.some((m) =>
+          op.markerId ? m.id === op.markerId : m.name.toLowerCase() === op.name.toLowerCase());
+        if (!matched) {
+          nextWorld.cityRenames = { ...(nextWorld.cityRenames || {}), [op.name.toLowerCase()]: op.newName };
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #510 — the AI can now rename places when the story warrants it (a city renamed after a leader/ideology, a capital re-designated, a colonial name replaced, a conquered city given the conqueror's name).

**How it works**
- A new **live `rename` marker-op** (`gameplaySchemas.js`) — ships via the tool schema, so it reaches existing frozen-prompt campaigns immediately, not just new games.
- `world.markers` cities/structures are renamed **in place** (`applyMarkerOps`).
- **Stock map cities** live in the PMTiles city layer, not `world.markers`, so a rename that matches no marker is folded into a `world.cityRenames` override map, and `Cities.jsx` applies it as a client-side `match` label expression — the renamed city shows its new name without rebuilding tiles.
- A call-time **[Place Renaming]** directive (`gameplay.js`) tells the model how/when to use it ("sparingly, only when a real event motivates it"), reaching existing games too.

**Verification:** build passes; booted the app and confirmed the cities layer wiring loads with no style error and the generated label expression is a valid MapLibre `match`. The actual on-map label swap needs real map tiles (not available in the sandbox) — worth a quick spot-check in a live game.

**Known limitation (flagged):** stock-city rename is name-keyed (PMTiles features have no stable per-feature id), so it renames every city of that exact name. Acceptable for now.