### PR TITLE
Validate the language code inside readLangPack, not just at its callers

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -183,7 +183,14 @@ const shippedLangDir = fs.existsSync(path.join(distDir, "lang"))
   : path.join(__dirname, "../public/lang");
 const savedLangDir = path.join(DATA_DIR, "lang");
 
+const isLangCode = (code) => /^[a-z]{2,3}$/.test(code);
+
 const readLangPack = (dir, code) => {
+  // `code` arrives from the :code route param and is interpolated into a
+  // filename below. The route handlers check it too, but this is the function
+  // that actually touches the path, so it rejects anything that is not a bare
+  // language code rather than trusting every future caller to have done so.
+  if (!isLangCode(code)) return {};
   try {
     const parsed = JSON.parse(fs.readFileSync(path.join(dir, `${code}.json`), "utf8"));
     return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
@@ -191,8 +198,6 @@ const readLangPack = (dir, code) => {
     return {};
   }
 };
-
-const isLangCode = (code) => /^[a-z]{2,3}$/.test(code);
 
 app.get("/api/lang/:code", (req, res) => {
   const code = String(req.params.code || "").toLowerCase();


### PR DESCRIPTION
The one worthwhile change from #616, on its own.

`readLangPack` interpolates `code` straight into a filename:

```js
JSON.parse(fs.readFileSync(path.join(dir, `${code}.json`), "utf8"))
```

`code` originates from the `:code` route param. **Both** routes that call it already reject anything that isn't a bare language code before calling, so this is **defence in depth, not a live hole** — I'd rather say that than overstate it. But the function that actually touches the path shouldn't rely on every future caller remembering to check, and it's one line.

`isLangCode` moves above `readLangPack` so it is declared before use — adding the guard without moving it would have introduced a use-before-declaration that didn't exist before.

## Why not just merge #616

That PR bundles this with six unrelated changes, one of which is breaking:

- **`largeJsonParser` 2048mb → 10mb** would 413 every map-editor save. Documents in this repo run **50–80 MB** (`modern-day-6.json` is 81 MB) and go through that parser at `/api/mapeditor/documents`.
- `jsonParser` 64mb → 1mb sits on `/api/runtime/json/:assetKey`, the route every world/events/chats write uses.
- `path.join` → `path.format` doesn't sanitise anything; three of the four sites are keyed by sha256 hex and were never attacker-controlled.
- Forcing `application/octet-stream` on `/api/hub/file` breaks client mime derivation (`communityBasemaps.js:96-98`) for non-PNG basemaps and flags, and duplicates the `nosniff` + `Content-Disposition` + CSP already shipped in #613.

Credit to @anupamme for spotting this one.

## Verification

Booted the patched server on a spare port with a scratch `OH_DATA_DIR`:

- `/api/lang/es` → **200**, 20,946 bytes of real translations — the normal path is unchanged
- `../../package`, `en/../../../package` → 404; `..%2F..%2Fpackage`, `toolong` → 400
- `EN` → 200 (the handler lowercases before checking, as before)