### PR TITLE
Stop a flattened structure throwing away the turn; stop the SW breaking map tiles — main

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -11,6 +11,12 @@ self.addEventListener("activate", (event) => {
     event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener("fetch", (event) => {
-    event.respondWith(fetch(event.request));
-});
+// Deliberately does NOT call respondWith. This worker caches nothing, so taking
+// over a request could only ever re-issue it — and re-issuing a cross-origin one
+// through fetch() loses the mode/credentials the browser chose for it. Map tiles
+// are exactly that case: terrain from s3.amazonaws.com and basemaps from
+// arcgisonline came back as "A ServiceWorker intercepted the request and
+// encountered an unexpected error", and the tiles simply failed to load.
+// Leaving the handler in place (but passive) keeps the install criteria that
+// wanted a fetch listener, while the browser handles every request itself.
+self.addEventListener("fetch", () => {});

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -513,6 +513,24 @@ const runJsonTask = async (taskKey, {
           && (typeof parsed.catalyst !== "object" || Array.isArray(parsed.catalyst))) {
         parsed.catalyst = null;
       }
+      // Same idea for markerOps. The engine has always accepted `found`/`destroy`
+      // as aliases and a build written flat, but the schema only ever allowed the
+      // canonical spelling — and a single rejected op fails the WHOLE payload, so
+      // one flattened building cost the player the entire turn. Rewrite to the
+      // canonical shape here, before validation, so the turn survives.
+      for (const event of Array.isArray(parsed?.events) ? parsed.events : []) {
+        const ops = event?.impacts?.markerOps;
+        if (!Array.isArray(ops)) continue;
+        event.impacts.markerOps = ops.map((op) => {
+          if (!op || typeof op !== "object") return op;
+          const kind = String(op.op ?? "").trim().toLowerCase();
+          const canonical = kind === "found" ? "build" : kind === "destroy" ? "remove" : kind;
+          if (canonical !== "build" || op.marker) return { ...op, op: canonical };
+          // Flat build: lift the structure's own fields under `marker`.
+          const { op: _op, note, ...marker } = op;
+          return { op: "build", marker, ...(note == null ? {} : { note }) };
+        });
+      }
       let validation = parsed
         ? validateGameplayPayload(taskKey, parsed)
         : { valid: false, error: "Response did not contain parseable JSON or tool arguments." };

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -332,6 +332,27 @@ const markerOpSchema = {
       required: ["op", "marker"],
       additionalProperties: false,
     },
+    // The same build, written flat. Models routinely put the structure's fields
+    // beside `op` instead of nesting them under `marker`, and the engine has always
+    // read that shape (normalizeMarkerOp falls back to the entry itself). Only this
+    // schema refused it — and because a rejected op fails the WHOLE payload, one
+    // flattened building threw away the entire turn and left the player with
+    // fallback events. Accept what we already understand.
+    {
+      type: "object",
+      properties: {
+        op: { type: "string", enum: ["build"] },
+        id: textSchema("Stable marker identifier."),
+        name: nonEmptyTextSchema("Name of the structure or place."),
+        kind: textSchema("What it is: city, base, bunker, silo, embassy, port."),
+        ownerCode: textSchema("Owning polity's FULL country name (\"Spain\"), never a country code."),
+        lng: { type: "number", description: "Longitude.", minimum: -180, maximum: 180 },
+        lat: { type: "number", description: "Latitude.", minimum: -90, maximum: 90 },
+        note: textSchema("Brief explanation."),
+      },
+      required: ["op", "name", "lng", "lat"],
+      additionalProperties: false,
+    },
     {
       type: "object",
       properties: {


### PR DESCRIPTION
**1. The reported fallback bug.** `markerOps[0] did not match any allowed schema` — the model wrote a build op **flat** (name, kind, ownerCode, lng, lat beside `op`) instead of nesting them under `marker`. The engine has always read that shape (`normalizeMarkerOp` falls back to the entry itself) and accepts `found`/`destroy` as aliases too — **only the schema refused it**. Since one rejected op fails the entire payload, a single flattened building cost the player the whole turn and handed them canned fallback events.

The schema now accepts the flat build, and `markerOps` are rewritten to the canonical shape *before* validation, so aliases and the flat form both survive.

Verified against the reported payload: **rejected** by the old schema with the same `did not match any allowed schema` error, **valid** now — and nested/remove/rename all still validate.

**2. The ServiceWorker errors in the second screenshot.** `sw.js` caches nothing, so taking over a request could only re-issue it — and re-issuing a **cross-origin** one through `fetch()` loses the mode/credentials the browser chose. That's why terrain tiles from `s3.amazonaws.com` and basemaps from `arcgisonline` failed with *"a ServiceWorker intercepted the request and encountered an unexpected error"*. The handler stays (some install criteria want one) but no longer responds, so the browser handles every request itself.

57 regionVocab + 26 server tests pass.