### PR TITLE
Sort unread chats to the top, and stop re-publishing hub content

### DIFF
--- a/server/flagStore.js
+++ b/server/flagStore.js
@@ -61,6 +61,10 @@ export const createFlag = (body = {}) => {
     author: String(body.author || "").slice(0, 80),
     dataUrl,
     contentHash,
+    // Provenance, mirroring basemapStore: { community: true, url } marks a flag
+    // that came FROM the hub, so publishing a scenario doesn't offer it back to
+    // the community as if it were new. Null for a flag the map-maker uploaded.
+    source: body.source && typeof body.source === "object" ? JSON.parse(JSON.stringify(body.source)) : null,
     createdAt: new Date().toISOString(),
   };
   writeAll([flag, ...flags]);

--- a/src/Editor/FlagPicker.jsx
+++ b/src/Editor/FlagPicker.jsx
@@ -255,7 +255,24 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
     setBusyId(post.id);
     setCommunityError("");
     try {
-      pick(await loadCommunityFlagDataUrl(post));
+      const dataUrl = await loadCommunityFlagDataUrl(post);
+      // Save it into My flags the way a pack install does — same as before for the
+      // map-maker (the flag is applied either way), but it now leaves a record
+      // marked community, which is what stops a scenario using it from re-offering
+      // it to the hub. Best-effort: a library that won't save must not lose the pick.
+      try {
+        await saveFlag({
+          name: post.title || post.code || "Flag",
+          code: post.code || "",
+          author: post.author || "",
+          dataUrl,
+          source: { community: true, url: post.url || null },
+        });
+        refreshMine();
+      } catch (e) {
+        console.warn("[editor] could not save the community flag to the library:", e);
+      }
+      pick(dataUrl);
     } catch (e) {
       setCommunityError(e?.message || "Could not download that flag.");
     } finally {
@@ -280,6 +297,7 @@ const FlagPicker = ({ open, onClose, ownerCode, currentFlag, mapFlags = {}, auth
             code: flag.code || "",
             author: post.author || "",
             dataUrl: flag.dataUrl,
+            source: { community: true, url: post.url || null },
           });
           saved += 1;
         } catch { /* one bad flag must not sink the whole pack */ }

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -12,7 +12,6 @@ import {
     readJson,
 } from "../../runtime/assets.js";
 import { flagEmojiFromGid } from "../../runtime/countryFlags.js";
-import { chatLanguageDiffersFromUi, isRtlLanguage, resolveChatLanguage } from "../../runtime/i18n.js";
 import { readChatsState, writeChatsState } from "../../runtime/gameState.js";
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -165,9 +164,6 @@ const GearIcon = () => (
 const MessageBubble = ({ msg }) => {
     const isPlayer = msg.role === "user";
     const isError  = msg.role === "error";
-    // See advisor.jsx: errors are UI strings, so only a leader's own words are
-    // held back from the translator.
-    const asWritten = !isPlayer && !isError && chatLanguageDiffersFromUi();
     const flag     = useCountryFlag(isPlayer || isError ? {} : { code: msg.code, name: msg.speaker });
     const reactions = Object.entries(msg.reactions ?? {});
     const reactionFlags = useCountryFlags(reactions.map(([name, { code }]) => ({ name, code })));
@@ -199,7 +195,7 @@ const MessageBubble = ({ msg }) => {
         )}
 
         {/* Player-typed text stays verbatim under UI translation. */}
-        <div data-no-translate={isPlayer || asWritten ? "" : undefined} dir={asWritten && isRtlLanguage(resolveChatLanguage()) ? "rtl" : undefined} style={{
+        <div data-no-translate={isPlayer ? "" : undefined} style={{
             padding: "0.6rem 0.85rem",
             borderRadius: isPlayer ? "12px 12px 2px 12px" : "12px 12px 12px 2px",
             backgroundColor: isPlayer
@@ -664,9 +660,46 @@ const CountryTurnLabel = ({ country, remaining }) => {
     );
 };
 
+// ── Unread tracking ───────────────────────────────────────────────────────────
+
+// Message totals per chat as of the last time the panel was open. Module-level
+// AND persisted because two separate components need the SAME baseline: the
+// toolbar's unread badge and the panel's chat list. It used to be a useRef
+// inside the toolbar button, so the list could not read it and every remount
+// silently reset it.
+const SEEN_KEY = "oh:chat-seen";
+
+// null (not {}) when nothing has ever been recorded — the two cases differ: no
+// baseline at all means "first run, don't shout about chats that were already
+// there", while an empty baseline means every chat really is new.
+const readSeen = () => {
+    try {
+        const raw = localStorage.getItem(SEEN_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch { return null; }
+};
+
+const writeSeen = (totals) => {
+    try { localStorage.setItem(SEEN_KEY, JSON.stringify(totals)); } catch { /* private mode / quota */ }
+};
+
+const chatMessageCount = (chat) => chat?.messages?.length ?? 0;
+const seenTotals = (list) => Object.fromEntries(list.map((c) => [String(c.id), chatMessageCount(c)]));
+
+// Unread = more messages than when the panel was last open. A chat with no entry
+// is unread (that is how a brand-new conversation surfaces) — but only once a
+// baseline exists, so a first run doesn't light up every existing chat.
+const isChatUnread = (chat, seen) => {
+    if (!seen) return false;
+    const prev = seen[String(chat.id)];
+    return prev === undefined || chatMessageCount(chat) > prev;
+};
+
 // ── Chat list item ────────────────────────────────────────────────────────────
 
-const ChatListItem = ({ chat, onClick, onDelete }) => {
+const ChatListItem = ({ chat, onClick, onDelete, unread = false }) => {
     const [hovered, setHovered] = React.useState(false);
     const previewCountries = chat.countries.slice(0, 4);
     const flagMap  = useCountryFlags(previewCountries);
@@ -678,10 +711,14 @@ const ChatListItem = ({ chat, onClick, onDelete }) => {
     return (
         <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)} style={{ position: "relative" }}>
         <button onClick={onClick} style={{ width: "100%", padding: "0.7rem 0.9rem", borderRadius: "10px", border: "1px solid rgba(255,255,255,0.07)", background: hovered ? "rgba(255,255,255,0.07)" : "rgba(255,255,255,0.03)", display: "flex", alignItems: "center", gap: "0.75rem", cursor: "pointer", transition: "background 0.15s", fontFamily: "sans-serif", textAlign: "left" }}>
+        {/* Fixed-width slot, always rendered, so read and unread rows stay aligned. */}
+        <div style={{ width: "0.5rem", flexShrink: 0, display: "flex", justifyContent: "center" }} aria-hidden="true">
+        {unread && <div style={{ width: "0.5rem", height: "0.5rem", borderRadius: "50%", background: "#60a5fa" }} />}
+        </div>
         <div style={{ fontSize: "1.3rem", flexShrink: 0, lineHeight: 1 }}>{flags}</div>
         <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: "0.82rem", fontWeight: 600, color: "rgba(255,255,255,0.9)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{names}</div>
-        <div style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.35)", marginTop: "0.15rem", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{preview}</div>
+        <div style={{ fontSize: "0.82rem", fontWeight: unread ? 700 : 600, color: unread ? "#fff" : "rgba(255,255,255,0.9)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{names}{unread && <span style={{ fontWeight: 400, fontSize: "0.7rem", color: "#60a5fa", marginLeft: "0.4rem" }}>new</span>}</div>
+        <div style={{ fontSize: "0.75rem", color: unread ? "rgba(255,255,255,0.6)" : "rgba(255,255,255,0.35)", marginTop: "0.15rem", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{preview}</div>
         </div>
         </button>
         {hovered && (
@@ -713,6 +750,36 @@ const ChatPanel = ({ isOpen, onClose, requestedCountry, onConsumeRequest }) => {
     const [showSelector, setShowSelector]         = useState(false);
     const [hasLoadedInitialData, setHasLoadedInitialData] = useState(false);
     const openChats = chats.filter((chat) => chat.status !== "closed" && Array.isArray(chat.countries) && chat.countries.length > 0);
+
+    // Which chats to flag as unread, snapshotted when the panel OPENS and held
+    // until it closes — rows must not reshuffle under the cursor while the player
+    // is reading them. Reopening the panel is what re-sorts.
+    const [unreadIds, setUnreadIds] = useState(() => new Set());
+    const snapshotTakenRef = useRef(false);
+
+    useEffect(() => {
+        if (!isOpen) { snapshotTakenRef.current = false; return; }
+        if (snapshotTakenRef.current || !hasLoadedInitialData) return;
+        snapshotTakenRef.current = true;
+        setUnreadIds(new Set(openChats.filter((chat) => isChatUnread(chat, readSeen())).map((chat) => String(chat.id))));
+        // Everything on screen now counts as seen: the toolbar badge clears, and the
+        // next open only flags what arrived in between.
+        writeSeen(seenTotals(openChats));
+    }, [isOpen, hasLoadedInitialData, openChats]);
+
+    // Unread first, everything else in the order it already had — a stable
+    // partition, so chats the player has read don't jump around too.
+    const orderedChats = [
+        ...openChats.filter((chat) => unreadIds.has(String(chat.id))),
+        ...openChats.filter((chat) => !unreadIds.has(String(chat.id))),
+    ];
+
+    // Opening a chat marks it read, so messages that landed while the panel was
+    // already open don't come back flagged on the next open.
+    const openChatFromList = (chat) => {
+        setActiveChat(chat);
+        writeSeen({ ...(readSeen() || {}), [String(chat.id)]: chatMessageCount(chat) });
+    };
 
     useEffect(() => {
         if (!isOpen || hasLoadedInitialData) return;
@@ -871,7 +938,7 @@ const ChatPanel = ({ isOpen, onClose, requestedCountry, onConsumeRequest }) => {
                     <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.25)", fontSize: "0.82rem", fontStyle: "italic", textAlign: "center", padding: "2rem" }}>
                     No diplomatic conversations yet.<br />Start one below.
                     </div>
-                ) : openChats.map(chat => <ChatListItem key={chat.id} chat={chat} onClick={() => setActiveChat(chat)} onDelete={() => handleDeleteChat(chat.id)} />)}
+                ) : orderedChats.map(chat => <ChatListItem key={chat.id} chat={chat} unread={unreadIds.has(String(chat.id))} onClick={() => openChatFromList(chat)} onDelete={() => handleDeleteChat(chat.id)} />)}
                 </div>
                 <div style={{ padding: "0.75rem 1rem", borderTop: "1px solid rgba(255,255,255,0.07)", flexShrink: 0 }}>
                 <button onClick={() => setShowSelector(true)} style={{ width: "100%", padding: "0.7rem", borderRadius: "10px", border: "1px solid rgba(255,255,255,0.12)", background: "rgba(255,255,255,0.07)", color: "rgba(255,255,255,0.85)", fontSize: "0.85rem", fontWeight: 500, cursor: "pointer", fontFamily: "sans-serif" }}
@@ -891,9 +958,6 @@ const Chat = ({ hovered, setHovered, isOpen, onToggle }) => {
     const [hasOpened, setHasOpened] = useState(false);
     const [pendingCountry, setPendingCountry] = useState(null);
     const [unseenCount, setUnseenCount] = useState(0);
-    // Message totals per chat as of the last time the panel was open — the
-    // baseline "seen" state for the unread badge.
-    const seenRef = useRef(null);
     const setChatOpen = () => { onToggle(); };
 
     useEffect(() => {
@@ -910,19 +974,19 @@ const Chat = ({ hovered, setHovered, isOpen, onToggle }) => {
         .then((saved) => {
             if (cancelled || !Array.isArray(saved)) return;
             const open = saved.filter((c) => c.status !== "closed" && Array.isArray(c.countries) && c.countries.length > 0);
-            const totals = new Map(open.map((c) => [String(c.id), c.messages?.length ?? 0]));
-            if (isOpen || seenRef.current === null) {
-                // Panel open (or first look): everything currently there is seen.
-                seenRef.current = totals;
+            // The badge only READS the baseline. The panel writes it when it opens,
+            // and it must be the only writer: if this poll also wrote on isOpen it
+            // could clear the baseline first and the list would find nothing unread.
+            if (isOpen) { setUnseenCount(0); return; }
+            const seen = readSeen();
+            if (seen === null) {
+                // First look ever — seed the baseline instead of declaring every
+                // chat that already existed unread.
+                writeSeen(seenTotals(open));
                 setUnseenCount(0);
                 return;
             }
-            let fresh = 0;
-            for (const [id, count] of totals) {
-                const seen = seenRef.current.get(id);
-                if (seen === undefined || count > seen) fresh += 1;
-            }
-            setUnseenCount(fresh);
+            setUnseenCount(open.filter((c) => isChatUnread(c, seen)).length);
         })
         .catch(() => {});
 

--- a/src/Game/GameUI/communityHub.jsx
+++ b/src/Game/GameUI/communityHub.jsx
@@ -24,6 +24,8 @@ import {
   splitScenarioBundleImage,
 } from "../../runtime/communityBasemaps.js";
 import { unzipBundle, zipBundle } from "../../runtime/bundleZip.js";
+import { sha256Hex } from "../../runtime/basemapLibrary.js";
+import { listFlags } from "../../runtime/flagLibrary.js";
 
 // The one and only hub. Not configurable by design.
 const HUB_OWNER = "Open-Historia";
@@ -32,6 +34,35 @@ const HUB_URL = `https://github.com/${HUB_OWNER}/${HUB_REPO}`;
 const HUB_API_ISSUES = `https://api.github.com/repos/${HUB_OWNER}/${HUB_REPO}/issues?state=open&labels=scenario&per_page=100`;
 const HUB_NEW_POST_URL = `${HUB_URL}/issues/new?template=scenario.yml`;
 const CACHE_TTL_MS = 5 * 60 * 1000;
+
+// How many of a scenario's custom flags are the author's OWN — i.e. worth
+// advertising to the hub. A flag installed from the Community tab is already
+// posted there, and tagging this scenario with it would list the very same flag
+// a second time in the picker's Community tab. Matched by content hash against
+// the local flag library (the same hash the library dedupes on). A flag with no
+// library record — made before provenance shipped, or arrived inside an imported
+// scenario — counts as the author's, so the tag is never wrongly suppressed.
+// This only affects the Flags-Count TAG: the flags still travel inside the
+// bundle exactly as before, so import is unchanged.
+const countPublishableFlags = async (flagsData) => {
+  const values = Object.values(flagsData ?? {}).filter(
+    (value) => typeof value === "string" && value.startsWith("data:"),
+  );
+  if (!values.length) return 0;
+  let communityHashes;
+  try {
+    communityHashes = new Set(
+      (await listFlags())
+        .filter((flag) => flag?.source?.community && flag?.contentHash)
+        .map((flag) => flag.contentHash),
+    );
+  } catch {
+    return values.length; // library unreachable: publish as before rather than under-report
+  }
+  if (!communityHashes.size) return values.length;
+  const hashes = await Promise.all(values.map((value) => sha256Hex(value).catch(() => null)));
+  return hashes.filter((hash) => !hash || !communityHashes.has(hash)).length;
+};
 
 // First GitHub-hosted .json (release asset, attachment or raw) link in an issue
 // body = the bundle. Release links come first in official posts so imports go
@@ -606,8 +637,7 @@ const CommunityPanel = ({ fullPage = false, onImported }) => {
       // count so the flag picker's Community tab surfaces the post as an
       // installable flag pack without downloading every bundle first. Harmless if
       // the scenario form has no such field — GitHub ignores unknown prefills.
-      const customFlagCount = Object.values(bundle.assets?.flags?.data ?? {})
-        .filter((value) => typeof value === "string" && value.startsWith("data:")).length;
+      const customFlagCount = await countPublishableFlags(bundle.assets?.flags?.data);
       const technicalLines = [
         ...(split ? [`Basemap-Hash: ${split.hash}`, `Basemap-Kind: ${split.kind}`] : []),
         ...(customFlagCount > 0 ? [`Flags-Count: ${customFlagCount}`] : []),

--- a/src/runtime/communityBasemaps.js
+++ b/src/runtime/communityBasemaps.js
@@ -9,7 +9,7 @@
 // re-embedding it. Publishing is the token-less flow scenarios use: the app hands
 // the author the real image file and opens a prefilled issue form to drag it into.
 
-import { createBasemap, makeImageThumbnail, makeVectorThumbnail, sha256Hex } from "./basemapLibrary.js";
+import { createBasemap, listBasemaps, makeImageThumbnail, makeVectorThumbnail, sha256Hex } from "./basemapLibrary.js";
 import { unzipBundle, zipBundle } from "./bundleZip.js";
 
 // UTF-8-safe base64 <-> string (the scenario bundle base64-encodes the
@@ -280,6 +280,17 @@ const loadBasemapPayload = async (post) => {
 };
 
 // Install a community basemap into the local "Your basemaps" library.
+// Which file of a hub post actually carries the basemap, and how it must be read
+// back. A data file (an old .basemap.json bundle, or a vector's .geojson) is
+// parsed as JSON; anything else — an inline image, or an .svg GitHub attached as
+// a file — is fetched as a raw image. Shared by install and by publish-time
+// dedupe so a reference written from a local record and one written from a live
+// hub search are byte-identical.
+const payloadRefVia = (post) =>
+  post?.bundleUrl && !IMAGE_EXT_PATTERN.test(post.bundleUrl) ? "dataFile" : "image";
+const payloadRefUrl = (post) =>
+  (payloadRefVia(post) === "dataFile" ? post?.bundleUrl : post?.coverImageUrl || post?.bundleUrl) || null;
+
 export const installCommunityBasemap = async (post) => {
   const { meta, kind, payload } = await loadBasemapPayload(post);
   if ((kind === "image" && !payload.dataUrl) || (kind === "vector" && !payload.geojson)) {
@@ -294,7 +305,18 @@ export const installCommunityBasemap = async (post) => {
     thumbnail: thumbnail || meta.thumbnail || null,
     contentHash: meta.contentHash || post.contentHash || null,
     author: meta.author || post.author,
-    source: { community: true, hash: meta.contentHash || post.contentHash || null, url: post.url },
+    // `url` is the issue permalink (for "view the post"); `payloadUrl` is the file
+    // a later publish can point a communityRef at, resolved the same way a hub
+    // search hit is. Keeping both means dedupeScenarioBundleBackground never has
+    // to guess which one it is holding — an html_url there would resolve to a web
+    // page and the scenario would import with no basemap at all.
+    source: {
+      community: true,
+      hash: meta.contentHash || post.contentHash || null,
+      url: post.url,
+      payloadUrl: payloadRefUrl(post),
+      payloadVia: payloadRefVia(post),
+    },
     payload,
   });
 };
@@ -384,13 +406,36 @@ export const dedupeScenarioBundleBackground = async (bundle) => {
     bg = null;
   }
   if (!bg) return { referenced: false, needsPublish: false };
+
+  // Ask the LOCAL library first. A basemap installed from the Community tab was
+  // saved with source.community + the post's url (installCommunityBasemap), so we
+  // already know it is on the hub without asking GitHub — which matters because
+  // the hub search is the flaky part: offline, rate-limited (403) or simply slow,
+  // it returns nothing and the author would re-upload a basemap that is already
+  // shared. Falls through to the hub search for a basemap that came from anywhere
+  // else (an older install, a scenario import) but happens to match a post.
+  // Requires source.payloadUrl, which only installs from this version on record —
+  // an older install has just the issue permalink, which is not fetchable as a
+  // payload, so it correctly falls through to the hub search below.
+  const local = await listBasemaps().catch(() => []);
+  const installed = local.find(
+    (bm) => bm?.contentHash && bm.contentHash === bg.hash && bm?.source?.community && bm?.source?.payloadUrl,
+  );
+  if (installed) {
+    bundle.assets.backgroundData = {
+      mode: "communityRef",
+      hash: bg.hash,
+      via: installed.source.payloadVia === "dataFile" ? "dataFile" : "image",
+      url: installed.source.payloadUrl,
+      fileName: "background.json",
+    };
+    return { referenced: true, needsPublish: false };
+  }
+
   const match = await findCommunityBasemapByHash(bg.hash);
   if (match) {
-    // A data file (old .basemap.json bundle, or a vector .geojson) is fetched and
-    // parsed as JSON on import; an image link (incl. an .svg attached as a file) or
-    // an inline image is fetched as the raw image.
-    const viaDataFile = Boolean(match.bundleUrl) && !IMAGE_EXT_PATTERN.test(match.bundleUrl);
-    const url = viaDataFile ? match.bundleUrl : match.coverImageUrl || match.bundleUrl;
+    const viaDataFile = payloadRefVia(match) === "dataFile";
+    const url = payloadRefUrl(match);
     if (url) {
       bundle.assets.backgroundData = {
         mode: "communityRef",

--- a/src/runtime/web/flagStore.js
+++ b/src/runtime/web/flagStore.js
@@ -50,6 +50,9 @@ const createFlag = async (body = {}) => {
     author: String(body.author || "").slice(0, 80),
     dataUrl,
     contentHash,
+    // See server/flagStore.js — marks a flag installed from the community hub so
+    // it isn't re-offered to the hub when a scenario using it is published.
+    source: body.source && typeof body.source === "object" ? JSON.parse(JSON.stringify(body.source)) : null,
     createdAt: new Date().toISOString(),
   };
   await idbPut(STORES.flags, flag);


### PR DESCRIPTION
## Chat unread sorting

The chat list had **no sort at all** — `openChats` was a bare `.filter()`, so a country that messaged you stayed exactly where it already was and you had to go hunting for the new message.

- Unread chats lift to the **top**, with a blue dot, a bolder name and a `new` label. Read chats keep their existing relative order (stable partition), so nothing else moves around.
- **Re-sorts only when the panel reopens.** The unread set is snapshotted on open and held until close, so rows can't reshuffle under the cursor mid-read.
- The seen baseline moved out of a `useRef` living inside the toolbar button — the list could never read it, and it reset on every remount — into a persisted `oh:chat-seen` map. The badge and the list now share one source. The panel is the only writer; the toolbar poll only reads, so it can't clear the baseline before the list has looked at it.
- First run (no baseline at all) seeds it rather than declaring every pre-existing chat unread.

## Basemap + flag publishing

Something installed from the Community tab is already on the hub, so a scenario using it shouldn't offer it back as new content.

- Installs record `source.community`. `dedupeScenarioBundleBackground` checks the **local library first**, so a community basemap becomes a `communityRef` without a hub round-trip — the previous path depended on a GitHub search that returns nothing when offline or rate-limited, and the author would silently re-upload.
- `installCommunityBasemap` now also stores the **payload url** next to the issue permalink. Referencing the permalink would have resolved to an HTML page and the scenario would have imported with **no basemap at all**.
- `Flags-Count` counts only the author's own flags, matched by content hash against the flag library. A flag with no record still counts as theirs, so the tag is never wrongly suppressed. Flags still travel inside the bundle — **import is unchanged**.
- Built-in editor basemaps are remote ESRI tile services, never embedded, so they needed no filtering.

## Also, separately

The hub repo had **no `basemap` label** — `basemap.yml` declares `labels: ["basemap"]`, GitHub silently drops labels that don't exist, and `HUB_API_BASEMAPS` queries `labels=basemap`. That's why "Open hub" errored with *invalid value basemap for label*, and it means the community Basemaps tab could never have shown anything. The label has been created on the hub repo (no basemap posts existed yet, so there was nothing to backfill).

## Verification

Rendered the real `ChatPanel` against a fixture through Vite and asserted the DOM: unread chat lifts 3rd → 1st with the dot and label; reopen with a current baseline shows none; no baseline shows none; a chat missing from the baseline is unread; all-unread keeps relative order. Flag provenance round-tripped through the real Express store, and the browser's `sha256Hex` was confirmed to match the server's `contentHash` (same hex) so the lookup key is sound. `countPublishableFlags` verified for community-only (0), own-only (1), mixed (1), empty (0) and unknown-flag (1). Build clean.