### PR TITLE
Persist country stats; the AI changes them (stop regenerating every date)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1617,6 +1617,19 @@ export const generateCountryStatSheet = async ({ code, name } = {}) => {
     ].filter(Boolean).join("\n\n"),
     variables,
   });
+  // Persist into world state so the sheet SURVIVES date changes and the AI can mutate
+  // it via polityChanges.stats (see applyEventImpactsToWorld) — "stats persist and only
+  // change when the AI changes them". Re-read the world first to avoid clobbering a
+  // concurrent jump's write.
+  const statCode = normalizeString(code);
+  if (statCode && payload && typeof payload === "object") {
+    try {
+      const world = normalizeWorldState(await readWorldState({ force: true }));
+      await writeWorldState({ ...world, countryStats: { ...world.countryStats, [statCode]: payload } });
+    } catch (error) {
+      console.warn("[ai] failed to persist country stats:", error);
+    }
+  }
   return payload;
 };
 

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -104,6 +104,63 @@ const regionTransferSchema = {
   additionalProperties: false,
 };
 
+// AI-authored updates to a country's PERSISTENT stat sheet (world.countryStats[code]).
+// Only fields that CHANGED this period are sent; everything else persists. Absolute
+// values, not deltas. Kept self-contained (no percentageSchema dep, which is defined
+// later). LIVE via the tool schema, so it reaches existing frozen-prompt games.
+const statPct = (description) => ({ type: "integer", minimum: 0, maximum: 100, description });
+const statsUpdateSchema = {
+  type: "object",
+  description:
+    "Updated national statistics for this polity. Include ONLY the fields that changed this period "
+    + "(a coup changes leader/government/stability; a war changes reputation/economy) — every field you "
+    + "omit keeps its previous value. Values are absolute, not deltas.",
+  properties: {
+    capital: textSchema("Capital, only when it changes."),
+    continent: textSchema("Continent / broad region, only when it changes."),
+    government: textSchema("Government system and ideology, only when it changes."),
+    leader: textSchema("Head of state or government, only when it changes."),
+    stability: statPct("National stability 0-100."),
+    indices: {
+      type: "object",
+      properties: {
+        sovereignty: statPct("Practical political sovereignty."),
+        foodAutonomy: statPct("Domestic food autonomy."),
+        energyAutonomy: statPct("Domestic energy autonomy."),
+        economicIndependence: statPct("Economic independence."),
+        internalSecurity: statPct("Internal security."),
+        internationalReputation: statPct("International reputation / standing."),
+      },
+      additionalProperties: false,
+    },
+    economy: {
+      type: "object",
+      properties: {
+        gdp: textSchema("GDP estimate."),
+        gdpGrowth: textSchema("Annual GDP growth estimate."),
+        gdpPerCapita: textSchema("GDP per capita estimate."),
+        currency: textSchema("Currency."),
+        inflation: textSchema("Inflation estimate."),
+        unemployment: textSchema("Unemployment estimate."),
+        publicDebt: textSchema("Public debt estimate."),
+        budgetBalance: textSchema("Budget balance estimate."),
+      },
+      additionalProperties: false,
+    },
+    gdpBreakdown: {
+      type: "object",
+      description: "Agriculture/industry/services shares — send all three together so they still sum to ~100.",
+      properties: {
+        agriculture: statPct("Agriculture share of GDP."),
+        industry: statPct("Industry share of GDP."),
+        services: statPct("Services share of GDP."),
+      },
+      additionalProperties: false,
+    },
+  },
+  additionalProperties: false,
+};
+
 const polityChangeSchema = {
   type: "object",
   description: "A creation, rename, recolor, or metadata change for a polity.",
@@ -128,6 +185,7 @@ const polityChangeSchema = {
       + "rewrite these.",
     ),
     note: textSchema("Brief reason for the change."),
+    stats: statsUpdateSchema,
   },
   required: ["code"],
   additionalProperties: false,

--- a/src/Game/GameUI/stats.jsx
+++ b/src/Game/GameUI/stats.jsx
@@ -185,8 +185,20 @@ const StatsPane = ({ active }) => {
         if (!code) return;
         const cacheKey = `${player.gameKey}:${code}`;
         if (!force) {
+            // The persisted, AI-maintained sheet in world state wins and SURVIVES date
+            // changes — it changes only when the AI changes it (polityChanges.stats).
+            try {
+                const world = await readWorldState({ force: false });
+                const persisted = world?.countryStats?.[code];
+                if (persisted && isValidStatSheet(persisted)) {
+                    memoryCache.set(cacheKey, { date: player.date, sheet: persisted });
+                    setState({ status: "ready", sheet: persisted, error: "" });
+                    return;
+                }
+            } catch { /* fall through to the device cache / regenerate */ }
+            // Device-cache fallback — no longer date-gated, so it persists across dates.
             const cached = memoryCache.get(cacheKey) ?? readStoredSheets()[cacheKey];
-            if (cached && cached.date === player.date && isValidStatSheet(cached.sheet)) {
+            if (cached && isValidStatSheet(cached.sheet)) {
                 memoryCache.set(cacheKey, cached);
                 setState({ status: "ready", sheet: cached.sheet, error: "" });
                 return;

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -21,6 +21,10 @@ export const WORLD_DEFAULTS = {
   // polityChanges and fed back into prompts. Authoritative, unlike the on-demand
   // stat sheet it was first read from.
   internationalReputation: {},
+  // Persisted per-country stat sheets (code -> the full sheet), seeded on first view
+  // and thereafter changed ONLY by the AI (polityChanges.stats), so a country's stats
+  // stop regenerating/drifting every date change.
+  countryStats: {},
   // Per-country tags the AI has changed: owner code -> string[]. The scenario's
   // tags.json holds the map-maker's STARTING tags; this holds every change since,
   // and wins where present (see resolveCountryTags).
@@ -462,6 +466,12 @@ const normalizePolityChange = (entry) => {
     ? normalizeTagList(entry.tags || entry.countryTags)
     : null;
 
+  // Persistent stat-sheet update: keep the partial object as-is (the merge + the Stats
+  // pane tolerate missing/extra fields); null means "no stat change this period".
+  const stats = entry.stats && typeof entry.stats === "object" && !Array.isArray(entry.stats)
+    ? entry.stats
+    : null;
+
   return {
     aliases: normalizeActionParticipants(entry.aliases || entry.additionalNames),
     code,
@@ -469,6 +479,7 @@ const normalizePolityChange = (entry) => {
     name: normalizeOptionalString(entry.name || entry.newName),
     note: normalizeOptionalString(entry.note || entry.reason),
     reputation,
+    stats,
     tags,
   };
 };
@@ -857,10 +868,18 @@ export const normalizeWorldState = (world) => {
       .filter(([country, list]) => country && list.length),
   );
 
+  // Persisted per-country stat sheets: keep each code -> sheet-object entry as-is (the
+  // Stats pane tolerates missing fields). Explicit, not via the spread — new-field trap.
+  const countryStats = Object.fromEntries(
+    Object.entries(nextWorld.countryStats ?? {})
+      .filter(([code, sheet]) => normalizeOptionalString(code) && sheet && typeof sheet === "object"),
+  );
+
   return {
     ...WORLD_DEFAULTS,
     ...nextWorld,
     countryTags,
+    countryStats,
     actionSuggestions: normalizeActionSuggestions(nextWorld.actionSuggestions),
     activeCatalyst: normalizeCatalyst(nextWorld.activeCatalyst),
     consolidatedHistory: normalizeConsolidatedHistory(nextWorld.consolidatedHistory),
@@ -1086,6 +1105,34 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
       // Reputation the AI set this turn becomes the polity's authoritative value.
       if (Number.isFinite(change.reputation)) {
         nextWorld.internationalReputation[change.code] = change.reputation;
+        // Keep the persisted sheet's reputation index in sync with the authoritative value.
+        if (nextWorld.countryStats?.[change.code]?.indices) {
+          nextWorld.countryStats[change.code] = {
+            ...nextWorld.countryStats[change.code],
+            indices: { ...nextWorld.countryStats[change.code].indices, internationalReputation: change.reputation },
+          };
+        }
+      }
+
+      // Persistent stat sheet: merge the AI's changed fields into the stored sheet so a
+      // country's stats change ONLY when the AI changes them (not every date). Deep-merge
+      // the nested groups and mirror the reputation index into the authoritative store.
+      if (change.stats && typeof change.stats === "object") {
+        if (!nextWorld.countryStats || typeof nextWorld.countryStats !== "object") nextWorld.countryStats = {};
+        const prev = nextWorld.countryStats[change.code] && typeof nextWorld.countryStats[change.code] === "object"
+          ? nextWorld.countryStats[change.code]
+          : {};
+        const merged = { ...prev, ...change.stats };
+        for (const group of ["indices", "economy", "gdpBreakdown"]) {
+          if (change.stats[group] && typeof change.stats[group] === "object") {
+            merged[group] = { ...(prev[group] || {}), ...change.stats[group] };
+          }
+        }
+        nextWorld.countryStats[change.code] = merged;
+        const rep = Number(merged.indices?.internationalReputation);
+        if (Number.isFinite(rep)) {
+          nextWorld.internationalReputation[change.code] = Math.max(0, Math.min(100, Math.round(rep)));
+        }
       }
 
       // Tags the AI set this turn replace the scenario's starting tags for this


### PR DESCRIPTION
Your report: once a country's stats are generated, they should persist and change **only when the AI changes them** — instead the whole sheet regenerated from scratch every time the date advanced.

**Fix**
- Stats now live in **`world.countryStats[code]`** (persisted, synced, travels with the save) — not a date-keyed cache that regenerated on every jump.
- The AI mutates them via a new **live `stats` field on polityChanges**: it sends only the fields that changed (a coup → leader/stability; a war → reputation/economy), and `applyEventImpactsToWorld` **deep-merges** them onto the stored sheet so every other field persists. Reputation stays in sync with the authoritative `world.internationalReputation` both ways.
- `generateCountryStatSheet` persists the first-generated sheet into world state so the AI has a full sheet to mutate.
- The Stats pane reads `world.countryStats` first and no longer regenerates on date change (the ↻ refresh still forces a fresh sheet).

Reaches existing campaigns immediately (the `stats` schema field is live).

**Verified in a real browser** against the actual data functions: a partial stat update applied its changed fields (stability, economy.gdp, reputation) while **preserving every unchanged field** (capital, sovereignty, currency), and mirrored reputation into the authoritative store. `normalizeWorldState` keeps `countryStats`; build passes.

Delivered isolated from the still-open city-rename PR (#521) even though both touch `gameState.js`/`gameplaySchemas.js` — the hunks are in different places, so this is a clean #3-only diff.