### PR TITLE
Build the desktop installers for all three platforms — main

### DIFF
--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -1,14 +1,14 @@
-# Builds the Windows desktop installer (Electron + NSIS) and attaches it to a
-# release. The player-facing point of this file is that NOTHING is built on the
-# player's machine any more: the client is compiled here, packaged with the
-# server into an Electron app, and shipped as one setup .exe.
-name: Desktop installer (Windows)
+# Builds the desktop app for Windows, macOS and Linux and attaches the installers
+# to a release. The player-facing point of this file is that NOTHING is built on
+# the player's machine any more: the client is compiled here, packaged with the
+# server into an Electron app, and shipped as one download per platform.
+name: Desktop installers
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to publish the installer to
+        description: Release tag to publish the installers to
         required: false
         default: desktop-stable
   push:
@@ -20,10 +20,20 @@ permissions:
 
 jobs:
   build:
-    # Must be Windows: electron-builder produces the NSIS installer with Windows
-    # tooling, and the runner has the symlink privilege its code-signing cache
-    # needs to unpack (a local build without it fails there).
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false # one platform failing must not throw away the other two
+      matrix:
+        include:
+          # Each installer must be built on its own OS: electron-builder shells out
+          # to platform tooling (NSIS on Windows, hdiutil for the .dmg), and a macOS
+          # build simply cannot be produced anywhere but macOS.
+          - os: windows-latest
+            args: --win
+          - os: macos-latest
+            args: --mac
+          - os: ubuntu-latest
+            args: --linux
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -41,29 +51,37 @@ jobs:
         run: npm run build
 
       - name: Build the installer
-        run: npx electron-builder --win --publish never
+        run: npx electron-builder ${{ matrix.args }} --publish never
         env:
-          # No code-signing certificate yet. Without this electron-builder tries
-          # to discover one and fails the build rather than skipping signing.
+          # No code-signing certificate yet. Without this electron-builder tries to
+          # discover one and fails the build rather than skipping signing.
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
-      - name: Upload the installer as a build artifact
+      - name: Upload as a build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: open-historia-windows-installer
-          path: release/*.exe
+          name: open-historia-${{ matrix.os }}
+          # Only the finished installers; release/ also holds the unpacked app tree.
+          path: |
+            release/*.exe
+            release/*.dmg
+            release/*.AppImage
           if-no-files-found: error
 
-      - name: Attach the installer to the release
+      - name: Attach to the release
         if: github.event_name == 'push' || inputs.tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
         shell: bash
         run: |
-          # --clobber so re-running replaces the asset instead of erroring, and
-          # the release is created on first use rather than needing to exist.
+          # --clobber so re-running replaces the asset instead of erroring, and the
+          # release is created on first use rather than having to exist already.
+          # Three jobs race here, so creating it tolerates "already exists".
           gh release view "$TAG" >/dev/null 2>&1 || \
-            gh release create "$TAG" --title "Open Historia for Windows" \
-              --notes "Windows installer. Downloads the world map on first launch."
-          gh release upload "$TAG" release/*.exe --clobber
+            gh release create "$TAG" --title "Open Historia for Desktop" \
+              --notes "Windows, macOS and Linux downloads. The world map downloads on first launch." \
+            || true
+          shopt -s nullglob
+          files=(release/*.exe release/*.dmg release/*.AppImage)
+          gh release upload "$TAG" "${files[@]}" --clobber


### PR DESCRIPTION
Replaces the Windows-only job with a matrix across windows/macos/ubuntu runners, so the desktop app ships for all three platforms.

Each installer has to be built on its own OS — electron-builder shells out to platform tooling (NSIS on Windows, hdiutil for the .dmg), and a macOS build cannot be produced anywhere but macOS. `fail-fast: false` so one platform failing doesn't discard the other two.

Pairs with #568, which added the mac (dmg, x64 + arm64) and linux (AppImage) targets and pinned the artifact names.