### PR TITLE
Fix AI-turn bugs: reasoning chats, disable-timeout, null-island units, owner labels

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -389,7 +389,7 @@ const ACTIONS_REFERENCE = "[Actions You Can Take]\nThis is the full menu of leve
 const runJsonTask = async (taskKey, {
   fallback,
   signal,
-  timeoutMs = 120000,
+  timeoutMs = getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 120000 : 0,
   userMessage,
   validatePayload,
   variables,
@@ -446,6 +446,12 @@ const runJsonTask = async (taskKey, {
   // take-the-whole-region (default) vs capture-only-the-city (markerOps) distinction.
   if (["jumpForward", "autoJumpForward"].includes(taskKey)) {
     systemPrompt = `${systemPrompt}\n\n[Region and City Capture]\nOn this map, territory is owned by REGIONS, and impacts.regionTransfers MUST name a region exactly as it appears in the [Game Map Description] above — never a city, town, port, or landmark. Cities such as Toulouse or Narbonne are only markers that sit INSIDE a region; a regionTransfer whose regionId is a city name matches no region and is silently discarded, so the border never moves even though the event says it did. To capture a place and the ground around it, transfer the REGION that contains it, and set fromCode to that region\u2019s current owner.\nTaking a region takes everything inside it, cities included — that is the normal case, so a city changing hands usually means transferring its whole region. To capture ONLY a city while its region stays with its current owner (a besieged holdout, an occupied port, an enclave), do NOT name it in regionTransfers; instead emit an impacts.markerOps build for it — {\"op\":\"build\",\"marker\":{\"name\":\"<city>\",\"kind\":\"city\",\"ownerCode\":\"<new holder>\",\"lng\":<lng>,\"lat\":<lat>}} — using that city\u2019s coordinates from [City Coordinates]. That places the city under the new owner without moving the region border.`;
+  }
+
+  // Units kept landing at 0,0 (null island) because the model copied the lng:0,lat:0
+  // placeholder from the output template; guide it to real coordinates.
+  if (["jumpForward", "autoJumpForward"].includes(taskKey)) {
+    systemPrompt = `${systemPrompt}\n\n[Unit Coordinates]\nEvery unitOps spawn and move MUST use the real-world longitude and latitude of where the unit actually is or is going. The lng 0 / lat 0 shown in the output template is ONLY a placeholder \u2014 0,0 is open ocean off West Africa, never a valid position, and a unit placed there is discarded. Set lng and lat to the actual coordinates: use the values from [City Coordinates] for a unit at or near one of those cities, or the real coordinates of the region or front where the action happens.`;
   }
 
   if (["actions", "jumpForward", "autoJumpForward", "catalystCreation", "catalystExecutor"].includes(taskKey)) {
@@ -575,7 +581,7 @@ const consolidateHistoryBatch = async (bundle, events, chats) => {
         buildChatSummaryText(chats, { limit: chats.length || 1 }),
       ].filter(Boolean).join("\n"),
     }),
-    timeoutMs: 60000,
+    timeoutMs: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 60000 : 0,
     userMessage: "Consolidate the supplied campaign history with the required tool.",
     variables,
   });
@@ -2200,7 +2206,7 @@ export const maybeSendIdleDiplomacy = async ({ chance = IDLE_DIPLOMACY_CHANCE } 
     if (!normalizeString(bundle.game?.country)) return null; // no active game
     const variables = await buildTemplateVariables(bundle);
     const { payload } = await runJsonTask("idleDiplomacy", {
-      timeoutMs: 60000,
+      timeoutMs: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 60000 : 0,
       userMessage:
         "A quiet moment between rounds. Decide whether any single polity would send the player a short diplomatic note right now. Return JSON only.",
       validatePayload: async (candidate, { finalAttempt } = {}) => {

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -152,25 +152,38 @@ function extractGeminiToolInput(data, tool) {
     return call?.args && typeof call.args === "object" ? call.args : null;
 }
 
+// Qwen/DeepSeek thinking models emit reasoning either in a separate field or inline in
+// <think>...</think>. Strip the think block so we return the actual answer; an unclosed
+// <think> means the stream was cut mid-thought, leaving no answer, so drop it too.
+function stripThinking(value) {
+    if (typeof value !== "string") return "";
+    let out = value.replace(/<think>[\s\S]*?<\/think>/gi, "");
+    const open = out.search(/<think>/i);
+    if (open !== -1) out = out.slice(0, open);
+    return out.trim();
+}
+
 function extractOpenAIMessageText(data) {
-    const content = data?.choices?.[0]?.message?.content;
+    const message = data?.choices?.[0]?.message;
+    const raw = message?.content;
+    let text = "";
 
-    if (typeof content === "string") {
-        return content.trim();
-    }
-
-    if (Array.isArray(content)) {
-        return content
+    if (typeof raw === "string") {
+        text = raw;
+    } else if (Array.isArray(raw)) {
+        text = raw
         .map((part) => {
             if (typeof part === "string") return part;
             if (typeof part?.text === "string") return part.text;
             return "";
         })
-        .join("")
-        .trim();
+        .join("");
     }
 
-    return "";
+    text = stripThinking(text);
+    // All reasoning, no answer (#540): fall back to the reasoning text rather than error.
+    if (!text) text = stripThinking(message?.reasoning);
+    return text;
 }
 
 function extractOpenAIToolInput(data, tool) {
@@ -345,6 +358,7 @@ export async function readOpenAIStreamedResponse(response) {
     const decoder = new TextDecoder();
     let buffer = "";
     let content = "";
+    let reasoning = "";
     let toolName = "";
     let toolArguments = "";
     let finishReason = null;
@@ -365,6 +379,10 @@ export async function readOpenAIStreamedResponse(response) {
                 if (!choice) continue;
                 const delta = choice.delta ?? choice.message ?? {};
                 if (typeof delta.content === "string") content += delta.content;
+                // Thinking-mode models (Qwen3, DeepSeek-R1) stream their chain of thought in a
+                // separate reasoning field; keep it so an all-reasoning delta isn't lost (#540).
+                if (typeof delta.reasoning === "string") reasoning += delta.reasoning;
+                else if (typeof delta.reasoning_content === "string") reasoning += delta.reasoning_content;
                 const call = Array.isArray(delta.tool_calls) ? delta.tool_calls[0] : null;
                 if (call?.function?.name) toolName = call.function.name;
                 if (typeof call?.function?.arguments === "string") toolArguments += call.function.arguments;
@@ -379,6 +397,7 @@ export async function readOpenAIStreamedResponse(response) {
             finish_reason: finishReason,
             message: {
                 content,
+                ...(reasoning ? { reasoning } : {}),
                 ...(toolName || toolArguments
                     ? { tool_calls: [{ type: "function", function: { name: toolName, arguments: toolArguments } }] }
                     : {}),

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -351,7 +351,11 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
     if (props.gid0 && props.country && !countryNameByCode.has(props.gid0)) {
       countryNameByCode.set(props.gid0, props.country);
     }
-    const owner = overrides?.[props.id] ?? props.owner;
+    const rawOwner = overrides?.[props.id] ?? props.owner;
+    // Captured-region override stores the AI's owner CODE ("ESP"); the seed stores the NAME
+    // ("Spain"). Canonicalize so both share one cluster + label instead of the code splitting
+    // off as a phantom new country.
+    const owner = COUNTRY_NAMES[rawOwner] ?? rawOwner;
     if (!owner) continue;
     const best = largestRingOf(allFeatures[index].geometry);
     if (!best || best.area <= 0) continue;
@@ -725,8 +729,11 @@ const WorldMap = ({ isGlobe = false }) => {
   // Resolving the name but not the colour painted those regions a muddy
   // procedural fallback, which reads to a player as "the map didn't annex it".
   const resolveOwnerRgb = useCallback(
-    (owner) => {
-      if (!owner) return null;
+    (rawOwner) => {
+      if (!rawOwner) return null;
+      // Canonicalize an owner CODE ("ESP" from a transfer override) to the NAME the palette
+      // is keyed by ("Spain") so a captured region takes its true owner's colour.
+      const owner = COUNTRY_NAMES[rawOwner] ?? rawOwner;
       const exact = colorMap[owner];
       if (exact) return exact;
       const registry = parseColorToRgb(polityOverrides?.[owner]?.color);

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -496,7 +496,7 @@ export const normalizeUnitEntry = (entry, index = 0) => {
   const lng = finiteOrNull(entry.lng ?? entry.lon ?? entry.longitude);
   const lat = finiteOrNull(entry.lat ?? entry.latitude);
   const ownerCode = normalizeOptionalString(entry.ownerCode || entry.owner || entry.code);
-  if (lng === null || lat === null || !ownerCode) {
+  if (lng === null || lat === null || (lng === 0 && lat === 0) || !ownerCode) {
     return null;
   }
 
@@ -539,7 +539,7 @@ export const normalizeMarkerEntry = (entry, index = 0) => {
   const lng = finiteOrNull(entry.lng ?? entry.lon ?? entry.longitude);
   const lat = finiteOrNull(entry.lat ?? entry.latitude);
   const name = normalizeOptionalString(entry.name || entry.title);
-  if (lng === null || lat === null || !name) {
+  if (lng === null || lat === null || (lng === 0 && lat === 0) || !name) {
     return null;
   }
 
@@ -640,7 +640,7 @@ const normalizeUnitOp = (entry) => {
   if (op === "move") {
     const toLng = finiteOrNull(entry.toLng ?? entry.lng);
     const toLat = finiteOrNull(entry.toLat ?? entry.lat);
-    if (toLng === null || toLat === null) return null;
+    if (toLng === null || toLat === null || (toLng === 0 && toLat === 0)) return null;
     return {
       op,
       unitId,


### PR DESCRIPTION
This session's confirmed bug fixes, ported onto main: #540 reasoning-mode chats, #539 disable-timeout, units-at-0,0, and owner code->name render labels. Each verified (esbuild) and traced. See commit body.