### PR TITLE
Revert the far-zoom source cap; log why unit ops are dropped — beta

### DIFF
--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -1162,14 +1162,7 @@ const WorldMap = ({ isGlobe = false }) => {
           its geometry is already reduced, and the reduction was a grid SNAP precisely
           so shared borders survive it — letting the source simplify on top would undo
           that. It fades out by z4, where the seed tier has faded in. */}
-      {/* maxzoom 4 is load-bearing, not a detail. A GeoJSON source defaults to
-          building its tile pyramid all the way to zoom 18, and it does that
-          regardless of the zooms its LAYERS are visible at — so without this the
-          ultra tier held a second, complete, street-level tiling of every region
-          in memory purely to draw a world-view fill that is hidden by z4. Capping
-          the source means it builds the handful of tiles it actually uses and
-          overzooms them; the layers stop drawing at 4 anyway. */}
-      <Source id="custom-regions-ultra-source" type="geojson" data={ultraCoarseRegionData} tolerance={0} maxzoom={4}>
+      <Source id="custom-regions-ultra-source" type="geojson" data={ultraCoarseRegionData} tolerance={0}>
         <Layer
           id="custom-regions-fill-ultra"
           type="fill"

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -624,6 +624,36 @@ export const applyMarkerOps = (markers, ops) => {
 };
 
 // One AI-authored mutation to the unit list: spawn | move | strength | remove.
+// Why normalizeUnitOp refused an entry, in words a player can paste into a bug
+// report. Mirrors the checks below — keep the two in step.
+const describeUnitOpRejection = (entry) => {
+  if (!entry || typeof entry !== "object") return "not an object";
+  const op = normalizeOptionalString(entry.op).toLowerCase();
+  if (!op) return "no op (expected spawn, move, strength or remove)";
+  if (op === "spawn") {
+    const unit = entry.unit ?? entry;
+    if (!unit || typeof unit !== "object") return "spawn without a unit";
+    const lng = finiteOrNull(unit.lng ?? unit.lon ?? unit.longitude);
+    const lat = finiteOrNull(unit.lat ?? unit.latitude);
+    if (lng === null || lat === null) {
+      // The usual cause: a non-numeric coordinate ("37,06", "37.06°N") that JSON
+      // carried through as a string and Number() turned into NaN.
+      return `spawn has unusable coordinates (lng=${JSON.stringify(unit.lng)}, lat=${JSON.stringify(unit.lat)})`;
+    }
+    if (lng === 0 && lat === 0) return "spawn at 0,0 — the output template's placeholder, not a real position";
+    if (!normalizeOptionalString(unit.ownerCode || unit.owner || unit.code)) return "spawn has no owner";
+    return "spawn rejected";
+  }
+  if (!normalizeOptionalString(entry.unitId || entry.id)) return `${op} without a unitId`;
+  if (op === "move") {
+    const toLng = finiteOrNull(entry.toLng ?? entry.lng);
+    const toLat = finiteOrNull(entry.toLat ?? entry.lat);
+    if (toLng === null || toLat === null) return `move has unusable destination (toLng=${JSON.stringify(entry.toLng)}, toLat=${JSON.stringify(entry.toLat)})`;
+    if (toLng === 0 && toLat === 0) return "move to 0,0 — the output template's placeholder, not a real position";
+  }
+  return `unknown op "${op}"`;
+};
+
 const normalizeUnitOp = (entry) => {
   if (!entry || typeof entry !== "object") {
     return null;
@@ -722,7 +752,23 @@ const normalizeEventImpacts = (value) => {
     markerOps: normalizeArray(value.markerOps).map(normalizeMarkerOp).filter(Boolean),
     polityChanges: normalizeArray(value.polityChanges).map(normalizePolityChange).filter(Boolean),
     regionTransfers: normalizeArray(value.regionTransfers).map(normalizeRegionTransfer).filter(Boolean),
-    unitOps: normalizeArray(value.unitOps).map(normalizeUnitOp).filter(Boolean),
+    // Say WHY a unit op was thrown away. A dropped op is the difference between an
+    // event that narrates a deployment and troops that actually appear on the map,
+    // and it used to vanish into .filter(Boolean) without a word — leaving no way
+    // to tell "the model never emitted one" from "it emitted one we rejected".
+    // Region transfers have logged their drops for a while; units now match.
+    unitOps: normalizeArray(value.unitOps)
+      .map((entry, index) => {
+        const normalized = normalizeUnitOp(entry);
+        if (!normalized) {
+          console.warn(
+            `[ai] unitOps[${index}] dropped — ${describeUnitOpRejection(entry)}:`,
+            entry,
+          );
+        }
+        return normalized;
+      })
+      .filter(Boolean),
   };
 };
 


### PR DESCRIPTION
**1. Reverts the far-zoom source cap.** Capping that source at zoom 4 made the map render low-resolution when zoomed **in**, and the tier wasn't the cause of the memory increase anyway — it's there to improve performance. Restores the previous behaviour exactly.

**2. Says why a unit op was dropped.** A rejected unit op vanished into `.filter(Boolean)` without a word, so an event that narrates a deployment while no troops appear left nothing to go on — no way to tell *"the model never emitted one"* from *"it emitted one we threw away"*. Region transfers have logged their drops for a while; units now match and name the actual reason.

Runtime-verified against five ops — four rejected with specific reasons, the valid one kept:
```
[ai] unitOps[0] dropped — spawn has unusable coordinates (lng="37,06", lat="37,38")
[ai] unitOps[1] dropped — spawn at 0,0 — the output template's placeholder, not a real position
[ai] unitOps[2] dropped — spawn has no owner
[ai] unitOps[3] dropped — move without a unitId
```
The first is the case worth noting for the non-English report: a decimal comma arriving as `"37,06"` becomes NaN and the unit disappears — now visible instead of silent.