### PR TITLE
Build the desktop app for macOS and Linux too — main

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "preview:web": "vite preview --outDir dist-web",
     "test": "node --test \"server/**/*.test.js\"",
     "electron": "electron .",
-    "dist:win": "npm run build && electron-builder --win"
+    "dist:win": "npm run build && electron-builder --win",
+    "dist:mac": "npm run build && electron-builder --mac",
+    "dist:linux": "npm run build && electron-builder --linux"
   },
   "dependencies": {
     "@noble/ed25519": "^2.3.0",
@@ -100,7 +102,8 @@
           ]
         }
       ],
-      "icon": "public/icon-512.png"
+      "icon": "public/icon-512.png",
+      "artifactName": "Open-Historia-Setup-${os}.${ext}"
     },
     "nsis": {
       "oneClick": false,
@@ -108,7 +111,38 @@
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "shortcutName": "Open Historia"
+      "shortcutName": "Open Historia",
+      "artifactName": "Open-Historia-Setup.${ext}"
+    },
+    "mac": {
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ],
+      "icon": "public/icon-512.png",
+      "category": "public.app-category.strategy-games",
+      "artifactName": "Open-Historia-${arch}.${ext}"
+    },
+    "dmg": {
+      "title": "Open Historia"
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "icon": "public/icon-512.png",
+      "category": "Game",
+      "artifactName": "Open-Historia-${arch}.${ext}"
     }
   }
 }


### PR DESCRIPTION
Adds macOS and Linux targets so the Electron app ships everywhere, not just Windows.

- **mac**: dmg, x64 + arm64
- **linux**: AppImage — runs on essentially any distro without packaging per family, and its mount is read-only, which is already what the app assumes about its own bundle
- **Stable artifact names.** The first build produced `Open.Historia.Setup.0.0.0.exe`, so every website download link would have broken the moment the version changed. Now `Open-Historia-Setup.exe` / `Open-Historia-<arch>.dmg` / `Open-Historia-<arch>.AppImage`.

Config only — the build matrix that actually produces the three lives in the workflow file (separate change, needs `workflow` scope to push).