### PR TITLE
Stop the hub proxy from serving attacker HTML on our own origin

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -570,6 +570,20 @@ const HUB_DOWNLOAD_HOSTS = new Set([
 ]);
 const HUB_MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
 
+// This route echoes a file that ANY member of the public can attach to a hub
+// issue, and it serves it from the game's OWN origin. Without these two headers a
+// crafted post could be an .html (or a scripted .svg) and a link to
+// /api/hub/file?url=... would execute it as same-origin script -- with reach into
+// localStorage (the player's AI keys) and every /api/* route. nosniff stops the
+// browser inferring a dangerous type; the attachment disposition stops it
+// rendering one it was told about. Every real consumer reads this route with
+// fetch(), which ignores both headers, so nothing legitimate changes.
+const setHubFileGuards = (res) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Content-Disposition", "attachment");
+  res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
+};
+
 // Browser AI calls to self-hosted OpenAI-compatible endpoints (llama.cpp,
 // LM Studio, NVIDIA NIM...) die on CORS — those servers rarely send the
 // headers. The game server relays them instead: same-origin for the browser,
@@ -643,6 +657,7 @@ app.get("/api/hub/file", async (req, res) => {
       let cachedType = "application/octet-stream";
       try { cachedType = fs.readFileSync(cache.type, "utf8") || cachedType; } catch { /* default */ }
       res.setHeader("Cache-Control", "no-store");
+      setHubFileGuards(res);
       res.setHeader("Content-Type", cachedType);
       return fs.createReadStream(cache.body).pipe(res);
     }
@@ -688,6 +703,7 @@ app.get("/api/hub/file", async (req, res) => {
     }
 
     res.setHeader("Cache-Control", "no-store");
+    setHubFileGuards(res);
     // Pass the upstream content type through untouched. JSON bundles still parse
     // via response.json() (which ignores the header), while binary bundles (.zip)
     // and raw basemap images (.png/.jpg) arrive byte-for-byte.


### PR DESCRIPTION
## The hole

`/api/hub/file` echoes a file that **anyone** can attach to a public issue on the community hub, and serves it **from the game's own origin** with the upstream `Content-Type` passed through untouched — no `nosniff`, no disposition, no CSP.

So a crafted hub post can be an `.html` file (or an `.svg` with a script in it), and a link to `/api/hub/file?url=<that file>` renders it as **same-origin script**. From there it reaches `localStorage` — where the player's AI provider keys live — and every `/api/*` route behind it: saved games, scenarios, the AI relay.

Importing never triggered this. Every real consumer reads the route with `fetch()`, which treats the bytes as data, so it needed a lure to be exploited. That's a mitigation, not a fix — the route shouldn't be capable of it.

Worst on the **desktop / self-hosted** build, where the proxy is same-origin with the game. On the website the proxy lives on the Worker origin instead, so the blast radius is smaller.

## The fix

`nosniff` + `Content-Disposition: attachment` + `default-src 'none'; sandbox`, on **both** the fresh and the cached branch (the cached branch returns early, so it needed its own call). `fetch()` ignores all three, so no legitimate path changes.

## What I checked around it, and found clean

- No `eval`, `new Function`, `innerHTML` or `dangerouslySetInnerHTML` anywhere in the import path.
- **SSRF** already properly defended: host allowlist, redirects followed manually with every hop re-checked, hop cap, size cap. Re-verified — a request for `169.254.169.254` is rejected 400.
- **Zip-slip**: bundles are read in memory via JSZip by explicit entry name, never directory-walked onto disk.
- **Path traversal**: scenario ids go through `resolveWithinDirectory` containment plus slugging.
- **SVG**: basemaps and flags are only ever rendered through `<img src>`, where scripts don't execute.
- Community bundles carry no prompt overrides.

## Verification

Booted the server and hit the route with a real allowlisted URL: all three headers present on the fresh request and again on the cached one, body still intact byte-for-byte so imports are unaffected, and the link-local metadata probe still 400s.