### PR TITLE
Fix "toCountryName is not defined" crash on every timeline jump — alpha

### DIFF
--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import { JSON_URLS, getNationTags, loadRegionCatalog, readJson } from "../../runtime/assets.js";
 import { resolveAllCountryTags, resolveCountryTags } from "../../runtime/countryTags.js";
+import { toCountryName } from "../../runtime/ownerNames.js";
 import {
   buildActionDisplayText,
   isPolityLandless,


### PR DESCRIPTION
Hotfix: `promptContext.js` calls `toCountryName` seven times but never imported it, so `buildTemplateVariables` threw `toCountryName is not defined` as soon as a jump built its prompt — every timeline jump failed (reported in-game). Introduced by the owner-name change (#553-555).

Bundlers do not resolve free identifiers, so this compiled and deployed clean; only executing the path surfaces it. One-line import.