### PR TITLE
Drop the unused __dirname from the flag store

### DIFF
--- a/server/flagStore.js
+++ b/server/flagStore.js
@@ -10,11 +10,9 @@
 
 import fs from "fs";
 import path from "path";
-import url from "url";
 import crypto from "crypto";
-
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 import { DATA_DIR } from "./dataDir.js";
+
 const FLAGS_PATH = path.join(DATA_DIR, "flags-library.json");
 
 const readAll = () => {


### PR DESCRIPTION
`server/flagStore.js` declared a `__dirname` that nothing used:

```js
import url from "url";
const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
```

It went dead when the file switched to `import { DATA_DIR } from "./dataDir.js"`, and the `url` import existed only to build it — so both go.

Verified before removing: `__dirname` appears exactly once in the file (its own declaration), and the identifier `url` appears only on those two lines. Nothing else in the file references either.

**Alpha needs no change** — it already has this exact shape, so alpha was skipped rather than given an empty PR. After this, the import block on all three channels matches byte for byte.

Split out of #607/#608/#609 deliberately, to keep that change focused on the chat-unread and hub-provenance work. Different hunk of the same file, so the two merge independently.

Verified by round-tripping the patched module: create → list → delete against a temp `OH_DATA_DIR`, with the content hash unchanged from before the edit.