### PR TITLE
Make deleting a chat hide it rather than erase it, and stop turns reviving it

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1468,6 +1468,11 @@ const applySimulationResult = async ({
     status: action.status === "planned" && result.clearActions ? "resolved" : action.status,
   }));
   const nextChats = [...normalizeChats(baseChats)];
+  // Chats this turn CREATED, kept apart from the pre-turn snapshot. A turn takes a
+  // while to generate and the player can edit the chat list while it runs, so the
+  // write at the end merges these onto whatever is actually stored by then rather
+  // than putting the stale snapshot back. See the re-read before writeChatsState.
+  const generatedChats = [];
 
   const { colors: nextColors, world: worldWithImpacts } = applyEventImpactsToWorld({
     colors: baseColors,
@@ -1505,7 +1510,7 @@ const applySimulationResult = async ({
         fallbackTitle: event.title,
         playerName: baseGame.country,
       });
-      if (nextChat) nextChats.unshift(nextChat);
+      if (nextChat) { nextChats.unshift(nextChat); generatedChats.unshift(nextChat); }
     }
   }
 
@@ -1516,7 +1521,7 @@ const applySimulationResult = async ({
     const nextChat = await buildGeneratedChat({ ...chatLike, source: "outreach" }, "", worldWithImpacts, {
       playerName: baseGame.country,
     });
-    if (nextChat) nextChats.unshift(nextChat);
+    if (nextChat) { nextChats.unshift(nextChat); generatedChats.unshift(nextChat); }
   }
 
   if (result.mode === "jump" || result.mode === "auto") {
@@ -1533,9 +1538,22 @@ const applySimulationResult = async ({
     }
   }
 
+  // Re-read the chat list instead of writing the pre-turn snapshot back over it.
+  // Turns take a while, and anything the player did to the list while one ran —
+  // deleting a thread, archiving one — exists only in storage. Writing baseChats
+  // on top resurrected deleted chats, and the AI's next message then landed in the
+  // revived thread instead of opening a fresh one. Falls back to the snapshot if
+  // the read fails, which is the old behaviour and never loses a generated chat.
+  let chatsToWrite;
+  try {
+    chatsToWrite = [...generatedChats, ...normalizeChats(await readChatsState({ force: true }))];
+  } catch {
+    chatsToWrite = nextChats;
+  }
+
   await Promise.all([
     writeActionsState(nextActions),
-    writeChatsState(nextChats),
+    writeChatsState(chatsToWrite),
     writeEventsState(nextEvents),
     writeGameData(nextGame),
     writeJson(JSON_URLS.colors, nextColors, { pretty: true }),
@@ -1564,7 +1582,7 @@ const applySimulationResult = async ({
 
   return {
     actions: nextActions,
-    chats: nextChats,
+    chats: chatsToWrite, // what was actually persisted, not the pre-turn snapshot
     colors: nextColors,
     events: nextEvents,
     game: nextGame,

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -152,12 +152,23 @@ const BackIcon = () => (
     </svg>
 );
 
-const GearIcon = () => (
-    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="12" r="3"/>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+// Drawn rather than typed, like every other icon here. The list row used the
+// U+1F5D1 emoji, which has no colour glyph in Windows' default UI font and falls
+// back to a monochrome symbol face; an inline SVG renders the same everywhere and
+// matches the stroke weight of its neighbours.
+const TrashIcon = () => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+    <path d="M3 6h18" />
+    <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    <path d="M10 11v6M14 11v6" />
     </svg>
 );
+
+
+
+
 
 // ── Message bubble ────────────────────────────────────────────────────────────
 
@@ -405,7 +416,10 @@ const CountrySelectorModal = ({ countries, loading, onStart, onCancel }) => {
 
 // ── Conversation view ─────────────────────────────────────────────────────────
 
-const ConversationView = ({ chat, playerCountry, gameDate, onArchive, onBack, onMessagesUpdate }) => {
+const ConversationView = ({ chat, playerCountry, gameDate, onDelete, onBack, onMessagesUpdate }) => {
+    // Two-step delete, matching the list row. Disarms on blur so a half-pressed
+    // delete never sits waiting to catch a later click.
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
     const countries = useMemo(
         () => Array.isArray(chat?.countries)
             ? chat.countries.filter((country) => country && (country.name || country.code))
@@ -586,10 +600,15 @@ const ConversationView = ({ chat, playerCountry, gameDate, onArchive, onBack, on
             <span style={{ flex: 1, fontWeight: 700, fontSize: "0.95rem", color: "white", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             Chat with {countries.map(c => c.name).join(", ") || "unknown participant"}
             </span>
-            <button title="Archive chat" onClick={onArchive} style={{ background: "none", border: "none", cursor: "pointer", color: "rgba(255,255,255,0.45)", display: "flex", padding: "0.25rem", borderRadius: "6px" }}
-            onMouseEnter={e => { e.currentTarget.style.color = "white"; e.currentTarget.style.background = "rgba(255,255,255,0.08)"; }}
-            onMouseLeave={e => { e.currentTarget.style.color = "rgba(255,255,255,0.45)"; e.currentTarget.style.background = "none"; }}>
-            <GearIcon />
+            {/* Two-step, same as the list row: one click arms, the next confirms. */}
+            <button title={confirmingDelete ? "Click again to delete this chat" : "Delete chat"}
+            aria-label={confirmingDelete ? "Confirm deleting this chat" : "Delete chat"}
+            onClick={() => { if (confirmingDelete) { onDelete?.(); } else { setConfirmingDelete(true); } }}
+            onBlur={() => setConfirmingDelete(false)}
+            style={{ display: "flex", alignItems: "center", gap: "0.3rem", background: confirmingDelete ? "rgba(239,68,68,0.18)" : "none", border: `1px solid ${confirmingDelete ? "rgba(239,68,68,0.55)" : "transparent"}`, cursor: "pointer", color: confirmingDelete ? "#fca5a5" : "rgba(239,68,68,0.65)", fontSize: "0.72rem", fontWeight: 600, fontFamily: "sans-serif", padding: confirmingDelete ? "0.25rem 0.5rem" : "0.25rem", borderRadius: "6px", lineHeight: 1 }}
+            onMouseEnter={e => { if (!confirmingDelete) { e.currentTarget.style.color = "rgba(239,68,68,1)"; e.currentTarget.style.background = "rgba(239,68,68,0.1)"; } }}
+            onMouseLeave={e => { if (!confirmingDelete) { e.currentTarget.style.color = "rgba(239,68,68,0.65)"; e.currentTarget.style.background = "none"; } }}>
+            {confirmingDelete ? "Delete?" : <TrashIcon />}
             </button>
             <button onClick={onBack} style={{ background: "none", border: "none", cursor: "pointer", color: "rgba(255,255,255,0.45)", fontSize: "1rem", lineHeight: 1, padding: "0.25rem 0.3rem", borderRadius: "6px" }}
             onMouseEnter={e => { e.currentTarget.style.color = "white"; e.currentTarget.style.background = "rgba(255,255,255,0.08)"; }}
@@ -701,6 +720,10 @@ const isChatUnread = (chat, seen) => {
 
 const ChatListItem = ({ chat, onClick, onDelete, unread = false }) => {
     const [hovered, setHovered] = React.useState(false);
+    // Deleting a chat is not undoable, so the bin arms first and deletes on the
+    // second click. Resets whenever the pointer leaves the row, so a half-pressed
+    // delete never sits waiting to catch a later click.
+    const [confirming, setConfirming] = React.useState(false);
     const previewCountries = chat.countries.slice(0, 4);
     const flagMap  = useCountryFlags(previewCountries);
     const flags    = previewCountries.map(c => flagMap[c.name] ?? "🏳").join(" ");
@@ -709,7 +732,7 @@ const ChatListItem = ({ chat, onClick, onDelete, unread = false }) => {
     const preview  = lastMsg ? lastMsg.text.replace(/\*\*/g, "").slice(0, 60) + (lastMsg.text.length > 60 ? "…" : "") : "No messages yet";
 
     return (
-        <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)} style={{ position: "relative" }}>
+        <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => { setHovered(false); setConfirming(false); }} style={{ position: "relative" }}>
         <button onClick={onClick} style={{ width: "100%", padding: "0.7rem 0.9rem", borderRadius: "10px", border: "1px solid rgba(255,255,255,0.07)", background: hovered ? "rgba(255,255,255,0.07)" : "rgba(255,255,255,0.03)", display: "flex", alignItems: "center", gap: "0.75rem", cursor: "pointer", transition: "background 0.15s", fontFamily: "sans-serif", textAlign: "left" }}>
         {/* Fixed-width slot, always rendered, so read and unread rows stay aligned. */}
         <div style={{ width: "0.5rem", flexShrink: 0, display: "flex", justifyContent: "center" }} aria-hidden="true">
@@ -722,10 +745,13 @@ const ChatListItem = ({ chat, onClick, onDelete, unread = false }) => {
         </div>
         </button>
         {hovered && (
-            <button onClick={e => { e.stopPropagation(); onDelete(); }}
-            style={{ position: "absolute", top: "50%", right: "0.6rem", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", color: "rgba(239,68,68,0.7)", fontSize: "0.9rem", padding: "0.2rem", borderRadius: "6px", lineHeight: 1 }}
-            onMouseEnter={e => { e.currentTarget.style.color = "rgba(239,68,68,1)"; e.currentTarget.style.background = "rgba(239,68,68,0.1)"; }}
-            onMouseLeave={e => { e.currentTarget.style.color = "rgba(239,68,68,0.7)"; e.currentTarget.style.background = "none"; }}>🗑</button>
+            <button onClick={e => { e.stopPropagation(); if (confirming) { onDelete(); } else { setConfirming(true); } }}
+            title={confirming ? "Click again to delete this chat" : "Delete chat"}
+            aria-label={confirming ? "Confirm deleting this chat" : "Delete chat"}
+            style={{ position: "absolute", top: "50%", right: "0.6rem", transform: "translateY(-50%)", display: "flex", alignItems: "center", gap: "0.3rem", background: confirming ? "rgba(239,68,68,0.18)" : "none", border: `1px solid ${confirming ? "rgba(239,68,68,0.55)" : "transparent"}`, cursor: "pointer", color: confirming ? "#fca5a5" : "rgba(239,68,68,0.7)", fontSize: "0.72rem", fontWeight: 600, fontFamily: "sans-serif", padding: confirming ? "0.25rem 0.5rem" : "0.25rem", borderRadius: "6px", lineHeight: 1 }}
+            onMouseEnter={e => { if (!confirming) { e.currentTarget.style.color = "rgba(239,68,68,1)"; e.currentTarget.style.background = "rgba(239,68,68,0.1)"; } }}
+            onMouseLeave={e => { if (!confirming) { e.currentTarget.style.color = "rgba(239,68,68,0.7)"; e.currentTarget.style.background = "none"; } }}>
+            {confirming ? "Delete?" : <TrashIcon />}</button>
         )}
         </div>
     );
@@ -878,18 +904,23 @@ const ChatPanel = ({ isOpen, onClose, requestedCountry, onConsumeRequest }) => {
         setActiveChat(newChat);
     };
 
+    // Deleting hides the thread from the player; it does NOT erase it. gameplay.js
+    // feeds closed chats back to the model as concluded-negotiation history, so
+    // dropping the record outright would make the AI act as though the talks never
+    // happened. Closing also means the next approach from that country opens a
+    // FRESH chat instead of reviving this one — closed chats are excluded from the
+    // "already talking to them" lookup.
+    //
+    // This is what the old Archive button did, so there is no separate archive
+    // control any more: two buttons that both close a chat only invited the
+    // question of which one really deleted it.
     const handleDeleteChat = (id) => {
-        setChats(prev => { const u = prev.filter(c => c.id !== id); saveAllChats(u); return u; });
-        if (activeChat?.id === id) setActiveChat(null);
-    };
-
-    const handleArchiveChat = (id) => {
         setChats(prev => {
             const updated = prev.map(chat => chat.id === id ? { ...chat, status: "closed" } : chat);
             saveAllChats(updated);
             return updated;
         });
-        setActiveChat(null);
+        if (activeChat?.id === id) setActiveChat(null);
     };
 
     // Open (or reuse) a 1-on-1 chat with a country requested from the region popup.
@@ -924,7 +955,7 @@ const ChatPanel = ({ isOpen, onClose, requestedCountry, onConsumeRequest }) => {
             {showSelector && <CountrySelectorModal countries={availableCountries} loading={loadingCountries} onStart={handleStartChat} onCancel={() => setShowSelector(false)} />}
 
             {activeChat && Array.isArray(activeChat.countries) && activeChat.countries.length > 0 ? (
-                <ConversationView chat={activeChat} playerCountry={playerCountry} gameDate={gameDate} onArchive={() => handleArchiveChat(activeChat.id)} onBack={() => setActiveChat(null)} onMessagesUpdate={handleMessagesUpdate} />
+                <ConversationView chat={activeChat} playerCountry={playerCountry} gameDate={gameDate} onDelete={() => handleDeleteChat(activeChat.id)} onBack={() => setActiveChat(null)} onMessagesUpdate={handleMessagesUpdate} />
             ) : (
                 <>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "1rem 1.25rem 0.75rem", borderBottom: "1px solid rgba(255,255,255,0.07)", flexShrink: 0 }}>


### PR DESCRIPTION
Three fixes to the same button, plus the turn-side bug behind it.

## The gear
The control in an open chat was a **`GearIcon`** — that is why it read as settings rather than delete. It is a bin now. The list row's bin was the `U+1F5D1` emoji, which has no colour glyph in Windows' default UI font and falls back to a monochrome symbol face; both are drawn SVGs now, matching every other icon in the panel.

## Confirmation
Two-step in both places: one click arms, the next confirms. It disarms when the pointer leaves the row (or the button blurs), so a half-pressed delete never sits waiting to catch a later click. Nothing is written on the first click.

## Delete keeps the history
Deleting now **closes** the chat instead of dropping it from storage. `gameplay.js` feeds closed chats back to the model as concluded-negotiation history, so erasing the record made the AI behave as though the talks never happened. Closed chats are also excluded from the "already talking to them" lookup, so the next approach from that country opens a **fresh** thread rather than reviving the old one.

That is exactly what the **Archive** button did, so there is no separate archive control any more — two buttons that both closed a chat only invited the question of which one really deleted it.

`normalizeChatEntry` is a fixed whitelist, so a new `deleted` field would have been silently dropped on the next read; `status` already carries this, which is why it is reused rather than adding a flag.

## The turn was reviving deleted chats
`applySimulationResult` wrote its **pre-turn** chat snapshot (`baseChats`, from the bundle read at turn start) back over storage at the end. Turns take a while to generate, so a chat deleted while one ran came straight back, and the AI's next message landed in the revived thread. Chats a turn creates are now tracked separately and merged onto a fresh read at write time, falling back to the old behaviour if that read fails.

## Verification
Rendered the real `ChatPanel` through Vite and drove it, asserting on the DOM and on the bytes it tried to persist:

- open chat has no archive control, and its delete button is an SVG (4 paths), not a glyph
- first click → `Delete?`, still in the conversation, **nothing persisted**
- second click → back to the list, one row left
- the persisted array still has **both** entries — `chat-a:closed`, `chat-b:open` — so the thread survives as history
- same two-step verified on the list row, including disarm-on-leave

Built from **upstream's** `gameplay.js`, not the local copy, which is stale and would have reverted `ACTIONS_REFERENCE`, `[Polity Names]` and `wholeCountry`.