### PR TITLE
Fix the macOS build: keep spaces out of the dmg volume title — beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "artifactName": "Open-Historia-${arch}.${ext}"
     },
     "dmg": {
-      "title": "Open Historia"
+      "title": "Open-Historia"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
dmg-builder runs `ln -s /Applications /Volumes/<title>/Applications` without quoting, so the default volume title (the product name, "Open Historia") split on its space and the macOS job failed before producing a .dmg. Windows and Linux were unaffected and already built successfully.