### PR TITLE
Give the desktop app the update banner — main

### DIFF
--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -56,6 +56,14 @@ jobs:
 
       # The map archives are NOT packaged - they are ~200MB and the app downloads
       # them on first launch - so nothing here fetches them.
+      # One id for all three platforms in this run, baked into the app and written
+      # into latest.json below. The app compares the two to know an update exists.
+      - name: Stamp the build id
+        shell: bash
+        run: |
+          echo "{\"build\":\"${{ github.run_id }}\"}" > electron/build-id.json
+          cat electron/build-id.json
+
       - name: Build the client
         run: npm run build
 
@@ -93,4 +101,18 @@ jobs:
             || true
           shopt -s nullglob
           files=(release/*.exe release/*-mac-*.zip release/*.AppImage)
+          # Only the Windows job writes latest.json, so three racing jobs cannot
+          # each publish a different view of the same release.
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            B="https://github.com/${{ github.repository }}/releases/download/$TAG"
+            cat > latest.json <<JSON
+          {
+            "build": "${{ github.run_id }}",
+            "windows": "$B/Open-Historia-Setup.exe",
+            "mac": "$B/Open-Historia-mac-arm64.zip",
+            "linux": "$B/Open-Historia-x86_64.AppImage"
+          }
+          JSON
+            files+=(latest.json)
+          fi
           gh release upload "$TAG" "${files[@]}" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ CLAUDE.md
 
 # Offline root signing PRIVATE key — never commit
 /trust/*.key.pem
+# generated per release build by the desktop workflow
+electron/build-id.json

--- a/electron/gamePreload.cjs
+++ b/electron/gamePreload.cjs
@@ -1,0 +1,24 @@
+/*! Open Historia — desktop bridge for the game page © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// The game runs at http://localhost:3000, so it is an ordinary web page with no way
+// to know it is inside the desktop app — and no way to check for a new release
+// itself (GitHub sends no CORS headers on release assets). This exposes just enough
+// for the existing update banner to work here: a signal that we ARE the desktop app,
+// a subscription to what the main process found, and a way to open the download.
+//
+// Deliberately tiny. The page never sees ipcRenderer, and there is nothing here that
+// can act on the machine beyond opening a download in the normal browser.
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("ohDesktop", {
+  isDesktop: true,
+  // Fires with { build, notes, url } when a newer release exists, and is also
+  // replayed on subscribe so a late-mounting banner still hears about it.
+  onUpdate: (fn) => {
+    ipcRenderer.on("desktop:update", (_event, payload) => fn(payload));
+    ipcRenderer.invoke("desktop:update-state").then((state) => { if (state) fn(state); });
+  },
+  // Opens the installer in the player's browser. Downloading it inside the app
+  // would leave them with a file and no idea where it went.
+  download: (url) => ipcRenderer.invoke("desktop:download", url),
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -112,6 +112,10 @@ const createMainWindow = () => {
     backgroundColor: "#0d1122",
     show: false,
     title: "Open Historia",
+    // The game is a localhost page: it cannot tell it is inside the desktop app,
+    // and cannot fetch a release asset itself (GitHub sends no CORS headers).
+    // gamePreload gives it exactly those two things and nothing more.
+    webPreferences: { preload: path.join(__dirname, "gamePreload.cjs") },
   });
   // Links to GitHub/Discord open in the real browser rather than replacing the
   // game with a page the player cannot navigate back from.
@@ -121,6 +125,51 @@ const createMainWindow = () => {
   });
   win.once("ready-to-show", () => win.show());
   return win;
+};
+
+// --- desktop updates ------------------------------------------------------
+
+// This build's id, written by the release workflow. A dev run has no such file and
+// therefore never reports an update, which is what we want.
+const readBuildId = () => {
+  try {
+    return String(JSON.parse(fs.readFileSync(path.join(__dirname, "build-id.json"), "utf8")).build || "");
+  } catch {
+    return "";
+  }
+};
+const BUILD_ID = readBuildId();
+// A small latest.json sits beside the installers on the release. Reading that rather
+// than the GitHub API matters: the API is rate limited PER IP, and players behind one
+// carrier NAT share an IP, so at any scale the check starts 403ing for all of them at
+// once. A release asset is a plain CDN download with no such limit.
+const LATEST_URL =
+  "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/latest.json";
+const UPDATE_CHECK_MS = 6 * 60 * 60 * 1000;
+// Which installer this machine should be offered.
+const ASSET_FOR_PLATFORM = { win32: "windows", darwin: "mac", linux: "linux" };
+
+let updateState = null;
+
+const checkForUpdate = async () => {
+  if (!BUILD_ID) return; // unstamped (dev) build - nothing to compare against
+  try {
+    const res = await fetch(LATEST_URL, { cache: "no-store", signal: AbortSignal.timeout(10000) });
+    if (!res.ok) return;
+    const latest = await res.json();
+    const build = String(latest?.build || "");
+    // Any DIFFERENCE counts, not just "newer": the ids are opaque, and a rollback is
+    // just as much "not what you are running".
+    if (!build || build === BUILD_ID) return;
+    const url = latest?.[ASSET_FOR_PLATFORM[process.platform]] || latest?.url;
+    if (!url) return;
+    updateState = { build, notes: String(latest?.notes || ""), url };
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("desktop:update", updateState);
+    }
+  } catch {
+    /* fail open: a failed check simply shows no banner */
+  }
 };
 
 // --- boot -------------------------------------------------------------------
@@ -161,6 +210,8 @@ const boot = async () => {
   mainWindow = createMainWindow();
   const port = process.env.PORT || 3000;
   await mainWindow.loadURL(`http://localhost:${port}`);
+  checkForUpdate();
+  setInterval(checkForUpdate, UPDATE_CHECK_MS);
   setupWindow?.close();
   setupWindow = null;
 };
@@ -179,4 +230,9 @@ if (!app.requestSingleInstanceLock()) {
   app.whenReady().then(boot);
   app.on("window-all-closed", () => app.quit());
   ipcMain.handle("setup:cancel", () => app.quit());
+  ipcMain.handle("desktop:update-state", () => updateState);
+  ipcMain.handle("desktop:download", (_event, url) => {
+    // Only ever the installer from our own release - never a URL the page invented.
+    if (typeof url === "string" && url === updateState?.url) shell.openExternal(url);
+  });
 }

--- a/src/runtime/AppUpdateBanner.jsx
+++ b/src/runtime/AppUpdateBanner.jsx
@@ -64,18 +64,23 @@ export default function AppUpdateBanner() {
   // server for the release manifest and updates by downloading an APK; the website
   // compares its baked build id against the deployed version.json and updates by
   // reloading onto the new bundle. Desktop/dev carry neither stamp and no-op.
-  const isApp = Number.isFinite(APP_BUILD) && APP_BUILD > 0;
-  const isWeb = !isApp && WEB_BUILD !== "";
-  const supported = isApp || isWeb;
+  // The desktop app announces itself through its preload bridge (electron/
+  // gamePreload.cjs) — the page is served from localhost either way, so there is
+  // nothing else to detect it by. Its main process does the release check, because
+  // a page cannot fetch a GitHub asset (no CORS).
+  const isDesktop = typeof window !== "undefined" && window.ohDesktop?.isDesktop === true;
+  const isApp = !isDesktop && Number.isFinite(APP_BUILD) && APP_BUILD > 0;
+  const isWeb = !isDesktop && !isApp && WEB_BUILD !== "";
+  const supported = isDesktop || isApp || isWeb;
   const [latest, setLatest] = useState(null);
   const [dismissed, setDismissed] = useState(() => {
     try {
       const stored = localStorage.getItem(DISMISS_KEY);
       // App builds compare numerically ("is this newer than what I dismissed"); web
       // ids are opaque and compare by equality, so keep the raw string for them.
-      return isWeb ? String(stored ?? "") : Number(stored) || 0;
+      return isWeb || isDesktop ? String(stored ?? "") : Number(stored) || 0;
     } catch {
-      return isWeb ? "" : 0;
+      return isWeb || isDesktop ? "" : 0;
     }
   });
   const [updating, setUpdating] = useState(false);
@@ -83,6 +88,14 @@ export default function AppUpdateBanner() {
 
   useEffect(() => {
     if (!supported) return undefined;
+    if (isDesktop) {
+      // Main already polls; just listen. It replays the last result on subscribe,
+      // so a banner that mounts after the check still hears about it.
+      window.ohDesktop.onUpdate((payload) => {
+        if (payload?.build && payload?.url) setLatest({ ...payload, desktop: true });
+      });
+      return undefined;
+    }
     let cancelled = false;
     const check = async () => {
       try {
@@ -122,14 +135,21 @@ export default function AppUpdateBanner() {
       clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [supported, isWeb]);
+  }, [supported, isWeb, isDesktop]);
 
   if (!supported) return null;
-  if (isWeb ? !latest : !isUpdateAvailable(APP_BUILD, latest)) return null;
+  if (isWeb || isDesktop ? !latest : !isUpdateAvailable(APP_BUILD, latest)) return null;
   // Web ids are opaque strings, so dismissal is an equality check rather than "<=".
-  if (isWeb ? String(dismissed) === String(latest.build) : latest.build <= dismissed) return null;
+  if (isWeb || isDesktop ? String(dismissed) === String(latest.build) : latest.build <= dismissed) return null;
 
   const onUpdate = async () => {
+    if (isDesktop) {
+      // Hands the installer to the player's browser. Downloading it inside the app
+      // would leave them with a file and no idea where it went.
+      setUpdating(true);
+      window.ohDesktop.download(latest.url);
+      return;
+    }
     if (isWeb) {
       setUpdating(true);
       // Bundle filenames are content-hashed, so re-fetching the shell is all it takes
@@ -178,7 +198,7 @@ export default function AppUpdateBanner() {
               : latest.notes || `Build ${latest.build} · tap Update to download and install.`}
         </span>
       </div>
-      {isWeb || latest.apk ? (
+      {isWeb || isDesktop || latest.apk ? (
         <button type="button" style={btn} onClick={onUpdate} disabled={updating}>
           {updating ? (isWeb ? "Reloading…" : "Downloading…") : "Update now"}
         </button>


### PR DESCRIPTION
The banner already handled the APK and the website; the Electron app fell through both checks and showed nothing, so someone who installed it had no way to learn a new build existed.

The game runs at localhost inside the app, so it can't tell it's in the desktop app and can't fetch a release asset to check (**GitHub sends no CORS headers** on those). The **main process** does the check and hands the result to the page through a narrow preload bridge — is-desktop, subscribe-to-update, open-download, nothing else.

It reads a small `latest.json` published beside the installers rather than the GitHub API: the API is rate-limited **per IP**, and players behind one carrier NAT share an IP, so at scale an API check starts 403ing for all of them at once.

**Update now** opens the installer in the player's browser rather than downloading it inside the app, where they'd end up with a file and no idea where it went. The download handler only accepts the exact URL the check produced, so the page can't ask it to open anything else.

The workflow stamps the run id into the app and writes the same id into `latest.json`; **only the Windows job writes it**, so three racing jobs can't publish three different views of one release. An unstamped (dev) build never reports an update.