### PR TITLE
Cap the far-zoom source's tile pyramid (fixes the memory regression) — beta

### DIFF
--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -1162,7 +1162,14 @@ const WorldMap = ({ isGlobe = false }) => {
           its geometry is already reduced, and the reduction was a grid SNAP precisely
           so shared borders survive it — letting the source simplify on top would undo
           that. It fades out by z4, where the seed tier has faded in. */}
-      <Source id="custom-regions-ultra-source" type="geojson" data={ultraCoarseRegionData} tolerance={0}>
+      {/* maxzoom 4 is load-bearing, not a detail. A GeoJSON source defaults to
+          building its tile pyramid all the way to zoom 18, and it does that
+          regardless of the zooms its LAYERS are visible at — so without this the
+          ultra tier held a second, complete, street-level tiling of every region
+          in memory purely to draw a world-view fill that is hidden by z4. Capping
+          the source means it builds the handful of tiles it actually uses and
+          overzooms them; the layers stop drawing at 4 anyway. */}
+      <Source id="custom-regions-ultra-source" type="geojson" data={ultraCoarseRegionData} tolerance={0} maxzoom={4}>
         <Layer
           id="custom-regions-fill-ultra"
           type="fill"


### PR DESCRIPTION
**The RAM increase on the website came from the far-zoom region tier**, and this is the cause.

That tier added a second GeoJSON source. A GeoJSON source builds its tile pyramid to **zoom 18 by default**, and it does so independently of the zooms its *layers* are visible at. The ultra layers stop drawing at z4 — so the browser was holding a complete street-level tiling of all ~3,200 regions purely to paint a world-view fill, on top of the tiling the main source already keeps.

Capping the source at `maxzoom={4}` makes it build only the handful of tiles it can actually draw, and overzoom them past that. **Visually identical** — the layers were already invisible above z4.