### PR TITLE
Stop re-sending the entire resolved-action history on every turn

### DIFF
--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -139,20 +139,44 @@ export const buildAdvisorHistoryText = (messages, { limit = 18 } = {}) => {
     : "No advisor messages are currently recorded.";
 };
 
-export const buildActionHistoryText = (actions, { includeResolved = false } = {}) => {
-  const normalizedActions = normalizeActions(actions);
-  const filteredActions = includeResolved
-    ? normalizedActions
-    : normalizedActions.filter((action) => action.status === "planned");
-  if (filteredActions.length === 0) {
-    return includeResolved ? "No actions have been recorded yet." : "No planned actions are currently queued.";
-  }
+// Resolved actions accumulate for the whole campaign, and every one of them used
+// to be re-sent on every turn. On a long save that is the bulk of the prompt — a
+// player measured 700k of their 803k characters as nothing but old resolved
+// actions — and because this history is interpolated into the prompt more than
+// once, it was pasted in repeatedly. Events were always capped (eventLimit /
+// longEventLimit); actions simply never were. Matching longEventLimit here.
+export const ACTION_HISTORY_LIMIT = 24;
 
-  return filteredActions.map((action) => {
+export const buildActionHistoryText = (actions, { includeResolved = false, limit = ACTION_HISTORY_LIMIT } = {}) => {
+  const normalizedActions = normalizeActions(actions);
+  const renderAction = (action) => {
     const kindLabel = action.kind === "chat" ? "chat" : "action";
     const statusLabel = action.status !== "planned" ? ` [${action.status}]` : "";
     return `- (${kindLabel}) ${action.title}${statusLabel}: ${buildActionDisplayText(action)}`;
-  }).join("\n");
+  };
+
+  if (!includeResolved) {
+    const planned = normalizedActions.filter((action) => action.status === "planned");
+    if (planned.length === 0) return "No planned actions are currently queued.";
+    return planned.map(renderAction).join("\n");
+  }
+
+  if (normalizedActions.length === 0) return "No actions have been recorded yet.";
+
+  // Every PLANNED action survives — those are live orders the model must act on —
+  // while only the most recent `limit` finished ones are quoted. The number of
+  // dropped entries is stated so the model knows the campaign runs deeper than
+  // the excerpt, rather than reading it as a short history.
+  const past = normalizedActions.filter((action) => action.status !== "planned");
+  const kept = new Set(limit > 0 ? past.slice(-limit) : []);
+  const omitted = past.length - kept.size;
+  const lines = normalizedActions
+    .filter((action) => action.status === "planned" || kept.has(action))
+    .map(renderAction);
+  if (omitted > 0) {
+    lines.unshift(`- (${omitted} earlier resolved action${omitted === 1 ? "" : "s"} omitted from this excerpt)`);
+  }
+  return lines.join("\n");
 };
 
 export const formatActionsForPrompt = (actions) => normalizeArray(actions)


### PR DESCRIPTION
Fixes the problem reported on Reddit: a long campaign's prompt was ~803k characters, of which ~700k was nothing but old resolved player actions being re-sent every single turn — about 200k tokens per request, enough to blow through Gemini's free-tier limit.

## Cause

`buildActionHistoryText(actions, { includeResolved: true })` returned **every action the campaign had ever produced**, with no bound. That string reaches the model through `PLAYER_EVERY_ACTION` and `PLAYER_EVERY_ACTION_NOT_PREVIOUS` — **five uses across the prompt bodies** — so a long save pasted its entire order log into the request several times over.

The giveaway is the asymmetry: event history has always been capped (`eventLimit = 10`, `longEventLimit = 24`). Actions never were. There's nothing about actions that justifies the difference — it looks like a plain oversight.

## Change

- Every **planned** action is kept in full. Those are live orders the model has to act on, and there are only ever a handful.
- Only the most recent **24** resolved actions are quoted (matching `longEventLimit`).
- The number of dropped entries is stated —  `- (776 earlier resolved actions omitted from this excerpt)` — so the model knows the campaign runs deeper than the excerpt instead of reading it as a short history.

Saves are untouched. This only changes what the prompt quotes, so nothing is lost and existing games benefit immediately.

## Measured

Simulated an 800-resolved + 3-planned campaign against the real module in a browser:

| | |
|---|---|
| before | **46,587** chars |
| after | **1,600** chars |
| reduction | **97%** |
| planned orders kept | all 3 |
| newest resolved kept | yes |
| oldest resolved dropped | yes |
| omission notice | `- (776 earlier resolved actions omitted from this excerpt)` |

Regression checks: the planned-only path is byte-identical, the empty case still returns "No actions have been recorded yet.", and a short campaign gets no omission notice.

The reporter's own numbers (803k → 124k, ~85%) line up with this.

Credit to the Reddit poster for diagnosing it precisely enough to point straight at the section.