### PR TITLE
Identify every polity by its full country name, never a code — main

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -2,6 +2,7 @@
 import { callAI } from "./main.jsx";
 import { normalizePromptPack } from "./gameplayPrompts.js";
 import { getGameplayTool, validateGameplayPayload } from "./gameplaySchemas.js";
+import { toCountryName } from "../../runtime/ownerNames.js";
 import {
   buildActionHistoryText,
   buildChatSummaryText,
@@ -445,7 +446,15 @@ const runJsonTask = async (taskKey, {
   // moves though the event narrates a capture. Force region names, and teach the
   // take-the-whole-region (default) vs capture-only-the-city (markerOps) distinction.
   if (["jumpForward", "autoJumpForward"].includes(taskKey)) {
-    systemPrompt = `${systemPrompt}\n\n[Region and City Capture]\nOn this map, territory is owned by REGIONS, and impacts.regionTransfers MUST name a region exactly as it appears in the [Game Map Description] above — never a city, town, port, or landmark. Cities such as Toulouse or Narbonne are only markers that sit INSIDE a region; a regionTransfer whose regionId is a city name matches no region and is silently discarded, so the border never moves even though the event says it did. To capture a place and the ground around it, transfer the REGION that contains it, and set fromCode to that region\u2019s current owner.\nTaking a region takes everything inside it, cities included — that is the normal case, so a city changing hands usually means transferring its whole region. To capture ONLY a city while its region stays with its current owner (a besieged holdout, an occupied port, an enclave), do NOT name it in regionTransfers; instead emit an impacts.markerOps build for it — {\"op\":\"build\",\"marker\":{\"name\":\"<city>\",\"kind\":\"city\",\"ownerCode\":\"<new holder>\",\"lng\":<lng>,\"lat\":<lat>}} — using that city\u2019s coordinates from [City Coordinates]. That places the city under the new owner without moving the region border.`;
+    systemPrompt = `${systemPrompt}\n\n[Region and City Capture]\nOn this map, territory is owned by REGIONS, and impacts.regionTransfers MUST name a region exactly as it appears in the [Game Map Description] above — never a city, town, port, or landmark. Cities such as Toulouse or Narbonne are only markers that sit INSIDE a region; a regionTransfer whose regionId is a city name matches no region and is silently discarded, so the border never moves even though the event says it did. To capture a place and the ground around it, transfer the REGION that contains it, and set fromCode to that region\u2019s current owner.\nTaking a region takes everything inside it, cities included — that is the normal case, so a city changing hands usually means transferring its whole region. To capture ONLY a city while its region stays with its current owner (a besieged holdout, an occupied port, an enclave), do NOT name it in regionTransfers; instead emit an impacts.markerOps build for it — {\"op\":\"build\",\"marker\":{\"name\":\"<city>\",\"kind\":\"city\",\"ownerCode\":\"<new holder>\",\"lng\":<lng>,\"lat\":<lat>}} — using that city\u2019s coordinates from [City Coordinates]. That places the city under the new owner without moving the region border.\nWhen a polity is conquered, annexed, partitioned, or unified OUTRIGHT — every region it still holds changing hands at once — you do not need one entry per region. Emit a SINGLE regionTransfer with "wholeCountry": true, put the losing polity's name in regionId instead of a region name, and set toCode to whoever takes it; the engine expands that into every region that polity currently owns. Use this ONLY for a total takeover of everything it holds. Any partial gain — a province, a border strip, a few regions — stays as ordinary per-region transfers, which remain the normal case.`;
+  }
+
+  // Polities are identified by their full country name EVERYWHERE. A model that
+  // answers "ESP" gets canonicalised on ingest, but it also then reasons about "ESP"
+  // and "Spain" as if they were two powers, so state the rule rather than only
+  // repairing the output.
+  if (["actions", "jumpForward", "autoJumpForward", "catalystCreation", "catalystExecutor"].includes(taskKey)) {
+    systemPrompt = `${systemPrompt}\n\n[Polity Names]\nEvery polity is identified ONLY by its full country name, exactly as written in the map description — "Spain", "United States", "Soviet Union". NEVER use a country code or abbreviation such as "ESP", "USA" or "SOV", anywhere, in any field. This applies to every owner field despite their names: toCode, fromCode, ownerCode and a polity's code all take the FULL NAME. A code is not a shorter way of writing a country here; it is a different, non-existent polity, and using one creates a phantom country on the map beside the real one.`;
   }
 
   // Units kept landing at 0,0 (null island) because the model copied the lng:0,lat:0
@@ -913,7 +922,9 @@ const resolveRegionTransfers = async (containers, world) => {
     return ownerAlias.get(key) ?? key;
   };
   const ownerKeyOf = (regionId) => {
-    const override = normalizeString(owners[regionId]);
+    // A legacy save can still hold a code here; canonicalise so it keys as the same
+    // owner as everything else rather than as a second, phantom power.
+    const override = toCountryName(normalizeString(owners[regionId]));
     if (override) return canonicalOwnerKey(override);
     // No override yet (e.g. the FIRST invasion of a war): the region is still held by
     // its base owner, which the catalog carries. Fall back to it — otherwise
@@ -921,12 +932,34 @@ const resolveRegionTransfers = async (containers, world) => {
     // the containment near-miss, AND buildTransferFeedback's candidate list all fail
     // exactly when the model most needs them (the transfer that STARTS a conflict).
     const region = byId.get(regionId);
-    return canonicalOwnerKey(region?.countryCode || region?.country || "");
+    return canonicalOwnerKey(region?.country || toCountryName(region?.countryCode) || "");
   };
   const regionsOwnedBy = (ownerToken) => {
     const key = canonicalOwnerKey(ownerToken);
     if (!key) return [];
     return catalog.filter((region) => ownerKeyOf(region.id) === key);
+  };
+  // Every owner key in this resolver is a full country NAME (ownerKeyOf canonicalises
+  // codes on the way through), so a country can be matched directly.
+  // Whole-country transfer: one entry that hands over EVERY region a polity still
+  // holds (total conquest, annexation, unification, partition). Regions the winner
+  // already owns are skipped so a self-transfer can't blank an owner.
+  const expandWholeCountry = (transfer) => {
+    const target = toCountryName(normalizeString(transfer?.regionId) || normalizeString(transfer?.regionName));
+    const key = canonicalOwnerKey(target);
+    if (!key) return [];
+    const toKey = canonicalOwnerKey(toCountryName(transfer?.toCode));
+    const owned = catalog.filter((region) => {
+      const owner = ownerKeyOf(region.id);
+      return owner === key && owner !== toKey;
+    });
+    return owned.map((region) => ({
+      ...transfer,
+      fromCode: toCountryName(normalizeString(transfer?.fromCode)) || target,
+      regionId: region.id,
+      regionName: region.name,
+      wholeCountry: undefined,
+    }));
   };
 
   const resolve = (transfer) => {
@@ -966,10 +999,35 @@ const resolveRegionTransfers = async (containers, world) => {
     if (transfers.length === 0) continue;
     const resolved = [];
     for (const transfer of transfers) {
+      // An explicit whole-country transfer expands FIRST: "annex Belgium" must move
+      // every Belgian region even though a region may share the country's name.
+      if (transfer?.wholeCountry === true) {
+        const expanded = expandWholeCountry(transfer);
+        if (expanded.length) {
+          console.info(
+            `[ai] ${path}.regionTransfers expanded whole country ` +
+              `"${normalizeString(transfer?.regionId)}" -> ${normalizeString(transfer?.toCode)}: ` +
+              `${expanded.length} region(s).`,
+          );
+          resolved.push(...expanded);
+          continue;
+        }
+      }
       const regionId = resolve(transfer);
       if (regionId) {
         transfer.regionId = regionId;
         resolved.push(transfer);
+        continue;
+      }
+      // Not a region the map knows — but it may be a POLITY the model meant wholesale
+      // ("Austria-Hungary is partitioned"). Expanding beats dropping the change.
+      const expanded = expandWholeCountry(transfer);
+      if (expanded.length) {
+        console.info(
+          `[ai] ${path}.regionTransfers treated "${normalizeString(transfer?.regionId)}" as a whole ` +
+            `country -> ${normalizeString(transfer?.toCode)}: ${expanded.length} region(s).`,
+        );
+        resolved.push(...expanded);
         continue;
       }
       unresolved.push({

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -33,7 +33,7 @@ const chatCountrySchema = {
   type: "object",
   description: "A polity participating in a generated diplomatic chat.",
   properties: {
-    code: textSchema("Polity code, when known."),
+    code: textSchema("Polity's FULL country name (\"Spain\"), never a country code."),
     name: nonEmptyTextSchema("Exact polity name."),
   },
   required: ["name"],
@@ -44,7 +44,7 @@ const chatMessageSchema = {
   type: "object",
   description: "An opening or follow-up message in a generated diplomatic chat.",
   properties: {
-    code: textSchema("Speaker polity code, when known."),
+    code: textSchema("Speaker polity's FULL country name (\"Spain\"), never a country code."),
     role: textSchema("Message role, such as leader or system."),
     speaker: textSchema("Exact name of the speaker."),
     text: textSchema("Message body."),
@@ -96,9 +96,18 @@ const regionTransferSchema = {
       + "(the engine resolves names to ids).",
     ),
     regionName: textSchema("Human-readable region name, when known."),
-    fromCode: textSchema("Previous owner polity code, when known."),
-    toCode: textSchema("New owner polity code."),
+    fromCode: textSchema("Previous owner's FULL country name (\"Spain\"), never a country code."),
+    toCode: textSchema("New owner's FULL country name (\"Spain\"), never a country code such as \"ESP\"."),
     note: textSchema("Brief reason for the transfer."),
+    wholeCountry: {
+      type: "boolean",
+      description:
+        "Set true ONLY for a total conquest, annexation, unification or partition in "
+        + "which one polity takes EVERY region another still holds. Then put the losing "
+        + "polity's name in regionId instead of a region name, and this single entry "
+        + "transfers all of its territory. Leave unset (the normal case) to transfer "
+        + "one named region.",
+    },
   },
   required: ["regionId", "toCode"],
   additionalProperties: false,
@@ -165,7 +174,7 @@ const polityChangeSchema = {
   type: "object",
   description: "A creation, rename, recolor, or metadata change for a polity.",
   properties: {
-    code: textSchema("Exact polity code."),
+    code: textSchema("Polity's exact FULL country name (\"Spain\"), never a country code."),
     name: textSchema("New polity name, only when it changes."),
     color: textSchema("New six-digit hexadecimal color, only when it changes."),
     aliases: stringArraySchema("Alternative polity names."),
@@ -202,7 +211,7 @@ const unitSchema = {
       description: "Unit type.",
       enum: ["infantry", "armor", "air", "naval", "artillery", "garrison"],
     },
-    ownerCode: nonEmptyTextSchema("Owning polity code."),
+    ownerCode: nonEmptyTextSchema("Owning polity's FULL country name (\"Spain\"), never a country code."),
     strength: {
       type: "integer",
       description: "Unit strength from 1 to 1000.",
@@ -291,7 +300,7 @@ const markerSchema = {
     id: textSchema("Stable marker identifier."),
     name: nonEmptyTextSchema("Display name of the structure."),
     kind: nonEmptyTextSchema("What the structure is, as a short lowercase noun phrase."),
-    ownerCode: textSchema("Owning polity code, when owned."),
+    ownerCode: textSchema("Owning polity's FULL country name (\"Spain\") when owned, never a country code."),
     lng: {
       type: "number",
       description: "Longitude of the structure.",

--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -361,23 +361,27 @@ export const buildWorldSummary = async (bundle, regionCatalog = null) => {
   // everyone else (the model names their regions on demand and the retry resolves
   // them). Focus = the player, anyone already re-owned, scenario-defined actors, and
   // the player's active chat partners — the likely belligerents.
-  const playerCode = normalizeString(bundle.game.country);
-  const overrideOwnerCodes = [...new Set(
-    territoryEntries.map(([, ownerCode]) => normalizeString(ownerCode)).filter(Boolean),
+  // Every focus token is a FULL COUNTRY NAME, because that is what the vocabulary is
+  // keyed by (regionOwnerName). A legacy override still holding "ESP" is canonicalised
+  // so it matches "Spain" — otherwise that power silently drops out of the enumerated
+  // section and the model is left inventing its region names again.
+  const playerName = toCountryName(normalizeString(bundle.game.country));
+  const overrideOwnerNames = [...new Set(
+    territoryEntries.map(([, owner]) => toCountryName(normalizeString(owner))).filter(Boolean),
   )];
-  const actorCodes = polities.map((entry) => normalizeString(entry?.code)).filter(Boolean);
-  const chatCodes = normalizeArray(bundle.chats).flatMap((chat) =>
-    normalizeArray(chat?.countries).map((country) => normalizeString(country?.code)).filter(Boolean));
-  const focusCodes = [playerCode, ...overrideOwnerCodes, ...actorCodes, ...chatCodes].filter(Boolean);
-  // Owner code -> display name for both sections: base country names from the catalog,
+  const actorNames = polities.map((entry) => toCountryName(normalizeString(entry?.code))).filter(Boolean);
+  const chatNames = normalizeArray(bundle.chats).flatMap((chat) =>
+    normalizeArray(chat?.countries).map((country) => toCountryName(normalizeString(country?.code))).filter(Boolean));
+  const focusCodes = [playerName, ...overrideOwnerNames, ...actorNames, ...chatNames].filter(Boolean);
+  // Owner name -> display name for both sections: base country names from the catalog,
   // with dynamic polity overrides layered on top (a re-owned/renamed power wins).
   const polityNames = {};
   for (const region of regions) {
-    const code = String(region.countryCode || region.country || "").toLowerCase();
-    if (code && !polityNames[code]) polityNames[code] = region.country || region.countryCode;
+    const name = String(region.country || toCountryName(region.countryCode) || "").toLowerCase();
+    if (name && !polityNames[name]) polityNames[name] = region.country || toCountryName(region.countryCode);
   }
   for (const entry of polities) {
-    if (entry?.code) polityNames[String(entry.code).toLowerCase()] = entry.name || entry.code;
+    if (entry?.code) polityNames[toCountryName(String(entry.code)).toLowerCase()] = entry.name || toCountryName(entry.code);
   }
   const regionOwnershipCatalog = buildRegionOwnershipText(regions, world.regionOwnershipOverrides, {
     focusCodes,

--- a/src/Game/AI/regionVocab.js
+++ b/src/Game/AI/regionVocab.js
@@ -17,39 +17,53 @@
 //     player, anyone already re-owned via an override, scenario-defined actors, and
 //     the player's active chat partners. These are the likely belligerents, so the
 //     model can emit a resolvable transfer on the FIRST attempt.
-//   Section 2 (CODES ONLY, no province names): every other owner, as
-//     `CODE (Name) — N regions`. This gives the model the fromCode/toCode vocabulary
+//   Section 2 (NAMES ONLY, no province names): every other owner, as
+//     `Name — N regions`. This gives the model the fromCode/toCode vocabulary
 //     for the long tail WITHOUT listing thousands of province names. When it targets
 //     one of these, it names the region as best it can and resolveRegionTransfers'
 //     retry (buildTransferFeedback, made reliable by the ownerKeyOf base-owner
 //     fallback) hands back that power's exact names — on demand, within the same jump.
 //
-// A region's owner is `regionOwnershipOverrides[id] ?? region.countryCode` (the base
+// Every owner in both sections is the FULL COUNTRY NAME. GADM's codes are provenance
+// on the region row, never an identity: the model is only ever shown, and only ever
+// asked for, "Spain".
+//
+// A region's owner is `regionOwnershipOverrides[id] ?? region.country` (the base
 // country from the catalog), so ownership is non-empty on stock maps, not just on
 // re-ownership scenarios. The catalog `name` is the exact in-game name the resolver
 // keys on (a GADM NAME_1 endonym like "Bayern"/"Ostpreussen"), so listing it — rather
 // than relying on the model's exonym guess ("Bavaria") — is what makes the transfer
 // resolvable.
 //
-// Pure and dependency-free so it is unit-tested directly (regionVocab.test.js)
-// without pulling in the browser-only asset layer that promptContext.js imports.
+// Unit-tested directly (regionVocab.test.js) without pulling in the browser-only asset
+// layer that promptContext.js imports — its only import is the owner-name
+// canonicaliser, which is plain data and safe to load anywhere.
+
+import { toCountryName } from "../../runtime/ownerNames.js";
 
 const norm = (value) => String(value ?? "").trim();
 const lower = (value) => norm(value).toLowerCase();
 
-// The in-game owner code for a region: an explicit override wins, else the base
-// country code from the catalog (so stock maps report real ownership, not "").
-export const regionOwnerCode = (region, overrides) => {
+// The in-game owner of a region, ALWAYS as the full country name ("Spain"): an
+// explicit override wins, else the base country from the catalog (so stock maps
+// report real ownership, not ""). It used to answer with the GADM CODE, which is
+// where the model learned to write "ESP" — and since a transfer's owner is stored
+// verbatim, that minted a phantom "ESP" country beside the real Spain. A legacy
+// override still holding a code is canonicalised here rather than handed on.
+// It also has to be the name for the FOCUS matching to work at all: the focus set is
+// built from the player's country and chat partners, which are names, so a code here
+// never matched and the player's own regions were left out of the enumerated list.
+export const regionOwnerName = (region, overrides) => {
   const override = norm(overrides?.[region?.id]);
-  if (override) return override;
-  return norm(region?.countryCode) || norm(region?.country);
+  if (override) return toCountryName(override);
+  return norm(region?.country) || toCountryName(norm(region?.countryCode));
 };
 
 // Group the catalog by current owner. Returns Map(lowerKey -> {label, regions}).
 const groupByOwner = (catalog, overrides) => {
   const groups = new Map();
   for (const region of catalog) {
-    const owner = regionOwnerCode(region, overrides);
+    const owner = regionOwnerName(region, overrides);
     if (!owner) continue; // unowned / ocean / malformed row
     const key = lower(owner);
     let group = groups.get(key);
@@ -67,7 +81,9 @@ export const FOCUS_INTRO =
   + "of these territories in a regionTransfer, copy a region's name or id EXACTLY "
   + "(never invent or translate a region name):";
 export const ROSTER_INTRO =
-  "All other powers and their owner codes (use the code for fromCode/toCode). A power "
+  "All other powers, by full country name. Every owner field (fromCode, toCode, "
+  + "ownerCode) takes the power's FULL NAME exactly as written here - \"Spain\", never "
+  + "a country code like \"ESP\" and never an abbreviation. A power "
   + "here is NOT region-listed above: when you narrate a transfer involving it, name "
   + "the region as precisely as you can and the engine will resolve it to the exact "
   + "in-game name, correcting you on retry if needed:";

--- a/src/Game/AI/regionVocab.test.js
+++ b/src/Game/AI/regionVocab.test.js
@@ -5,7 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildRegionOwnershipText,
-  regionOwnerCode,
+  regionOwnerName,
   FOCUS_INTRO,
   ROSTER_INTRO,
 } from "./regionVocab.js";
@@ -27,97 +27,101 @@ const sections = (text) => {
   };
 };
 
-// ---- Group A: regionOwnerCode ----------------------------------------------
+// ---- Group A: regionOwnerName (owners are FULL COUNTRY NAMES) ----------------------------------------------
 
 test("A1 override wins over base country", () => {
-  assert.equal(regionOwnerCode(CATALOG[2], { "DEU.1_1": "FRA" }), "FRA");
+  assert.equal(regionOwnerName(CATALOG[2], { "DEU.1_1": "FRA" }), "France");
 });
-test("A2 falls back to base countryCode with no override", () => {
-  assert.equal(regionOwnerCode(CATALOG[0], {}), "FRA");
+test("A2 falls back to the base country NAME with no override", () => {
+  assert.equal(regionOwnerName(CATALOG[0], {}), "France");
 });
 test("A3 falls back to country NAME when countryCode is absent", () => {
-  assert.equal(regionOwnerCode({ id: "X", name: "X", country: "Freedonia" }, {}), "Freedonia");
+  assert.equal(regionOwnerName({ id: "X", name: "X", country: "Freedonia" }, {}), "Freedonia");
 });
 test("A4 empty overrides object → base owner", () => {
-  assert.equal(regionOwnerCode(CATALOG[1], {}), "FRA");
+  assert.equal(regionOwnerName(CATALOG[1], {}), "France");
 });
 test("A5 null overrides → base owner, no throw", () => {
-  assert.equal(regionOwnerCode(CATALOG[1], null), "FRA");
+  assert.equal(regionOwnerName(CATALOG[1], null), "France");
 });
 test("A6 undefined region → empty string, no throw", () => {
-  assert.equal(regionOwnerCode(undefined, {}), "");
+  assert.equal(regionOwnerName(undefined, {}), "");
 });
 test("A7 whitespace override is trimmed", () => {
-  assert.equal(regionOwnerCode(CATALOG[0], { "FRA.1_1": "  SOV  " }), "SOV");
+  assert.equal(regionOwnerName(CATALOG[0], { "FRA.1_1": "  SOV  " }), "SOV");
 });
 test("A8 empty-string override falls through to base", () => {
-  assert.equal(regionOwnerCode(CATALOG[0], { "FRA.1_1": "   " }), "FRA");
+  assert.equal(regionOwnerName(CATALOG[0], { "FRA.1_1": "   " }), "France");
+});
+
+test("A9 a legacy CODE override is canonicalised to the full country name", () => {
+  assert.equal(regionOwnerName(CATALOG[2], { "DEU.1_1": "ESP" }), "Spain");
 });
 
 // ---- Group B: grouping / stock map -----------------------------------------
 
 test("B1 stock map (no overrides) groups every owner — the core gap", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA", "DEU"] });
-  assert.match(text, /- FRA \[2 regions\]:/);
-  assert.match(text, /- DEU \[3 regions\]:/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France", "Germany"] });
+  assert.match(text, /- France \[2 regions\]:/);
+  assert.match(text, /- Germany \[3 regions\]:/);
 });
 test("B2 counts are correct per owner", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["DEU"] });
-  assert.match(text, /- DEU \[3 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["Germany"] });
+  assert.match(text, /- Germany \[3 regions\]/);
 });
 test("B3 regions render as `name (id)`", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] });
   assert.match(text, /Bourgogne \(FRA\.1_1\)/);
   assert.match(text, /Bretagne \(FRA\.2_1\)/);
 });
 test("B4 a region appears exactly once", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA", "DEU"] });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France", "Germany"] });
   assert.equal(text.split("Bayern (DEU.1_1)").length - 1, 1);
 });
 test("B5 an override moves a region into the new owner's group and updates counts", () => {
-  const text = buildRegionOwnershipText(CATALOG, { "DEU.1_1": "FRA" }, { focusCodes: ["FRA", "DEU"] });
-  assert.match(sections(text).focus, /- FRA \[3 regions\]:[\s\S]*Bayern \(DEU\.1_1\)/);
-  assert.match(sections(text).focus, /- DEU \[2 regions\]:/);
+  const text = buildRegionOwnershipText(CATALOG, { "DEU.1_1": "FRA" }, { focusCodes: ["France", "Germany"] });
+  assert.match(sections(text).focus, /- France \[3 regions\]:[\s\S]*Bayern \(DEU\.1_1\)/);
+  assert.match(sections(text).focus, /- Germany \[2 regions\]:/);
 });
 test("B6 multiple overrides all apply", () => {
-  const text = buildRegionOwnershipText(CATALOG, { "DEU.1_1": "FRA", "DEU.2_1": "FRA" }, { focusCodes: ["FRA"] });
-  assert.match(text, /- FRA \[4 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, { "DEU.1_1": "FRA", "DEU.2_1": "FRA" }, { focusCodes: ["France"] });
+  assert.match(text, /- France \[4 regions\]/);
 });
 test("B7 all-unowned catalog → safe line", () => {
   const text = buildRegionOwnershipText([{ id: "z", name: "Z" }], {});
   assert.match(text, /No region ownership could be determined/);
 });
 test("B8 deterministic — same input twice yields identical output", () => {
-  const a = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] });
-  const b = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] });
+  const a = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] });
+  const b = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] });
   assert.equal(a, b);
 });
 
 // ---- Group C: focus section ------------------------------------------------
 
 test("C1 focus codes get full region lists", () => {
-  const { focus } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] }));
+  const { focus } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] }));
   assert.match(focus, /Bourgogne \(FRA\.1_1\)/);
 });
 test("C2 focus order is preserved", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["DEU", "FRA"] });
-  assert.ok(text.indexOf("- DEU") < text.indexOf("- FRA"));
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["Germany", "France"] });
+  assert.ok(text.indexOf("- Germany") < text.indexOf("- France"));
 });
 test("C3 focus matching is case-insensitive", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["fra"] });
-  assert.match(sections(text).focus, /- FRA \[2 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["france"] });
+  assert.match(sections(text).focus, /- France \[2 regions\]/);
 });
 test("C4 a focus code absent from the map is skipped gracefully", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["ZZZ", "FRA"] });
-  assert.match(sections(text).focus, /- FRA \[2 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["ZZZ", "France"] });
+  assert.match(sections(text).focus, /- France \[2 regions\]/);
   assert.doesNotMatch(text, /ZZZ/);
 });
 test("C5 focus powers are excluded from the roster (no duplication)", () => {
-  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] }));
-  assert.doesNotMatch(roster, /- FRA /);
+  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] }));
+  assert.doesNotMatch(roster, /- France /);
 });
 test("C6 FOCUS_INTRO is present when there is a focus set", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] });
   assert.ok(text.includes(FOCUS_INTRO));
 });
 test("C7 no focus set → no FOCUS_INTRO, roster only", () => {
@@ -126,39 +130,39 @@ test("C7 no focus set → no FOCUS_INTRO, roster only", () => {
   assert.ok(text.includes(ROSTER_INTRO));
 });
 test("C8 ownerCap truncates a focus group with a visible (+N more)", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["DEU"], ownerCap: 1 });
-  assert.match(text, /- DEU \[3 regions\]: Bayern \(DEU\.1_1\), \(\+2 more\)/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["Germany"], ownerCap: 1 });
+  assert.match(text, /- Germany \[3 regions\]: Bayern \(DEU\.1_1\), \(\+2 more\)/);
 });
 test("C9 focusTotalCap drops an unfittable focus power down into the roster", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA", "DEU"], focusTotalCap: 2, ownerCap: 40 });
-  assert.match(sections(text).focus, /- FRA \[2 regions\]/);
-  assert.match(sections(text).roster, /- DEU — 3 regions/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France", "Germany"], focusTotalCap: 2, ownerCap: 40 });
+  assert.match(sections(text).focus, /- France \[2 regions\]/);
+  assert.match(sections(text).roster, /- Germany — 3 regions/);
   assert.doesNotMatch(sections(text).roster, /Bayern/); // roster carries no province names
 });
 test("C10 focus header shows the polity display name", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"], polityNames: { fra: "French Republic" } });
-  assert.match(text, /- FRA \(French Republic\) \[2 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"], polityNames: { france: "French Republic" } });
+  assert.match(text, /- France \(French Republic\) \[2 regions\]/);
 });
 test("C11 focus region list preserves catalog order within a group", () => {
-  const { focus } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["DEU"] }));
+  const { focus } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["Germany"] }));
   assert.ok(focus.indexOf("Bayern") < focus.indexOf("Ostpreußen"));
   assert.ok(focus.indexOf("Ostpreußen") < focus.indexOf("Sachsen"));
 });
 test("C12 focus region with an empty id renders name-only", () => {
   const cat = [{ id: "", name: "Nowhere", countryCode: "FRA" }];
-  const text = buildRegionOwnershipText(cat, {}, { focusCodes: ["FRA"] });
-  assert.match(text, /- FRA \[1 region\]: Nowhere\b/);
+  const text = buildRegionOwnershipText(cat, {}, { focusCodes: ["France"] });
+  assert.match(text, /- France \[1 region\]: Nowhere\b/);
   assert.doesNotMatch(text, /Nowhere \(/);
 });
 
 // ---- Group D: roster section -----------------------------------------------
 
 test("D1 roster lists a non-focus owner as `CODE — N regions`", () => {
-  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] }));
-  assert.match(roster, /- DEU — 3 regions/);
+  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] }));
+  assert.match(roster, /- Germany — 3 regions/);
 });
 test("D2 roster carries NO province names", () => {
-  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] }));
+  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] }));
   assert.doesNotMatch(roster, /Bayern|Sachsen|Ostpreußen/);
 });
 test("D3 roster is sorted by region count descending", () => {
@@ -188,16 +192,16 @@ test("D5 rosterCap truncates with a (+K more) marker", () => {
   assert.match(text, /\(\+3 more powers not listed for brevity\.\)/);
 });
 test("D6 ROSTER_INTRO present when the roster is non-empty", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"] });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"] });
   assert.ok(text.includes(ROSTER_INTRO));
 });
 test("D7 every owner in focus → no roster section", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA", "DEU"] });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France", "Germany"] });
   assert.ok(!text.includes(ROSTER_INTRO));
 });
-test("D8 roster header shows the polity display name", () => {
-  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"], polityNames: { deu: "Germany" } }));
-  assert.match(roster, /- DEU \(Germany\) — 3 regions/);
+test("D8 roster header shows a display name that differs from the owner", () => {
+  const { roster } = sections(buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"], polityNames: { germany: "German Empire" } }));
+  assert.match(roster, /- Germany \(German Empire\) — 3 regions/);
 });
 test("D9 singular '1 region' in the roster", () => {
   const cat = [
@@ -215,18 +219,18 @@ test("D10 rosterOmitted count is exact", () => {
 
 // ---- Group E: polityNames / formatting -------------------------------------
 
-test("E1 polityNames keyed by lowercase code", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"], polityNames: { fra: "France" } });
-  assert.match(text, /- FRA \(France\)/);
+test("E1 polityNames keyed by lowercase owner name", () => {
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"], polityNames: { france: "Kingdom of France" } });
+  assert.match(text, /- France \(Kingdom of France\)/);
 });
 test("E2 polityNames keyed by original-case label", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"], polityNames: { FRA: "France" } });
-  assert.match(text, /- FRA \(France\)/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"], polityNames: { France: "Kingdom of France" } });
+  assert.match(text, /- France \(Kingdom of France\)/);
 });
 test("E3 display name equal to the code (any case) is not repeated", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["FRA"], polityNames: { fra: "fra" } });
-  assert.doesNotMatch(text, /- FRA \(fra\)/);
-  assert.match(text, /- FRA \[2 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["France"], polityNames: { fra: "fra" } });
+  assert.doesNotMatch(text, /- France \(fra\)/);
+  assert.match(text, /- France \[2 regions\]/);
 });
 test("E4 singular '1 region' vs plural in the focus section", () => {
   const cat = [{ id: "A.1", name: "solo", countryCode: "AAA" }];
@@ -234,12 +238,12 @@ test("E4 singular '1 region' vs plural in the focus section", () => {
   assert.match(text, /- AAA \[1 region\]:/);
 });
 test("E5 diacritics in region names are preserved verbatim", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["DEU"] });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: ["Germany"] });
   assert.match(text, /Ostpreußen \(DEU\.2_1\)/);
 });
 test("E6 a region with an empty name falls back to its id", () => {
   const cat = [{ id: "FRA.9_1", name: "", countryCode: "FRA" }];
-  const text = buildRegionOwnershipText(cat, {}, { focusCodes: ["FRA"] });
+  const text = buildRegionOwnershipText(cat, {}, { focusCodes: ["France"] });
   assert.match(text, /FRA\.9_1 \(FRA\.9_1\)/);
 });
 
@@ -253,7 +257,7 @@ test("F2 null catalog → safe line, never throws", () => {
 });
 test("F3 undefined options → does not throw and still groups", () => {
   const text = buildRegionOwnershipText(CATALOG, {});
-  assert.match(text, /- (FRA|DEU) —/); // no focus → all owners in the roster
+  assert.match(text, /- (France|Germany) —/); // no focus → all owners in the roster
 });
 test("F4 large catalog respects focusTotalCap and ownerCap", () => {
   const big = [];
@@ -275,11 +279,11 @@ test("F4 large catalog respects focusTotalCap and ownerCap", () => {
 test("F5 focusCodes empty array → roster only", () => {
   const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: [] });
   assert.ok(!text.includes(FOCUS_INTRO));
-  assert.match(text, /- FRA — 2 regions/);
+  assert.match(text, /- France — 2 regions/);
 });
 test("F6 null overrides still groups by base country", () => {
-  const text = buildRegionOwnershipText(CATALOG, null, { focusCodes: ["FRA"] });
-  assert.match(text, /- FRA \[2 regions\]/);
+  const text = buildRegionOwnershipText(CATALOG, null, { focusCodes: ["France"] });
+  assert.match(text, /- France \[2 regions\]/);
 });
 test("F7 whitespace-padded owner codes group together", () => {
   const cat = [
@@ -291,8 +295,8 @@ test("F7 whitespace-padded owner codes group together", () => {
 });
 test("F8 a fully-blank region row (no name, no id, no owner) is skipped", () => {
   const cat = [{ id: "", name: "", country: "", countryCode: "" }, ...CATALOG];
-  const text = buildRegionOwnershipText(cat, {}, { focusCodes: ["FRA", "DEU"] });
-  assert.match(text, /- FRA \[2 regions\]/); // unchanged; blank row contributed nothing
+  const text = buildRegionOwnershipText(cat, {}, { focusCodes: ["France", "Germany"] });
+  assert.match(text, /- France \[2 regions\]/); // unchanged; blank row contributed nothing
 });
 test("F9 duplicate region ids under different owners are each grouped", () => {
   const cat = [
@@ -300,21 +304,21 @@ test("F9 duplicate region ids under different owners are each grouped", () => {
     { id: "DUP", name: "Georgia", countryCode: "GEO" },
   ];
   const { roster } = sections(buildRegionOwnershipText(cat, {}, { focusCodes: [] }));
-  assert.match(roster, /- GEO — 1 region/);
-  assert.match(roster, /- USA — 1 region/);
+  assert.match(roster, /- Georgia — 1 region/);
+  assert.match(roster, /- United States — 1 region/);
 });
 test("F10 override to a brand-new owner code creates that group", () => {
   const text = buildRegionOwnershipText(CATALOG, { "FRA.1_1": "SOV" }, { focusCodes: ["SOV"] });
   assert.match(text, /- SOV \[1 region\]: Bourgogne \(FRA\.1_1\)/);
 });
 test("F11 same content, different call → structurally identical (no hidden state)", () => {
-  const opts = { focusCodes: ["FRA"], polityNames: { fra: "France" } };
+  const opts = { focusCodes: ["France"], polityNames: { fra: "France" } };
   assert.equal(
     buildRegionOwnershipText(CATALOG, {}, opts),
-    buildRegionOwnershipText(CATALOG.slice(), { ...{} }, { ...opts, focusCodes: ["FRA"] }),
+    buildRegionOwnershipText(CATALOG.slice(), { ...{} }, { ...opts, focusCodes: ["France"] }),
   );
 });
 test("F12 non-array focusCodes is treated as empty (no throw)", () => {
-  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: "FRA" });
+  const text = buildRegionOwnershipText(CATALOG, {}, { focusCodes: "France" });
   assert.ok(!text.includes(FOCUS_INTRO));
 });

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -20,7 +20,9 @@ import {
   readJson,
   resolveCountryDisplayName,
 } from "../../runtime/assets.js";
-import COUNTRY_NAMES from "../../runtime/generated/countryNames.js";
+import { resolveRegionName } from "../../runtime/regionNameFixes.js";
+import { toCountryName } from "../../runtime/ownerNames.js";
+import { buildCoarseGeometryById } from "./coarseGeometry.js";
 import { loadCountryLabelCollections } from "../../runtime/countryLabels.js";
 import { translateLabel } from "../../runtime/translator.js";
 import { MAP_SETTING_KEYS, useMapSetting } from "../../runtime/mapSettings.js";
@@ -209,9 +211,13 @@ const GADM_GEOMETRY_FILTER = [">=", ["index-of", ".", ["get", "id"]], 0];
 // dot test — stock and author-only maps render identically to before.
 const AUTHORED_GEOMETRY_FILTER = ["any", CUSTOM_GEOMETRY_FILTER, ["==", ["get", "edited"], true]];
 const STOCK_GEOMETRY_FILTER = ["all", GADM_GEOMETRY_FILTER, ["!=", ["get", "edited"], true]];
-// Crossfade band: seed geometry was extracted at tile-zoom 5, so hand off to
-// the tiles just past that.
-const FAR_FILL_FADE = ["interpolate", ["linear"], ["zoom"], 5.5, 0.72, 6.5, 0];
+// Crossfade bands. Detail now steps UP twice on the way in, and each step is a
+// crossfade so no border ever pops: the grid-snapped tier (coarseGeometry.js) holds
+// world view, the seed geometry takes over through the middle, and the stock vector
+// tiles take the close range. Seed geometry was extracted at tile-zoom 5, so it hands
+// off to the tiles just past that.
+const ULTRA_FILL_FADE = ["interpolate", ["linear"], ["zoom"], 3, 0.72, 4, 0];
+const FAR_FILL_FADE = ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.72, 5.5, 0.72, 6.5, 0];
 const TILE_FILL_FADE = ["interpolate", ["linear"], ["zoom"], 5.5, 0, 6.5, 0.72];
 
 // ---- Owner labels for custom maps -----------------------------------------
@@ -355,7 +361,7 @@ const buildOwnerLabelCollection = (regionsFC, overrides, polityOverrides, nameRe
     // Captured-region override stores the AI's owner CODE ("ESP"); the seed stores the NAME
     // ("Spain"). Canonicalize so both share one cluster + label instead of the code splitting
     // off as a phantom new country.
-    const owner = COUNTRY_NAMES[rawOwner] ?? rawOwner;
+    const owner = toCountryName(rawOwner);
     if (!owner) continue;
     const best = largestRingOf(allFeatures[index].geometry);
     if (!best || best.area <= 0) continue;
@@ -672,12 +678,14 @@ const WorldMap = ({ isGlobe = false }) => {
       // when there was an owner and a raw GADM code when there wasn't, and the
       // difference only showed up as an occasional "RUS" where a country name
       // belonged. owner === "" means genuinely unclaimed and must stay empty.
-      GID_0: owner || (owner === "" ? "" : COUNTRY_NAMES[gid0] || gid0),
+      GID_0: owner || (owner === "" ? "" : toCountryName(gid0)),
       // A stock-tile hit carries GADM's own COUNTRY attribute; a custom region has
       // no such property (and no longer carries `country` at all), so name it from
       // the provenance rather than handing the panel a blank.
-      COUNTRY: props.COUNTRY ?? COUNTRY_NAMES[gid0] ?? "",
-      NAME_1: props.NAME_1 ?? props.name ?? "",
+      COUNTRY: props.COUNTRY ?? toCountryName(gid0),
+      // Corrects the GADM regions whose stored name is the placeholder "NA" (England
+      // is one), so the panel names the place instead of showing the marker verbatim.
+      NAME_1: resolveRegionName(regionId, props.NAME_1 ?? props.name ?? ""),
       GID_1: regionId,
       // Kept as the flag fallback when the owner is an invented polity: "Roman
       // Empire" has no flag, but the land underneath it is still Italy.
@@ -733,7 +741,7 @@ const WorldMap = ({ isGlobe = false }) => {
       if (!rawOwner) return null;
       // Canonicalize an owner CODE ("ESP" from a transfer override) to the NAME the palette
       // is keyed by ("Spain") so a captured region takes its true owner's colour.
-      const owner = COUNTRY_NAMES[rawOwner] ?? rawOwner;
+      const owner = toCountryName(rawOwner);
       const exact = colorMap[owner];
       if (exact) return exact;
       const registry = parseColorToRgb(polityOverrides?.[owner]?.color);
@@ -913,6 +921,23 @@ const WorldMap = ({ isGlobe = false }) => {
       }),
     };
   }, [customRegionData, colorMap, regionOwnershipOverrides, regionClaimants, ownerColorCss, resolveOwnerRgb]);
+
+  // Lowest-detail tier, drawn only at world-ish zooms. The coordinate work is keyed to
+  // the RAW geometry so it runs when the scenario's regions load and not on the far
+  // more frequent recolours; re-attaching the enriched properties below is a plain
+  // object spread with no geometry maths in it.
+  const coarseGeometryById = useMemo(() => buildCoarseGeometryById(customRegionData), [customRegionData]);
+
+  const ultraCoarseRegionData = useMemo(() => {
+    const features = [];
+    for (const feature of enrichedCustomRegionData?.features ?? []) {
+      const geometry = coarseGeometryById.get(String(feature?.properties?.id));
+      // No entry means the shape collapsed at this grid (a speck or a tiny island) —
+      // leaving it out is the intended loss of detail, not a dropped region.
+      if (geometry) features.push({ ...feature, geometry });
+    }
+    return { type: "FeatureCollection", features };
+  }, [enrichedCustomRegionData, coarseGeometryById]);
 
   // GADM disputed regions also paint the stock tiles (the crisp z>6.5 layer):
   // GID_1 -> stripe-tile id stops for the tile twin of the disputed layer.
@@ -1133,6 +1158,31 @@ const WorldMap = ({ isGlobe = false }) => {
           and each region simplifies independently — shared borders drift
           apart at low zoom. Full resolution keeps them connected everywhere;
           the seed geometry is coarse enough that this stays cheap. */}
+      {/* Lowest-detail tier, world view only. Same tolerance 0 for the same reason:
+          its geometry is already reduced, and the reduction was a grid SNAP precisely
+          so shared borders survive it — letting the source simplify on top would undo
+          that. It fades out by z4, where the seed tier has faded in. */}
+      <Source id="custom-regions-ultra-source" type="geojson" data={ultraCoarseRegionData} tolerance={0}>
+        <Layer
+          id="custom-regions-fill-ultra"
+          type="fill"
+          maxzoom={4}
+          filter={STOCK_GEOMETRY_FILTER}
+          paint={{ "fill-color": CUSTOM_FILL_COLOR, "fill-opacity": customActive ? ULTRA_FILL_FADE : 0 }}
+        />
+        <Layer
+          id="custom-regions-hairline-ultra"
+          type="line"
+          maxzoom={4}
+          filter={STOCK_GEOMETRY_FILTER}
+          paint={{
+            "line-color": "#000",
+            "line-width": 0.3,
+            "line-opacity": customActive ? ["interpolate", ["linear"], ["zoom"], 3, 0.35, 4, 0] : 0,
+          }}
+        />
+      </Source>
+
       <Source id="custom-regions-source" type="geojson" data={enrichedCustomRegionData} tolerance={0}>
         {/* Zoomed-out fill for GADM regions from the seed geometry — the stock
             tiles are too simplified at low zoom and show sliver gaps there. */}
@@ -1154,8 +1204,10 @@ const WorldMap = ({ isGlobe = false }) => {
           paint={{
             "line-color": "#000",
             "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.3, 6.5, 0.6],
+            // Fades in over the same 3->4 band as the fill above, handing off from the
+            // ultra tier's hairlines so borders never double up or blink.
             "line-opacity": customActive
-              ? ["interpolate", ["linear"], ["zoom"], 3, 0.35, 5.5, 0.55, 6.5, 0]
+              ? ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.35, 5.5, 0.55, 6.5, 0]
               : 0,
           }}
         />

--- a/src/Game/Map/coarseGeometry.js
+++ b/src/Game/Map/coarseGeometry.js
@@ -1,0 +1,89 @@
+/*! Open Historia — far-zoom geometry coarsening © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Builds the lowest-detail tier of region geometry, used only when the map is zoomed
+// far out. The seed geometry is already coarse (tile-zoom 5), but at world view every
+// one of its vertices is still uploaded and drawn while being far below one pixel —
+// detail nobody can see, paid for on every frame.
+//
+// The reduction is a SNAP TO GRID, not ordinary line simplification, and that choice is
+// the whole point. Douglas-Peucker (what a GeoJSON source's `tolerance` applies) thins
+// each ring independently, so two regions sharing a border can keep different subsets
+// of the vertices along it and the shared edge cracks open into sliver gaps — the exact
+// reason the main source is pinned at tolerance 0. Snapping is a pure function of the
+// coordinate itself: identical vertices round identically, so a shared border stays
+// shared, and near-identical ones are welded together rather than pulled apart.
+//
+// Shapes that collapse below a drawable ring are dropped outright (specks and tiny
+// islands), which is itself part of being the far-zoom tier.
+
+const snap = (value, grid) => Math.round(value / grid) * grid;
+
+// A ring keeps its winding and its closure; only redundant vertices go. A polygon ring
+// needs 4 positions (3 distinct + the repeated first) to enclose any area at all.
+const quantizeRing = (ring, grid) => {
+  if (!Array.isArray(ring) || ring.length < 4) return null;
+  const out = [];
+  for (const point of ring) {
+    const x = snap(point[0], grid);
+    const y = snap(point[1], grid);
+    const previous = out[out.length - 1];
+    if (previous && previous[0] === x && previous[1] === y) continue;
+    out.push([x, y]);
+  }
+  const first = out[0];
+  const last = out[out.length - 1];
+  if (!first) return null;
+  if (first[0] !== last[0] || first[1] !== last[1]) out.push([first[0], first[1]]);
+  return out.length >= 4 ? out : null;
+};
+
+// A polygon survives only if its outer ring does; holes that collapse are simply
+// filled in, which at this zoom is invisible and cheaper than keeping them.
+const quantizePolygon = (rings, grid) => {
+  if (!Array.isArray(rings) || rings.length === 0) return null;
+  const outer = quantizeRing(rings[0], grid);
+  if (!outer) return null;
+  const holes = [];
+  for (let index = 1; index < rings.length; index += 1) {
+    const hole = quantizeRing(rings[index], grid);
+    if (hole) holes.push(hole);
+  }
+  return [outer, ...holes];
+};
+
+// Returns null when nothing drawable survives, so callers can drop the feature.
+// Non-area geometry has no far-zoom fill to draw and is dropped for the same reason.
+export const quantizeGeometry = (geometry, grid) => {
+  if (!geometry || !grid) return null;
+  if (geometry.type === "Polygon") {
+    const coordinates = quantizePolygon(geometry.coordinates, grid);
+    return coordinates ? { type: "Polygon", coordinates } : null;
+  }
+  if (geometry.type === "MultiPolygon") {
+    const coordinates = [];
+    for (const polygon of geometry.coordinates ?? []) {
+      const quantized = quantizePolygon(polygon, grid);
+      if (quantized) coordinates.push(quantized);
+    }
+    return coordinates.length ? { type: "MultiPolygon", coordinates } : null;
+  }
+  return null;
+};
+
+// ~0.25° ≈ 28km at the equator: under two screen pixels at the zooms this tier is
+// visible at, so the outline still reads as the right shape, while the vertex count
+// (and the per-frame work at world view) drops sharply.
+export const FAR_ZOOM_GRID_DEGREES = 0.25;
+
+// id -> coarsened geometry. Keyed by id so the per-feature PROPERTIES (fill colour,
+// stripes) can be re-attached later without redoing any coordinate maths: colours
+// change on most turns, geometry almost never does.
+export const buildCoarseGeometryById = (featureCollection, grid = FAR_ZOOM_GRID_DEGREES) => {
+  const byId = new Map();
+  for (const feature of featureCollection?.features ?? []) {
+    const id = feature?.properties?.id;
+    if (id == null) continue;
+    const geometry = quantizeGeometry(feature.geometry, grid);
+    if (geometry) byId.set(String(id), geometry);
+  }
+  return byId;
+};

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -1,6 +1,7 @@
 /*! Open Historia — portions (custom regions.geojson runtime endpoint) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import mapLibreGl from "maplibre-gl";
 import { PMTiles, Protocol, SharedPromiseCache } from "pmtiles";
+import { resolveRegionName } from "./regionNameFixes.js";
 
 const { addProtocol, setMaxParallelImageRequests, setWorkerCount } = mapLibreGl;
 
@@ -1057,7 +1058,11 @@ export const loadRegionCatalog = async ({ force = false } = {}) => {
       for (let index = 0; index < layer.length; index += 1) {
         const props = layer.feature(index).properties;
         const id = props?.GID_1 || props?.gid_1 || props?.HASC_1 || props?.fid;
-        const name = props?.NAME_1 || props?.name_1 || props?.NAME || props?.name;
+        // A few GADM regions carry the literal placeholder "NA" as their name (England
+        // among them). Correct the known ones and treat the rest as nameless, so the
+        // `!name` skip below drops them instead of teaching the model a region called
+        // "NA" that it can never meaningfully transfer.
+        const name = resolveRegionName(id, props?.NAME_1 || props?.name_1 || props?.NAME || props?.name);
         const countryCode = props?.GID_0 || props?.gid_0 || "";
         const country = resolveCountryDisplayName(
           props?.COUNTRY || props?.Country || props?.country,
@@ -1103,7 +1108,11 @@ export const loadRegionCatalog = async ({ force = false } = {}) => {
           const props = feature?.properties ?? {};
           const id = props.id != null ? String(props.id) : "";
           if (!id) continue;
-          const name = props.name ? String(props.name) : "";
+          // Same placeholder correction as the stock pass above — and it must happen
+          // HERE too: a scenario's geometry is seeded from the same GADM export, so
+          // without this the scenario's own "NA" wins on the next line and puts the
+          // placeholder back over the corrected stock name.
+          const name = resolveRegionName(id, props.name);
           const existing = seen.get(id);
           if (existing) {
             // The scenario's own name for a stock region WINS. A world that

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -3,6 +3,7 @@ import { JSON_URLS, readJson, writeJson } from "./assets.js";
 import { enqueueContentStrings } from "./translator.js";
 import { normalizeTagList } from "./countryTags.js";
 import { dedupeEventLog } from "./eventDedup.js";
+import { toCountryName } from "./ownerNames.js";
 
 export const GAME_DEFAULTS = {
   country: "",
@@ -432,8 +433,12 @@ const normalizeRegionTransfer = (entry) => {
   }
 
   const regionId = normalizeOptionalString(entry.regionId || entry.id || entry.gid || entry.GID_1);
-  const toCode = normalizeOptionalString(entry.toCode || entry.toPolity || entry.ownerCode || entry.owner);
-  const fromCode = normalizeOptionalString(entry.fromCode || entry.fromPolity);
+  // Owners are stored as the FULL COUNTRY NAME. This value is written straight into
+  // world.regionOwnershipOverrides, so a model that answered "ESP" out of habit would
+  // otherwise mint a phantom country that paints and labels itself beside the real
+  // Spain. Canonicalise on the way in, once, rather than papering over it at render.
+  const toCode = toCountryName(normalizeOptionalString(entry.toCode || entry.toPolity || entry.ownerCode || entry.owner));
+  const fromCode = toCountryName(normalizeOptionalString(entry.fromCode || entry.fromPolity));
 
   if (!regionId || !toCode) {
     return null;
@@ -453,7 +458,7 @@ const normalizePolityChange = (entry) => {
     return null;
   }
 
-  const code = normalizeOptionalString(entry.code || entry.id || entry.polityCode);
+  const code = toCountryName(normalizeOptionalString(entry.code || entry.id || entry.polityCode));
   if (!code) {
     return null;
   }
@@ -495,7 +500,8 @@ export const normalizeUnitEntry = (entry, index = 0) => {
 
   const lng = finiteOrNull(entry.lng ?? entry.lon ?? entry.longitude);
   const lat = finiteOrNull(entry.lat ?? entry.latitude);
-  const ownerCode = normalizeOptionalString(entry.ownerCode || entry.owner || entry.code);
+  // Full country name, never a code — same identity everywhere (see ownerNames.js).
+  const ownerCode = toCountryName(normalizeOptionalString(entry.ownerCode || entry.owner || entry.code));
   if (lng === null || lat === null || (lng === 0 && lat === 0) || !ownerCode) {
     return null;
   }
@@ -547,7 +553,7 @@ export const normalizeMarkerEntry = (entry, index = 0) => {
     id: normalizeOptionalString(entry.id) || generateId(`marker-${index}`),
     name,
     kind: (normalizeOptionalString(entry.kind || entry.type) || "landmark").toLowerCase(),
-    ownerCode: normalizeOptionalString(entry.ownerCode || entry.owner || entry.code),
+    ownerCode: toCountryName(normalizeOptionalString(entry.ownerCode || entry.owner || entry.code)),
     lng,
     lat,
     note: normalizeOptionalString(entry.note || entry.description),
@@ -854,7 +860,9 @@ export const normalizeWorldState = (world) => {
 
   const regionOwnershipOverrides = Object.fromEntries(
     Object.entries(nextWorld.regionOwnershipOverrides ?? {})
-      .map(([regionId, ownerCode]) => [normalizeOptionalString(regionId), normalizeOptionalString(ownerCode)])
+      // Canonicalise on READ too, so a save written before this migrated still
+      // resolves to the same owner identity as everything computed now.
+      .map(([regionId, ownerCode]) => [normalizeOptionalString(regionId), toCountryName(normalizeOptionalString(ownerCode))])
       .filter(([regionId, ownerCode]) => regionId && ownerCode),
   );
 

--- a/src/runtime/ownerNames.js
+++ b/src/runtime/ownerNames.js
@@ -1,0 +1,28 @@
+/*! Open Historia — owner-name canonicalisation © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// A polity is identified EVERYWHERE by its full country name — "Spain", never "ESP".
+// Ownership, colours, flags, tags and the AI's own vocabulary are all keyed that way
+// (see server/ownerMigration.js, which migrated stored worlds to it). GADM's three
+// letter codes remain only as provenance inside the .pmtiles binaries and on a
+// region's `gid0`/`countryCode`; they are not an identity anyone keys off.
+//
+// The one place a code can still appear is INBOUND: a legacy save written before the
+// migration, or a model that answers "ESP" out of habit. Both funnel through here and
+// come out as the name, so a code can never enter the world state and mint a phantom
+// country sitting alongside the real one ("ESP" painted next to "Spain").
+import COUNTRY_NAMES from "./generated/countryNames.js";
+
+// Canonicalises one owner token to its full country name. Anything that is not a
+// known GADM code — an invented polity ("Roman Empire"), an era name, a name already
+// — is returned untouched, so this is always safe to apply.
+export const toCountryName = (token) => {
+  const raw = String(token ?? "").trim();
+  if (!raw) return "";
+  return COUNTRY_NAMES[raw] || COUNTRY_NAMES[raw.toUpperCase()] || raw;
+};
+
+// True when the token is a bare GADM code that has a full name to become. Only useful
+// for reporting; call sites should just canonicalise unconditionally.
+export const isCountryCode = (token) => {
+  const raw = String(token ?? "").trim();
+  return Boolean(raw) && Boolean(COUNTRY_NAMES[raw] || COUNTRY_NAMES[raw.toUpperCase()]);
+};

--- a/src/runtime/regionNameFixes.js
+++ b/src/runtime/regionNameFixes.js
@@ -1,0 +1,39 @@
+/*! Open Historia — GADM region-name corrections © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// A handful of GADM level-1 regions ship with no usable NAME_1. The value is not an
+// abbreviation — it is the literal string "NA" (R's missing-value marker, which GADM
+// is exported from) or "?", and it flows straight through to the map panel and to the
+// AI's region vocabulary. The worst case is England: "the majority of Britain" renders
+// nameless, and because the AI's region catalog is built from the same field, the model
+// cannot name England in a regionTransfer either — so England can never change hands.
+//
+// Only ids whose real name is unambiguous are corrected here. Each was confirmed from
+// the seed by centroid AND by which sibling name is missing from that country's set:
+//   GBR.1_1  centroid -2.30, 51.94 — siblings are Scotland/Wales/Northern Ireland
+//   IRL.4_1  centroid -9.28, 51.69 — the only one of Ireland's 26 counties missing
+//   NLD.14_1 centroid  4.50, 51.96 — the only Dutch province missing (Rotterdam area)
+// The remaining placeholders are unidentifiable slivers (an unassigned Shetland-area
+// polygon with no country, a Ukrainian artifact whose id is literally "?", and one
+// Marshall Islands atoll); they are treated as UNNAMED rather than guessed at.
+export const REGION_NAME_FIXES = {
+  "GBR.1_1": "England",
+  "IRL.4_1": "Cork",
+  "NLD.14_1": "Zuid-Holland",
+};
+
+// Matched case-insensitively against the trimmed name. Deliberately tight: a real
+// region name must never be mistaken for a placeholder, so this holds only markers
+// that cannot be a genuine toponym.
+const PLACEHOLDER_NAMES = new Set(["", "na", "n/a", "null", "nan", "?"]);
+
+export const isPlaceholderRegionName = (value) =>
+  PLACEHOLDER_NAMES.has(String(value ?? "").trim().toLowerCase());
+
+// The name a region should be shown and referred to by. Returns "" when the source
+// name is a placeholder and no correction is known — callers already treat a nameless
+// region as one to skip (the AI catalog) or leave blank (the map panel), which is
+// better than surfacing "NA" as if it were the place's actual name.
+export const resolveRegionName = (id, rawName) => {
+  const fixed = REGION_NAME_FIXES[String(id ?? "").trim()];
+  if (fixed) return fixed;
+  return isPlaceholderRegionName(rawName) ? "" : String(rawName ?? "").trim();
+};


### PR DESCRIPTION
Polities are identified by their FULL COUNTRY NAME everywhere — no codes, anywhere.

The world has been name-keyed since the owner migration, but the AI-facing layer still spoke codes: regionVocab told the model "use the code for fromCode/toCode" and showed it "ESP", the model answered "ESP", and that value was stored verbatim in regionOwnershipOverrides — minting a phantom country beside the real Spain. Codes are GADM provenance on a region row and nothing else.

- `regionOwnerName` (was `regionOwnerCode`) reports the full name; both vocabulary sections now list "Spain".
- Fixes the player's own regions never being enumerated (the focus set is names, the owners were codes, so it never matched).
- One canonicaliser (`runtime/ownerNames.js`) applied wherever an owner arrives: transfers, units, markers, polity changes, stored overrides from legacy saves, and the resolver's own keys. The render-time patch that mapped codes back is gone.
- Schema descriptions + a call-time [Polity Names] directive so the rule reaches frozen-prompt games.

Also: names the GADM regions stored as the placeholder "NA" (England, Cork, Zuid-Holland — England was nameless AND untakeable by the AI); whole-country transfers via `wholeCountry` (per-region remains the default); and a lower-detail far-zoom tier so detail only increases as you zoom in (grid snapping keeps shared borders welded).

57 regionVocab tests + 26 server tests pass; all files byte-identical across channels.