### PR TITLE
Bring an older install's games into the app — beta

### DIFF
--- a/electron/importLegacy.cjs
+++ b/electron/importLegacy.cjs
@@ -1,0 +1,97 @@
+/*! Open Historia — bring an older install's games across © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// The old desktop release was a zip you extracted and ran a launcher from, and it
+// kept everything in <extracted folder>/server/data. The installed app writes to
+// its own per-user data directory instead, so a player who upgrades opens the new
+// app and finds an empty library while their saves sit in the old folder. Nothing
+// carried them across; this does.
+//
+// It only ever runs when the new data directory has no games yet, so it cannot
+// overwrite anything, and it copies rather than moves — the old folder is left
+// exactly as it was in case anything goes wrong.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// A folder is an old install if it has the manifest the server writes.
+const MARKER = path.join("server", "data", "game-manifest.json");
+// Caches and telemetry markers rebuild themselves; hub-cache alone can be >100MB,
+// and copying it would make the import look broken for no benefit.
+const SKIP = new Set(["hub-cache", "import-pings"]);
+
+const looksLikeInstall = (dir) => {
+  try {
+    return fs.existsSync(path.join(dir, MARKER));
+  } catch {
+    return false;
+  }
+};
+
+// Where an extracted zip usually ends up. Deliberately shallow: this runs on the
+// UI thread at startup, so it checks a handful of likely folders one level deep
+// rather than walking the disk.
+const findLegacyInstall = (home) => {
+  const roots = ["Downloads", "Desktop", "Documents", ""].map((d) => path.join(home, d));
+  for (const root of roots) {
+    if (looksLikeInstall(root)) return root;
+    let entries = [];
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      // Cheap name filter first — readdir on every folder in Documents is slow.
+      if (!/open[-\s]?historia|pax[-\s]?historia/i.test(entry.name)) continue;
+      const candidate = path.join(root, entry.name);
+      if (looksLikeInstall(candidate)) return candidate;
+      // Zips are often extracted into a wrapper folder of the same name.
+      try {
+        for (const inner of fs.readdirSync(candidate, { withFileTypes: true })) {
+          if (!inner.isDirectory()) continue;
+          const nested = path.join(candidate, inner.name);
+          if (looksLikeInstall(nested)) return nested;
+        }
+      } catch { /* unreadable — skip */ }
+    }
+  }
+  return null;
+};
+
+// True when this profile has never held a library, which is the only time an
+// import is safe to offer.
+const isFreshProfile = (dataDir) => {
+  try {
+    return !fs.existsSync(path.join(dataDir, "game-manifest.json"));
+  } catch {
+    return true;
+  }
+};
+
+const importFrom = (installDir, dataDir) => {
+  const source = path.join(installDir, "server", "data");
+  fs.mkdirSync(dataDir, { recursive: true });
+  let copied = 0;
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    fs.cpSync(path.join(source, entry.name), path.join(dataDir, entry.name), {
+      recursive: true,
+      force: true,
+    });
+    copied += 1;
+  }
+  return copied;
+};
+
+// How many games are in there, so the prompt can say something concrete rather
+// than asking the player to trust a path.
+const countGames = (installDir) => {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(installDir, MARKER), "utf8"));
+    return Array.isArray(manifest?.order) ? manifest.order.length : 0;
+  } catch {
+    return 0;
+  }
+};
+
+module.exports = { findLegacyInstall, isFreshProfile, importFrom, countGames, looksLikeInstall };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -172,6 +172,70 @@ const checkForUpdate = async () => {
   }
 };
 
+// --- carrying an older install across ------------------------------------
+
+// Offered once, on a profile that has never held a library. The old zip release
+// kept saves next to itself; the installed app has its own data directory, so
+// without this an upgrade looks like every game was lost.
+const offerLegacyImport = async () => {
+  if (!legacy.isFreshProfile(DATA_DIR)) return;
+  let found = null;
+  try { found = legacy.findLegacyInstall(app.getPath("home")); } catch { /* keep going */ }
+
+  const games = found ? legacy.countGames(found) : 0;
+  const { response } = await dialog.showMessageBox({
+    type: "question",
+    title: "Bring your games across?",
+    message: found
+      ? "Found an earlier Open Historia install"
+      : "Bring games across from an earlier install?",
+    detail: found
+      ? `${found}
+
+${games ? `${games} game${games === 1 ? "" : "s"}` : "Its games"}, scenarios, basemaps and map-editor documents can be copied into this app. The old folder is left untouched.`
+      : "If you used the older download (the one you extracted and launched with a script), its games can be copied across. Choose the folder you extracted it to.",
+    buttons: found
+      ? ["Bring them across", "Choose another folder…", "Skip"]
+      : ["Choose folder…", "Skip"],
+    defaultId: 0,
+    cancelId: found ? 2 : 1,
+  });
+
+  let source = null;
+  if (found && response === 0) source = found;
+  else if ((found && response === 1) || (!found && response === 0)) {
+    const picked = await dialog.showOpenDialog({
+      title: "Select your old Open Historia folder",
+      properties: ["openDirectory"],
+    });
+    source = picked.canceled ? null : picked.filePaths[0];
+    if (source && !legacy.looksLikeInstall(source)) {
+      dialog.showErrorBox(
+        "That folder has no Open Historia data",
+        `${source}
+
+Pick the folder you extracted the old download into — the one containing a "server" folder.`,
+      );
+      source = null;
+    }
+  }
+  if (!source) return;
+
+  try {
+    const copied = legacy.importFrom(source, DATA_DIR);
+    console.log(`[open-historia] imported ${copied} item(s) from ${source}`);
+  } catch (error) {
+    console.error("[open-historia] import failed:", error);
+    dialog.showErrorBox(
+      "Could not bring the games across",
+      `${error?.message || error}
+
+Your old folder has not been changed. You can copy its server\data folder into:
+${DATA_DIR}`,
+    );
+  }
+};
+
 // --- boot -------------------------------------------------------------------
 
 // Starting the server is importing it: server.js calls app.listen() at module
@@ -206,6 +270,7 @@ const boot = async () => {
     setupWindow?.webContents.send("setup:done");
   }
 
+  await offerLegacyImport();
   await startServer();
   mainWindow = createMainWindow();
   const port = process.env.PORT || 3000;


### PR DESCRIPTION
**Upgrading looked like losing every save.** The old release was a zip you extracted and started with a launcher, keeping everything in `<extracted folder>/server/data`. The installed app has its own per-user data directory, so it opened an empty library while the saves sat in the old folder. Nothing moved them.

On a profile that has **never held a library**, the app now looks for that old folder (Downloads / Desktop / Documents, one level deep, name-filtered — a real home directory scans in ~5 ms) and offers to bring games, scenarios, basemaps and map-editor documents across. Finds nothing → offers a folder picker instead, and rejects a folder with no Open Historia data rather than silently doing nothing.

Safety properties, all verified:
- **Copies, never moves** — the old folder is left exactly as it was, so a bad import costs nothing
- **Skips `hub-cache` / `import-pings`** — they rebuild themselves and the cache alone can exceed 100 MB, which would make the import look hung
- **Only runs when there's no `game-manifest.json`** — it can never overwrite a library and never asks twice

Tested: detection in a normal layout *and* a nested wrapper folder (zips often extract into a same-named folder), correct `null` on an unrelated home (no false positives), manifests + games copied, cache skipped, profile no longer 'fresh' afterwards, old folder untouched.