### PR TITLE
Ship the macOS app as a zip instead of a dmg — beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "mac": {
       "target": [
         {
-          "target": "dmg",
+          "target": "zip",
           "arch": [
             "x64",
             "arm64"
@@ -126,10 +126,7 @@
       ],
       "icon": "public/icon-512.png",
       "category": "public.app-category.strategy-games",
-      "artifactName": "Open-Historia-${arch}.${ext}"
-    },
-    "dmg": {
-      "title": "Open-Historia"
+      "artifactName": "Open-Historia-mac-${arch}.${ext}"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
Building a .dmg mounts a volume then detaches it, and on the macOS runners that detach fails **every time** with `hdiutil` exit 16 (resource busy). Disabling Spotlight indexing — the usual remedy — made no difference across repeated runs, so the macOS job never produced an artifact while Windows and Linux built fine.

A zip needs no mounting at all and is a normal way to distribute a Mac Electron app: unzip and drag it to Applications. Both architectures (x64 + arm64) are still built. The workflow's artifact/release globs move from `*.dmg` to `*-mac-*.zip` (scoped so they can't pick up an unrelated archive).