### PR TITLE
Consolidate old player orders instead of just dropping them

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -439,6 +439,17 @@ const runJsonTask = async (taskKey, {
     systemPrompt = `${systemPrompt}\n\n[Place Renaming]\nYou may rename places when the story warrants it (a city renamed after a leader or ideology, a capital re-designated, a colonial name replaced, a conquered city given the conqueror's name). Emit an impacts.markerOps entry {"op":"rename","name":"<current name>","newName":"<new name>","note":"<why>"}. This works on structures you built AND on existing map cities. Do it sparingly and only when a real event motivates it.`;
   }
 
+  // The consolidator's summary REPLACES what it covers, so anything it leaves out
+  // is gone from the campaign for good. Existing games carry frozen prompts, so
+  // both the instruction and the order list have to arrive at call time.
+  if (taskKey === "eventConsolidator") {
+    systemPrompt = `${systemPrompt}\n\n[Durable Canon]\nThis summary REPLACES the material it covers: once consolidated, those events, conversations and player orders are never sent to the simulation again, so whatever you omit is lost permanently. Carry forward explicitly, as standing facts rather than narration:\n1. How this world has DIVERGED from real history — states that never formed, wars that never happened, rulers who never fell, borders that never moved. Name them. A later model that sees only a gap fills it from real history and invents powers this campaign does not contain.\n2. The lasting CONSEQUENCES of the player's own orders, not the orders themselves.\n3. Commitments still in force: treaties, alliances, occupations, debts, standing grievances.\nBrevity matters, but never at the cost of a divergence or a commitment that is still true.`;
+    const resolvedOrders = normalizeString(variables?.actionsToConsolidate);
+    if (resolvedOrders && !resolvedOrders.startsWith("No ")) {
+      systemPrompt = `${systemPrompt}\n\n[Player Orders Being Consolidated]\nThese are the player's own resolved orders for the period covered by this summary. Record what they CHANGED about the world; the order text itself is being discarded.\n${resolvedOrders}`;
+    }
+  }
+
   // Reputation context: how the world currently regards the player, and how the
   // model should let it bias behaviour and evolve it via polityChanges.
   // Territory is owned by REGIONS, but the model kept naming CITIES in regionTransfers
@@ -605,8 +616,18 @@ const CONSOLIDATION_RETAIN_EVENTS = 24;
 const CONSOLIDATION_SIZE_THRESHOLD = 48;
 const CONSOLIDATION_BATCH_SIZE = 60;
 
-const consolidateHistoryBatch = async (bundle, events, chats) => {
+const consolidateHistoryBatch = async (bundle, events, chats, actions = []) => {
   const variables = await buildTemplateVariables(bundle, {
+    // Resolved orders are consolidated alongside the events they caused. Capping
+    // the history that gets SENT each turn is not enough on its own: drop the old
+    // orders without recording what they did and the model loses the campaign's
+    // divergences from real history, then refills the gap from real history. A
+    // player hit exactly that — a 1920s Europe with no WW1 and a surviving Tsar
+    // started growing a Soviet Union that never existed.
+    actionsToConsolidate: buildActionHistoryText(actions, {
+      includeResolved: true,
+      limit: actions.length || 1,
+    }),
     chatsToConsolidate: buildDetailedChatHistoryText(chats, { limit: chats.length || 1, messageLimit: 100 }),
     eventsToConsolidate: buildEventHistoryText(events, { limit: events.length || 1 }),
   });
@@ -615,6 +636,7 @@ const consolidateHistoryBatch = async (bundle, events, chats) => {
       summary: [
         events.map((event) => `${event.date || "undated"} ${event.title}: ${event.description}`).join("; "),
         buildChatSummaryText(chats, { limit: chats.length || 1 }),
+        actions.length ? `Player orders resolved: ${actions.map((action) => action.title).join("; ")}` : "",
       ].filter(Boolean).join("\n"),
     }),
     timeoutMs: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 60000 : 0,
@@ -640,7 +662,20 @@ const compactHistoryIfNeeded = async (bundle) => {
 
   if (eventsToConsolidate.length === 0 && closedChats.length === 0) return world;
 
-  const { generation, summary } = await consolidateHistoryBatch(bundle, eventsToConsolidate, closedChats);
+  // Ride along with a consolidation that is happening anyway — no extra AI call,
+  // which matters when the point of the exercise is to shrink cost. Orders already
+  // folded into an earlier summary are skipped.
+  const priorActionIds = new Set(world.consolidatedHistory.flatMap((entry) => entry.actionIds));
+  const actionsToConsolidate = normalizeActions(bundle.actions)
+    .filter((action) => action.status !== "planned" && action.id && !priorActionIds.has(action.id))
+    .slice(0, CONSOLIDATION_BATCH_SIZE);
+
+  const { generation, summary } = await consolidateHistoryBatch(
+    bundle,
+    eventsToConsolidate,
+    closedChats,
+    actionsToConsolidate,
+  );
   if (!summary) return world;
   const throughEvent = eventsToConsolidate.at(-1);
 
@@ -649,6 +684,7 @@ const compactHistoryIfNeeded = async (bundle) => {
     consolidatedHistory: [
       ...world.consolidatedHistory,
       {
+        actionIds: actionsToConsolidate.map((action) => action.id),
         chatIds: closedChats.map((chat) => chat.id),
         createdAt: new Date().toISOString(),
         source: generation.source,

--- a/src/Game/AI/promptContext.js
+++ b/src/Game/AI/promptContext.js
@@ -139,20 +139,44 @@ export const buildAdvisorHistoryText = (messages, { limit = 18 } = {}) => {
     : "No advisor messages are currently recorded.";
 };
 
-export const buildActionHistoryText = (actions, { includeResolved = false } = {}) => {
-  const normalizedActions = normalizeActions(actions);
-  const filteredActions = includeResolved
-    ? normalizedActions
-    : normalizedActions.filter((action) => action.status === "planned");
-  if (filteredActions.length === 0) {
-    return includeResolved ? "No actions have been recorded yet." : "No planned actions are currently queued.";
-  }
+// Resolved actions accumulate for the whole campaign, and every one of them used
+// to be re-sent on every turn. On a long save that is the bulk of the prompt — a
+// player measured 700k of their 803k characters as nothing but old resolved
+// actions — and because this history is interpolated into the prompt more than
+// once, it was pasted in repeatedly. Events were always capped (eventLimit /
+// longEventLimit); actions simply never were. Matching longEventLimit here.
+export const ACTION_HISTORY_LIMIT = 24;
 
-  return filteredActions.map((action) => {
+export const buildActionHistoryText = (actions, { includeResolved = false, limit = ACTION_HISTORY_LIMIT } = {}) => {
+  const normalizedActions = normalizeActions(actions);
+  const renderAction = (action) => {
     const kindLabel = action.kind === "chat" ? "chat" : "action";
     const statusLabel = action.status !== "planned" ? ` [${action.status}]` : "";
     return `- (${kindLabel}) ${action.title}${statusLabel}: ${buildActionDisplayText(action)}`;
-  }).join("\n");
+  };
+
+  if (!includeResolved) {
+    const planned = normalizedActions.filter((action) => action.status === "planned");
+    if (planned.length === 0) return "No planned actions are currently queued.";
+    return planned.map(renderAction).join("\n");
+  }
+
+  if (normalizedActions.length === 0) return "No actions have been recorded yet.";
+
+  // Every PLANNED action survives — those are live orders the model must act on —
+  // while only the most recent `limit` finished ones are quoted. The number of
+  // dropped entries is stated so the model knows the campaign runs deeper than
+  // the excerpt, rather than reading it as a short history.
+  const past = normalizedActions.filter((action) => action.status !== "planned");
+  const kept = new Set(limit > 0 ? past.slice(-limit) : []);
+  const omitted = past.length - kept.size;
+  const lines = normalizedActions
+    .filter((action) => action.status === "planned" || kept.has(action))
+    .map(renderAction);
+  if (omitted > 0) {
+    lines.unshift(`- (${omitted} earlier resolved action${omitted === 1 ? "" : "s"} omitted from this excerpt)`);
+  }
+  return lines.join("\n");
 };
 
 export const formatActionsForPrompt = (actions) => normalizeArray(actions)

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -918,6 +918,11 @@ const normalizeConsolidatedHistory = (value) => normalizeArray(value)
     const summary = normalizeTextLike(entry.summary);
     if (!summary) return null;
     return {
+      // Ids of the resolved player orders folded into this summary. Without it the
+      // same orders would be re-summarised every consolidation, and — because this
+      // object is a fixed whitelist — an actionIds written by the consolidator
+      // would be dropped on the next read and the tracking would never stick.
+      actionIds: normalizeActionParticipants(entry.actionIds),
       chatIds: normalizeActionParticipants(entry.chatIds),
       createdAt: normalizeOptionalString(entry.createdAt) || new Date().toISOString(),
       source: normalizeOptionalString(entry.source) || "ai",


### PR DESCRIPTION
Supersedes #639/#640/#641, which capped the history without consolidating it. The Reddit reporter was right that capping alone is unsafe.

## Half one — stop re-sending everything

`buildActionHistoryText({ includeResolved: true })` returned every action a campaign had ever produced, and it reaches the model through `PLAYER_EVERY_ACTION` and `PLAYER_EVERY_ACTION_NOT_PREVIOUS` — **five uses across the prompt bodies** — so a long save pasted its whole order log in several times over. ~700k of an 803k-character prompt, per the report.

Event history was always capped (`eventLimit`, `longEventLimit`); actions never were. Now every **planned** order is kept in full and only the **24** most recent resolved ones are quoted, with the dropped count stated.

## Half two — don't lose what they meant

> in my first test in 1920s Europe without WW1 and an active Tsarist Russian Empire, the game started hallucinating actions made by the Soviet Union that did not exist

Exactly right, and the mechanism is clear: remove the orders without recording what they *did*, and the model sees a gap where the campaign's divergences should be — then fills it from real history.

The machinery for this already existed and actions were the one thing missing from it. `compactHistoryIfNeeded` runs a periodic separate model call, and its output lands in `world.consolidatedHistory`, which **is** sent to the simulation. Actions were passed into that function in the bundle and then never used.

- `consolidateHistoryBatch` now takes the resolved orders and summarises them with the events and closed chats.
- `compactHistoryIfNeeded` selects orders not already folded in and records their ids, so nothing is summarised twice. It **rides along with a consolidation that was happening anyway — no extra AI call**, which matters when the whole point is cutting cost.
- `normalizeConsolidatedHistory` learns `actionIds`. It's a fixed whitelist, so without that the field is silently dropped on the next read and the tracking never sticks.
- A call-time **`[Durable Canon]`** directive tells the consolidator that its summary *replaces* what it covers, and to carry forward, as standing facts: how the world diverged from real history (named explicitly), the lasting consequences of the player's orders, and commitments still in force. Call-time because existing campaigns carry frozen prompts — a `defaultPrompts.json` change would never reach them.

That is the reporter's "pinned canon", generated automatically instead of hand-maintained per save.

## Verified in a browser against the real modules

| check | result |
|---|---|
| `actionIds` survives `normalizeWorldState` | `["a1","a2"]` |
| …and survives a **second** pass (read/write/read) | `["a1","a2"]` |
| `chatIds` / `summary` unaffected | ✅ |
| per-turn cap on a 300-order campaign | `- (276 earlier resolved actions omitted from this excerpt)` |
| planned orders kept | ✅ |
| **consolidator still receives the full batch, uncapped** | all 60, no omission notice |
| `gameplay.js` loads (free-identifier check) | ✅ |

That last row is the important interaction: the per-turn prompt is capped, but the consolidator sees everything before it summarises, so nothing is discarded unread.

Earlier measurement stands — 46,587 → 1,600 characters on an 800-action campaign, a 97% cut.

Credit to the Reddit poster both for the original diagnosis and for catching that the first fix would have traded a cost bug for a continuity bug.