### PR TITLE
Add the Windows desktop installer workflow — main

### DIFF
--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -1,0 +1,69 @@
+# Builds the Windows desktop installer (Electron + NSIS) and attaches it to a
+# release. The player-facing point of this file is that NOTHING is built on the
+# player's machine any more: the client is compiled here, packaged with the
+# server into an Electron app, and shipped as one setup .exe.
+name: Desktop installer (Windows)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish the installer to
+        required: false
+        default: desktop-stable
+  push:
+    tags:
+      - "desktop-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    # Must be Windows: electron-builder produces the NSIS installer with Windows
+    # tooling, and the runner has the symlink privilege its code-signing cache
+    # needs to unpack (a local build without it fails there).
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The map archives are NOT packaged - they are ~200MB and the app downloads
+      # them on first launch - so nothing here fetches them.
+      - name: Build the client
+        run: npm run build
+
+      - name: Build the installer
+        run: npx electron-builder --win --publish never
+        env:
+          # No code-signing certificate yet. Without this electron-builder tries
+          # to discover one and fails the build rather than skipping signing.
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload the installer as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: open-historia-windows-installer
+          path: release/*.exe
+          if-no-files-found: error
+
+      - name: Attach the installer to the release
+        if: github.event_name == 'push' || inputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+        shell: bash
+        run: |
+          # --clobber so re-running replaces the asset instead of erroring, and
+          # the release is created on first use rather than needing to exist.
+          gh release view "$TAG" >/dev/null 2>&1 || \
+            gh release create "$TAG" --title "Open Historia for Windows" \
+              --notes "Windows installer. Downloads the world map on first launch."
+          gh release upload "$TAG" release/*.exe --clobber


### PR DESCRIPTION
Builds the Windows desktop installer (Electron + NSIS) on a Windows runner and attaches the setup .exe to a release. Companion to #565 — the app code is already merged; this is the piece that actually produces the download.

- `npm ci` → `npm run build` → `npx electron-builder --win`
- **Windows runner is required**: electron-builder needs the symlink privilege to unpack its code-signing cache (a local build without it fails there — that's the one step I couldn't run locally).
- `CSC_IDENTITY_AUTO_DISCOVERY: false` — no signing certificate yet; without this electron-builder fails rather than skipping signing.
- Map archives are **not** packaged (~200MB); the app downloads them on first launch with a progress bar.
- Runs on `workflow_dispatch` or a `desktop-v*` tag; uploads a build artifact and, when publishing, creates/updates the release asset with `--clobber`.