### PR TITLE
Desktop update banner, without touching the window — main

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -28,6 +28,18 @@ const ASSETS_DIR = path.join(USER_ROOT, "public", "assets");
 process.env.OH_DATA_DIR = DATA_DIR;
 process.env.OH_ASSETS_DIR = ASSETS_DIR;
 
+// The build id the release workflow stamped in. The server passes it to the page so
+// the update banner can compare it against the published one. Deliberately routed
+// this way rather than through a preload: attaching a preload to the game window is
+// what broke the app last time, and this adds nothing to how the window is created.
+try {
+  process.env.OH_DESKTOP_BUILD = String(
+    JSON.parse(fs.readFileSync(path.join(__dirname, "build-id.json"), "utf8")).build || "",
+  );
+} catch {
+  /* dev build: unstamped, so no update is ever offered */
+}
+
 const APP_ROOT = path.join(__dirname, "..");
 // asarUnpack keeps scripts/ outside the archive so a child process can run it.
 const unpacked = (p) => p.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);

--- a/server/server.js
+++ b/server/server.js
@@ -271,6 +271,10 @@ app.get("/api/library", (_req, res) => {
 const APP_UPDATE_MANIFESTS = {
   stable: "https://github.com/Open-Historia/open-historia/releases/download/android/latest.json",
   beta: "https://github.com/Open-Historia/open-historia/releases/download/android-beta/latest.json",
+  // The desktop app checks through here rather than from the page: a release asset
+  // sends no CORS headers, and the GitHub API is rate limited per IP. Exactly the
+  // reason the Android tracks are served this way.
+  desktop: "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/latest.json",
 };
 const APP_UPDATE_TTL_MS = 3 * 60 * 1000;
 const appUpdateCache = new Map(); // track -> { at, data }
@@ -294,10 +298,19 @@ app.get("/api/app-update", async (req, res) => {
       return;
     }
     const raw = await response.json();
+    const str = (value) => (typeof value === "string" ? value : "");
     const data = {
       build: Number(raw && raw.build) || 0,
-      apk: typeof (raw && raw.apk) === "string" ? raw.apk : "",
-      notes: typeof (raw && raw.notes) === "string" ? raw.notes : "",
+      apk: str(raw && raw.apk),
+      notes: str(raw && raw.notes),
+      // Desktop ids are opaque strings (a CI run id), not the ascending integer the
+      // Android tracks use, so they are kept as text and compared for INEQUALITY.
+      buildId: String((raw && raw.build) ?? ""),
+      // Set only when this server is the one running inside the desktop app. That is
+      // how the page can tell it is there at all — it is otherwise an ordinary
+      // localhost page — and it is absent everywhere else, so no banner appears.
+      current: String(process.env.OH_DESKTOP_BUILD || ""),
+      download: str(raw && raw[{ win32: "windows", darwin: "mac", linux: "linux" }[process.platform]]),
     };
     appUpdateCache.set(track, { at: Date.now(), data });
     res.json(data);

--- a/src/runtime/AppUpdateBanner.jsx
+++ b/src/runtime/AppUpdateBanner.jsx
@@ -65,8 +65,14 @@ export default function AppUpdateBanner() {
   // compares its baked build id against the deployed version.json and updates by
   // reloading onto the new bundle. Desktop/dev carry neither stamp and no-op.
   const isApp = Number.isFinite(APP_BUILD) && APP_BUILD > 0;
+  // The desktop app is an ordinary localhost page, so it cannot tell it is inside
+  // the app on its own. Its server answers /api/app-update with a `current` build,
+  // and only that server does — so the reply itself is the signal. Nothing is added
+  // to the window for this: a preload on the game window is what broke the app
+  // before.
+  const [desktop, setDesktop] = useState(null);
   const isWeb = !isApp && WEB_BUILD !== "";
-  const supported = isApp || isWeb;
+  const supported = isApp || isWeb || Boolean(desktop);
   const [latest, setLatest] = useState(null);
   const [dismissed, setDismissed] = useState(() => {
     try {
@@ -80,6 +86,28 @@ export default function AppUpdateBanner() {
   });
   const [updating, setUpdating] = useState(false);
   const lastRefocusRef = useRef(0);
+
+  useEffect(() => {
+    if (isApp || isWeb) return undefined;
+    let dropped = false;
+    const probe = async () => {
+      try {
+        const res = await fetch("/api/app-update?track=desktop", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        // `current` present = this is the desktop app. Any DIFFERENCE is an update:
+        // the ids are opaque, so a rollback counts just as much as a newer build.
+        if (dropped || !data?.current || !data?.buildId || !data?.download) return;
+        if (data.buildId === data.current) return;
+        setDesktop({ build: data.buildId, notes: data.notes || "", url: data.download });
+      } catch {
+        /* fail open: no banner */
+      }
+    };
+    probe();
+    const timer = setInterval(probe, APP_UPDATE_CHECK_INTERVAL_MS);
+    return () => { dropped = true; clearInterval(timer); };
+  }, [isApp, isWeb]);
 
   useEffect(() => {
     if (!supported) return undefined;
@@ -125,11 +153,21 @@ export default function AppUpdateBanner() {
   }, [supported, isWeb]);
 
   if (!supported) return null;
-  if (isWeb ? !latest : !isUpdateAvailable(APP_BUILD, latest)) return null;
+  const info = desktop ?? latest;
+  if (desktop ? false : isWeb ? !latest : !isUpdateAvailable(APP_BUILD, latest)) return null;
+  if (desktop && String(dismissed) === String(desktop.build)) return null;
   // Web ids are opaque strings, so dismissal is an equality check rather than "<=".
-  if (isWeb ? String(dismissed) === String(latest.build) : latest.build <= dismissed) return null;
+  if (!desktop && (isWeb ? String(dismissed) === String(latest.build) : latest.build <= dismissed)) return null;
 
   const onUpdate = async () => {
+    if (desktop) {
+      // window.open goes through the main process's window-open handler, which sends
+      // it to the real browser — so the installer downloads where the player can see
+      // it, and no extra bridge is needed to do it.
+      setUpdating(true);
+      window.open(desktop.url, "_blank", "noopener");
+      return;
+    }
     if (isWeb) {
       setUpdating(true);
       // Bundle filenames are content-hashed, so re-fetching the shell is all it takes
@@ -158,9 +196,9 @@ export default function AppUpdateBanner() {
     window.location.href = latest.apk;
   };
   const onDismiss = () => {
-    setDismissed(latest.build);
+    setDismissed(info.build);
     try {
-      localStorage.setItem(DISMISS_KEY, String(latest.build));
+      localStorage.setItem(DISMISS_KEY, String(info.build));
     } catch {
       /* ignore: dismissal just won't persist across launches */
     }
@@ -171,16 +209,18 @@ export default function AppUpdateBanner() {
       <div style={text}>
         A new version of Open Historia is ready.
         <span style={sub}>
-          {isWeb
+          {desktop
+            ? (updating ? "Opening the download…" : "Download the new version and run it — your games are kept.")
+            : isWeb
             ? (updating ? "Reloading…" : "Reload to get the latest fixes. Your games are saved.")
             : updating
               ? "Downloading… open the finished download to install and reopen."
               : latest.notes || `Build ${latest.build} · tap Update to download and install.`}
         </span>
       </div>
-      {isWeb || latest.apk ? (
+      {isWeb || desktop || latest.apk ? (
         <button type="button" style={btn} onClick={onUpdate} disabled={updating}>
-          {updating ? (isWeb ? "Reloading…" : "Downloading…") : "Update now"}
+          {updating ? (isWeb ? "Reloading…" : desktop ? "Opening…" : "Downloading…") : "Update now"}
         </button>
       ) : null}
       <button type="button" style={dismissBtn} onClick={onDismiss} aria-label="Dismiss update notice">


### PR DESCRIPTION
Re-adds the desktop update banner by the one route that **cannot repeat the last failure**.

The previous attempt attached a **preload to the game window**, and a preload that fails takes the page load with it — `loadURL` never resolves, `boot()` never finishes, no window is ever created. **Nothing here goes near window creation.**

The check runs where one already runs for the APK: `/api/app-update` gains a `desktop` track and the server fetches the release's `latest.json` itself (a release asset sends no CORS headers, and the GitHub API is rate-limited per IP). Electron passes its stamped build id in via `OH_DESKTOP_BUILD`; the server returns it as `current`. **Only that server sets it**, so the reply is also how the page knows it's in the desktop app at all — it's otherwise an ordinary localhost page.

**Update now** calls `window.open`, which the main process already routes to the real browser, so the installer downloads where the player can see it — no bridge needed. Dismissal is keyed on the opaque build id, and any *difference* counts as an update (a rollback is equally not-what-you're-running).

Verified against the live release:
- build id set → `current` differs from the published id, and the correct per-platform installer URL is returned
- no build id → `current` is empty, so no banner can appear (protects the plain node-server desktop and dev runs)
