### PR TITLE
Stop a malformed PUT from erasing a game's event log

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -2319,6 +2319,24 @@ const writeRuntimeJsonAsset = (assetKey, value) => {
     throw new Error(`Unsupported JSON asset key: ${assetKey}`);
   }
 
+  // Shape guard. The storage assets are arrays and everything else is an object.
+  // The SEED path already enforces this (normalizeBaseSaveSeedAsset), but this
+  // runtime path did not — so a PUT whose body never parsed, which express.json()
+  // hands us as {}, could overwrite a game's entire event log with {}. That is not
+  // hypothetical: a game in the wild has `storage/events.json` containing `{ }`,
+  // and because normalizeEvents({}) yields [] the events list then reads empty
+  // forever, which looks exactly like "my game saved nothing". Refusing is safe —
+  // writeJson throws on a non-ok response, so the caller sees a real failure
+  // instead of silently corrupting a save.
+  const expectsArray = assetKey in STORAGE_JSON_ASSET_FILES || assetKey in RUNTIME_ONLY_JSON_ASSET_FILES;
+  const shapeOk = expectsArray
+    ? Array.isArray(value)
+    : Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  if (!shapeOk) {
+    const got = value === null ? "null" : Array.isArray(value) ? "an array" : typeof value;
+    throw new Error(`Refusing to write ${assetKey}: expected ${expectsArray ? "an array" : "an object"}, received ${got}.`);
+  }
+
   let activeGameId = getActiveGameId();
   if (!activeGameId) {
     // With every game deleted, the map still renders (reads fall back to the

--- a/server/server.js
+++ b/server/server.js
@@ -530,7 +530,14 @@ app.get("/api/runtime/json/:assetKey", (req, res) => {
 
 app.put("/api/runtime/json/:assetKey", jsonParser, (req, res) => {
   try {
-    const asset = writeRuntimeJsonAsset(req.params.assetKey, req.body ?? {});
+    // express.json() hands us {} when the body was absent or unparseable, which is
+    // indistinguishable from a genuine {} — and for an object-shaped asset like
+    // world or game, writing that blanks the save. A real PUT always carries a
+    // body, so require one rather than letting `?? {}` erase a game.
+    if (!Number(req.headers["content-length"])) {
+      return sendError(res, 400, new Error(`Refusing to write ${req.params.assetKey}: the request had no body.`));
+    }
+    const asset = writeRuntimeJsonAsset(req.params.assetKey, req.body);
     res.setHeader("Cache-Control", "no-store");
     res.type("application/json");
     res.send(JSON.stringify(asset.data));


### PR DESCRIPTION
## The bug, reproduced

A game on my machine has `storage/events.json` containing **`{ }`** — an object where the array belongs. `normalizeEvents({})` yields `[]`, so the cheats Events tab (and anything else reading the log) shows nothing from then on, permanently. That is exactly the "no events, like the context isn't being saved" report.

Reproduced against an **unpatched** server, with a throwaway data dir:

```
seed:   HTTP 200   [{"id":"e1","title":"Real event", …}]
PUT {}: HTTP 200   <-- accepted
after:  {}
on disk: {}
```

The event log is gone, and the write that destroyed it reported success.

## Two holes, both on the runtime write path

- **`writeRuntimeJsonAsset` wrote whatever it was handed.** Storage assets (`actions`, `advisor`, `chat`, `events`, `snapshots`) are arrays; the rest are objects. The **seed** path already enforces precisely this via `normalizeBaseSaveSeedAsset` — the runtime path simply never did. It now refuses a mismatched shape rather than persisting it. Refusing is the safe direction: `writeJson` throws on a non-ok response, so the caller gets a real failure instead of a silently corrupted save.
- **The route passed `req.body ?? {}`.** `express.json()` hands a route `{}` when the body was absent or unparseable, which is indistinguishable from a genuine `{}` — and for an object-shaped asset like `world` or `game`, writing that blanks the save. A real PUT always carries a body, so one is now required.

## Verification

Patched server, throwaway data dir, real game:

| write | result |
|---|---|
| `PUT {}` → events (the real corruption) | **400**, log intact |
| `PUT {"a":1}` → events | 400, log intact |
| `PUT null` → events | 400, log intact |
| `PUT` with no body → events | 400, log intact |
| `PUT [ …valid… ]` → events | **200**, log updated |
| `PUT {}` → colors (legit object reset) | **200** |
| `PUT []` → colors (wrong shape) | 400 |

Error surfaced to the caller: `Refusing to write events: expected an array, received object.`

## Scope

This is the mechanism behind report 1 (cheats shows no events). It does **not** explain the other two reports — the map not following region changes, and the date staying at the start. I could not pin those by reading: the date already defaults to `targetDate` when the model omits `stopDate`, and fallback turns are surfaced to the player via `fallbackReason`. Those need a live reproduction rather than a guessed fix.