### PR TITLE
[beta] Add OpenCode Zen with beginner setup and free-first defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@
 your browser, and you bring your own AI key (it goes straight to your provider, never to
 us). The world map is served by the community [content-node network](https://github.com/Open-Historia/open-historia-node).
 
+**Want to try OpenCode Zen's free models?** Follow the [step-by-step setup guide](docs/opencode-zen.md)
+(key creation, free vs. paid models, Go vs. Zen billing, and troubleshooting; includes a Russian quick start).
+Use the desktop app or your own local server for Zen: its API currently does not allow cross-origin browser requests.
+
 Local AI (Ollama, LM Studio) needs one extra step in the browser: the server has to allow
 the site's origin, e.g. start Ollama with `OLLAMA_ORIGINS=https://openhistoria.com`. The
 desktop app below needs no such setup.

--- a/docs/ai-overview.md
+++ b/docs/ai-overview.md
@@ -37,12 +37,19 @@ Defined in `PROVIDER_OPTIONS` at `src/Game/AI/providerConfig.js`. The selected p
 | `anthropic` | Anthropic | Native APIs | `callAnthropic` (`main.jsx`) | `https://api.anthropic.com/v1` | **direct only** (`fetch`, browser‑access opt‑in header) | no |
 | `openai-compatible` | OpenAI Compatible | Gateways & self‑hosted | `callOpenAICompatible` (`main.jsx`) | user `endpoint` (default `http://localhost:11434/v1`) | `providerFetch` | yes |
 | `anthropic-compatible` | Anthropic Compatible | Gateways & self‑hosted | `callAnthropicCompatible` (`main.jsx`) | user `endpoint` | `providerFetch` | no |
+| `opencode-zen` | OpenCode Zen | Gateways & self-hosted | `callOpenCodeZen` → `callOpenAIStyleChatCompletions` | fixed `https://opencode.ai/zen/v1` | `providerFetch` via `zenFetch` (actionable CORS error on hosted pages) | public catalogue, Chat Completions families only; free-only auto-pick |
 
 `callAI` (`main.jsx`) is the single switch over `getStoredProvider()`; `gemini` is the `default` branch. Before dispatch it appends a language directive (`languageDirective()`, [i18n](i18n.md)) so replies come back in the player's language at the source.
 
 "OpenAI Compatible" is the catch‑all for Ollama, LM Studio, OpenRouter, vLLM, and other gateways speaking `/chat/completions`. "Anthropic Compatible" is a self‑hosted proxy speaking the Anthropic Messages API. Both share their native sibling's caller body but read a different settings namespace and are relay‑capable.
 
 ---
+
+### OpenCode Zen setup
+
+See **[OpenCode Zen: first-time setup](opencode-zen.md)** for key creation, the difference between Go and Zen billing, free-model selection, privacy and troubleshooting (also summarized in Russian). The same beginner steps are visible in Settings → AI → OpenCode Zen.
+
+The Zen adapter intentionally supports only documented **Chat Completions** families, not every protocol returned by Zen's catalogue. Paid models require an explicit opt-in (`opencode_zen_allow_paid = "1"`), checked against the effective model including task/custom-JSON overrides. A blank model always discovers a free model, never a paid fallback; discovery does not persist a potentially temporary free offer as the default. `openCodeZen.js` owns catalogue filtering and the paid-model guard. Zen currently lacks browser CORS support; local installs use the existing local relay, while the hosted website gets instructions to use the desktop app rather than handing a key to a hosted proxy.
 
 ## Configuration & storage keys
 
@@ -55,9 +62,10 @@ All AI config lives in **browser `localStorage`** — never on a server. `PROVID
 | `anthropic` | `anthropic_api_key` | `anthropic_model` (`claude-haiku-4-5`) | — (fixed) | `anthropic_custom_params` | `anthropic_structured_mode` (`auto`) |
 | `openai-compatible` | `openai_compatible_api_key` | `openai_compatible_model` (`""`) | `openai_compatible_endpoint` (`http://localhost:11434/v1`) | `openai_compatible_custom_params` | `openai_compatible_structured_mode` (`auto`) |
 | `anthropic-compatible` | `anthropic_compatible_api_key` | `anthropic_compatible_model` (`claude-haiku-4-5`) | `anthropic_compatible_endpoint` (`""`) | `anthropic_compatible_custom_params` | `anthropic_compatible_structured_mode` (`auto`) |
+| `opencode-zen` | `opencode_zen_api_key` | `opencode_zen_model` (`""` → free-only discovery) | — (fixed) | `opencode_zen_custom_params` | `opencode_zen_structured_mode` (`auto`) |
 
 Notes:
-- **`structuredMode` exists on all five providers but is only READ by three** — `openai`, `openai-compatible` and `anthropic-compatible`, whose callers walk the ladder. Native Gemini and Anthropic enforce their own tool contracts, so the settings UI does not offer the control there; a stored value on those two is inert.
+- **`structuredMode` exists on all six providers but is only READ by four** — `openai`, `openai-compatible`, `anthropic-compatible` and `opencode-zen`, whose callers walk the ladder. Native Gemini and Anthropic enforce their own tool contracts, so the settings UI does not offer the control there; a stored value on those two is inert.
 - **Legacy keys**: `openai-compatible` `endpoint`/`model` fall back to the pre‑rename `custom_api_endpoint`/`custom_api_model` keys (`readStoredValue`, `providerConfig.js`).
 - **Settings‑form binding**: the settings UI reads/writes via `FORM_FIELD_MAP` (`providerConfig.js`), `loadProviderSettingsFormState()`, and `persistProviderSetting()`.
 - **Default model constants** live in `main.jsx` too: `GEMINI_DEFAULT_MODEL` (`main.jsx`), `ANTHROPIC_DEFAULT_MODEL` (`main.jsx`), used as `resolveModel` fallbacks.
@@ -120,7 +128,7 @@ The whole security model is in the comment block at `main.jsx`. AI calls go **st
 - **`PAGE_IS_LOCAL`** (`main.jsx`, from `isLocallyServed()`): true when the page is served from a machine the player controls — `localhost`/`127.0.0.1`/`::1`/`*.local` or the LAN private ranges `10.*`, `192.168.*`, `172.16–31.*`. The LAN ranges cover the Android client, which loads the UI from a local server on the home network.
 - **`providerFetch(url, options)`** (`main.jsx`): tries `directFetch`; on a CORS/network `TypeError` (not an abort) **and** only when `PAGE_IS_LOCAL`, it remembers the origin in `relayOnlyOrigins` and retries through the same‑origin `/api/ai/relay` (`relayFetch`, `main.jsx`). A remembered origin skips the doomed direct attempt on later calls.
 - On a **hosted website** there is no relay: every call is direct‑only and the key is never handed to anything but the provider. If a hosted page tries to reach a **local** backend (Ollama/LM Studio) and the browser rejects it, `providerFetch` throws an actionable error telling the user to set `OLLAMA_ORIGINS`/enable CORS (`main.jsx`).
-- **Who uses the relay**: only the `providerFetch` callers — `openai`, `openai-compatible`, `anthropic-compatible`, and model discovery (`GET /models`). **Native Gemini and native Anthropic bypass `providerFetch` entirely** (plain `fetch`), because both explicitly allow browser calls (Anthropic via the `anthropic-dangerous-direct-browser-access: true` header, `main.jsx`). They are therefore always direct, relay or not.
+- **Who uses the relay**: only the `providerFetch` callers — `openai`, `openai-compatible`, `anthropic-compatible`, `opencode-zen`, and model discovery (`GET /models`). **Native Gemini and native Anthropic bypass `providerFetch` entirely** (plain `fetch`), because both explicitly allow browser calls (Anthropic via the `anthropic-dangerous-direct-browser-access: true` header, `main.jsx`). They are therefore always direct, relay or not.
 
 `isLocalEndpoint(url)` (`main.jsx`) is the per‑endpoint sibling of `PAGE_IS_LOCAL`; it also gates local streaming (below).
 
@@ -167,7 +175,7 @@ Every task entry point wraps itself in `beginSimulation()`/`endSimulation()` —
 
 ## Transport internals per provider
 
-`callAI` (`main.jsx`) → one of five callers. Shared retry/abort machinery:
+`callAI` (`main.jsx`) → one of six callers. Shared retry/abort machinery:
 
 - **Retries**: `retries = 3`, `retryDelay = 15000` ms. Retried on `429`/`503` (Gemini treats `429` as fatal "quota exhausted", `main.jsx`). Guarded by `canRetryBeforeDeadline(deadline, retryDelay)` (`main.jsx`) so a retry that would overrun the deadline is not attempted.
 - **Abort**: an `AbortSignal` (`signal`) propagates from `runJsonTask`'s controller through the caller to `fetch`/relay. An `AbortError` never triggers the relay fallback and never falls back to canned events (see [Cancellation](#cancellation--timeouts)).

--- a/docs/opencode-zen.md
+++ b/docs/opencode-zen.md
@@ -1,0 +1,70 @@
+# OpenCode Zen: first-time setup
+
+OpenCode Zen gives Open Historia access to free and paid AI models. **Start with free models.** You do not need to enable paid models in the game to try them. Free offers, account requirements and rate limits are controlled by OpenCode and can change.
+
+## 1. Create a key
+
+1. Open **[OpenCode](https://opencode.ai/auth)** and sign in, or create an account.
+2. In your OpenCode workspace, open **API Keys** and choose **Create API Key**. The exact button wording may change.
+3. Name the key **Open Historia**, create it, and copy the **entire secret value**. The key's name, your account password and a Go subscription receipt are not API keys.
+4. Keep the key private. Do not include it in screenshots, messages, bug reports or Git commits. If you accidentally share it, revoke it in OpenCode and create another.
+
+## 2. Paste it into the game
+
+1. Use the **Open Historia desktop app** or run the game on **your own local server**.
+2. Open the game menu → **Settings → AI** and choose **OpenCode Zen**.
+3. Paste the secret into **OpenCode Zen API Key**.
+4. Leave **Enable paid Zen models** switched **off**.
+5. Click **Load models**, then choose a model in **Free tier**. Alternatively, leave **Model** empty: the game looks up the current catalogue and selects a supported free model. It will not fall back to a paid model.
+6. Settings save automatically in this browser/app profile. Return to the game, open the advisor and send a short message such as “Hello”. This tests actual generation. **Loading the catalogue does not validate your key or balance.**
+
+The address is built in: `https://opencode.ai/zen/v1`. Do not substitute the Go address (`/zen/go/v1`). Keys remain in the same browser-local settings storage used by the other providers. Requests go directly to OpenCode, with the existing relay on **your local game server** used if necessary. No new hosted proxy is involved.
+
+**Website limitation:** at the time of integration, Zen does not supply the CORS headers required for cross-origin browser requests. The hosted game website therefore may fail with “Failed to fetch” or a CORS error. Use the desktop app/local server instead. Do not disable browser security or give a public proxy your key.
+
+## 3. Go vs. Zen — avoid unexpected charges
+
+- **Go** is an OpenCode subscription with its own endpoint and allowance.
+- **Zen** has its own free offers and pay-as-you-go billing. A key used with Go may also access Zen free models, but **a Go subscription does not pay for Zen paid-model requests**.
+- Paid Zen models are blocked in the game by default, including per-task model overrides and a `model` override in custom JSON.
+- To deliberately use a paid model: check **Zen Billing** in your OpenCode workspace, add credit if needed, set a spending limit, turn on **Enable paid Zen models**, and explicitly choose the desired model.
+- Even after enabling paid models, leaving **Model** blank still auto-selects only a free model. An unavailable free model is never silently replaced with a paid one.
+- The free label comes from Zen's published free model IDs/offers; it is **not a live price quote** or a promise of unlimited access. Check [current pricing](https://opencode.ai/docs/zen/#pricing).
+
+## Supported models
+
+This connection currently supports Zen's **Chat Completions** families: Big Pickle, MiMo, Ling, Nemotron, DeepSeek, GLM, Kimi and MiniMax. Available IDs are loaded from `/models`, with supported free models shown first. You can also paste an exact model ID; an `opencode/` prefix is accepted.
+
+Zen's catalogue also contains models requiring other protocols: GPT/Grok/Muse use Responses, Claude and the documented Qwen Plus/Max models use Messages, and Gemini uses its native API. These are **not supported by this connection yet**, and are not offered in the selector. See Zen's [endpoint table](https://opencode.ai/docs/zen/#endpoints). Listing a model does not guarantee that your workspace/key has access to it.
+
+For advanced use, the provider supports per-task models, custom request parameters, streaming and the game's existing structured-output fallback ladder. Model changes reset the structured-output preference to Auto, just as for the other gateways.
+
+## Quick fixes
+
+| Message / symptom | What to do |
+|---|---|
+| Invalid API key | Copy the full secret again. Make sure you did not paste its name/password. Create a replacement if the old key was revoked. |
+| Insufficient balance | Choose a free model or check **Zen** Billing. Go credit/allowance is separate. |
+| Rate limit / busy / 429 | Wait and retry, or choose another free model. Repeated retries do not remove a free-tier limit. |
+| Model not found / access denied | Reload the model list; check workspace model permissions. Free offers may have ended. |
+| Paid models disabled | Choose a free model, or deliberately enable paid models after checking billing. Check per-task overrides and custom JSON too. |
+| Failed to fetch / CORS | Use the desktop app or your own local server. Do not use a public key-handling proxy. |
+| No supported free model listed | Wait for an available free offer, enter a known supported free ID manually, or deliberately configure paid access. Nothing paid was selected automatically. |
+
+**Privacy:** some free models may collect prompts/replies for model improvement; NVIDIA trial endpoints warn against personal or confidential data. Read [Zen's privacy terms](https://opencode.ai/docs/zen/#privacy) before sending anything sensitive.
+
+---
+
+## Короткая инструкция по-русски
+
+1. Откройте [OpenCode](https://opencode.ai/auth), войдите или зарегистрируйтесь.
+2. В рабочем пространстве откройте **API Keys → Create API Key**, назовите ключ **Open Historia** и создайте его. Скопируйте весь секретный ключ, а не его название и не пароль от аккаунта.
+3. В **настольной игре** откройте **Settings → AI → OpenCode Zen** и вставьте ключ в **OpenCode Zen API Key**. Настройки сохраняются автоматически.
+4. Переключатель **Enable paid Zen models** оставьте **выключенным**. Нажмите **Load models** и выберите модель из **Free tier**. Можно оставить поле **Model** пустым — игра попробует выбрать доступную бесплатную модель сама. На платную она сама не переключится.
+5. Вернитесь в игру и отправьте советнику короткое «Привет». Загрузка списка моделей сама по себе **не проверяет** ключ и баланс.
+
+**Подписка Go и баланс Zen — разные вещи.** Ключ аккаунта с Go может работать на бесплатных моделях Zen, но подписка не оплачивает платные запросы Zen. Для платных моделей отдельно проверьте **Zen Billing**, пополните баланс при необходимости, установите лимит расходов и только затем включайте платные модели в игре.
+
+Если написано **Invalid API key** — скопируйте ключ заново или создайте новый. **Insufficient balance** — выберите бесплатную модель либо проверьте баланс Zen. **429 / Rate limit** — подождите или выберите другую бесплатную модель. **Failed to fetch / CORS** на сайте — используйте настольную игру или свой локальный сервер: сейчас Zen не разрешает прямые запросы из чужого браузерного сайта.
+
+Никому не отправляйте ключ, не показывайте его на скриншотах и не вставляйте в публичные прокси. Если раскрыли — отзовите его в OpenCode и создайте новый. Не отправляйте бесплатным моделям личные или секретные данные: у некоторых есть условия об использовании запросов для улучшения моделей. Бесплатные предложения и ограничения могут меняться.

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -1,6 +1,7 @@
 /*! Open Historia — portions (server relay for OpenAI-style APIs + reasoning toggle) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import {
     getModelForTask,
+    getProviderField,
     getProviderSettings,
     getReasoningEnabled,
     getStoredProvider,
@@ -8,6 +9,7 @@ import {
     saveRecentModel,
     setProviderField,
 } from "./providerConfig.js";
+import { OPENCODE_ZEN_ENDPOINT, pickZenFreeModel, validateZenModel, zenChatModels } from "./openCodeZen.js";
 import { splitSystemPromptForCache } from "./promptLayout.js";
 import { attachCallMetrics, finishAiRecord, isTelemetryEnabled, startAiRecord } from "./telemetry.js";
 import { JSON_URLS, readJson } from "../../runtime/assets.js";
@@ -900,6 +902,7 @@ async function callOpenAIStyleChatCompletions({
     observerKey = "",
     maxTokens,
     tokenLimitField = "max_tokens",
+    fetchRequest = providerFetch,
 }) {
     // Where to BEGIN on the ladder. "auto" (the default) starts at the strongest
     // method; a configured mode starts lower, skipping rungs this endpoint has
@@ -960,7 +963,7 @@ async function callOpenAIStyleChatCompletions({
         // it renders tokens and therefore streamed. Nothing downstream changes: the
         // readers reassemble the provider's normal envelope.
         const streamThisRequest = !streamingDisabled;
-        const response = await providerFetch(`${normalizeEndpoint(endpoint)}/chat/completions`, {
+        const response = await fetchRequest(`${normalizeEndpoint(endpoint)}/chat/completions`, {
             headers,
             signal,
             payload: {
@@ -1296,6 +1299,64 @@ async function callOpenAI(systemPrompt, history, opts = {}) {
         observerKey: `${settings.provider}|${model}`,
         tokenLimitField: "max_completion_tokens",
         ...opts,
+    });
+}
+
+// The public catalogue is not an authentication/balance check. Fetch it without
+// a key: merely looking at the available models must not expose a credential.
+export async function discoverOpenCodeZenModels({ signal } = {}) {
+    const response = await zenFetch(`${OPENCODE_ZEN_ENDPOINT}/models`, { method: "GET", signal });
+    if (!response.ok) {
+        const payload = await readErrorPayload(response);
+        throw new Error(extractErrorMessage(payload, "Could not load OpenCode Zen models. Try again later."));
+    }
+    return zenChatModels(await response.json());
+}
+
+async function zenFetch(url, options) {
+    try {
+        return await providerFetch(url, options);
+    } catch (error) {
+        if (!PAGE_IS_LOCAL && !options?.signal?.aborted && error instanceof TypeError) {
+            throw new Error("OpenCode Zen could not be reached from this browser. Zen currently does not allow cross-origin browser requests (CORS). Use the Open Historia desktop app or your own local server; never paste your key into a public proxy.");
+        }
+        throw error;
+    }
+}
+
+async function callOpenCodeZen(systemPrompt, history, opts = {}) {
+    const provider = "opencode-zen";
+    const settings = getProviderSettings(provider);
+    const apiKey = settings.apiKey.trim();
+    if (!apiKey) throw new Error("Open AI settings, select OpenCode Zen, and follow the setup steps to create and paste your API key.");
+
+    const customParams = parseCustomParams(settings.customParams, "OpenCode Zen");
+    // Validate the EFFECTIVE model, including the escape hatch and task routing.
+    // Otherwise custom JSON could bypass the paid-model opt-in, while telemetry
+    // misleadingly named the free model in the ordinary settings field.
+    let model = customParams.model ?? getModelForTask(provider, opts.taskKey).trim();
+    delete customParams.model;
+    if (!model) {
+        model = pickZenFreeModel(await discoverOpenCodeZenModels({ signal: opts.signal }));
+        if (!model) throw new Error("No supported free OpenCode Zen model is currently listed. Choose a model in AI settings; no paid model was selected automatically.");
+    }
+    model = validateZenModel(model, getProviderField(provider, "allowPaid") === "1");
+    saveRecentModel(provider, model);
+    opts.onModel?.(model);
+
+    return callOpenAIStyleChatCompletions({
+        endpoint: OPENCODE_ZEN_ENDPOINT,
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+        model,
+        systemPrompt,
+        history,
+        providerLabel: "OpenCode Zen",
+        customParams,
+        allowJsonSchemaFallback: true,
+        configuredStructuredMode: settings.structuredMode,
+        observerKey: `${provider}|${model}`,
+        ...opts,
+        fetchRequest: zenFetch,
     });
 }
 
@@ -1796,6 +1857,8 @@ function dispatchToProvider(provider, systemPrompt, history, providerOpts) {
         return callAnthropicCompatible(systemPrompt, history, providerOpts);
     case "openai-compatible":
         return callOpenAICompatible(systemPrompt, history, providerOpts);
+    case "opencode-zen":
+        return callOpenCodeZen(systemPrompt, history, providerOpts);
     case "gemini":
     default:
         return callGemini(systemPrompt, history, providerOpts);

--- a/src/Game/AI/openCodeZen.js
+++ b/src/Game/AI/openCodeZen.js
@@ -1,0 +1,47 @@
+/*! Open Historia — portions (OpenCode Zen model selection) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+export const OPENCODE_ZEN_ENDPOINT = "https://opencode.ai/zen/v1";
+
+export function normalizeZenModel(model) {
+    return String(model ?? "").trim().replace(/^opencode\//, "");
+}
+
+// Zen is NOT one OpenAI-compatible endpoint for its entire catalogue. Its
+// documented GPT/Grok/Muse, Claude/Qwen and Gemini models use Responses,
+// Messages and generateContent respectively. Offer only the Chat Completions
+// families this adapter actually speaks, rather than discovering an expensive
+// Claude model that cannot answer this request. Keep this list aligned with
+// https://opencode.ai/docs/zen/#endpoints when adding another family.
+export function isZenChatModel(model) {
+    return /^(?:big-pickle$|(?:deepseek|glm|minimax|kimi|mimo|ling|nemotron)-)/.test(normalizeZenModel(model));
+}
+
+export function isZenFreeModel(model) {
+    const id = normalizeZenModel(model);
+    return isZenChatModel(id) && (id === "big-pickle" || id.endsWith("-free"));
+}
+
+export function zenChatModels(data) {
+    const entries = Array.isArray(data?.data) ? data.data : [];
+    const ids = entries.map((entry) => entry?.id).filter((id) => typeof id === "string" && isZenChatModel(id));
+    return [...new Set(ids.map(normalizeZenModel))].sort((a, b) => (
+        Number(isZenFreeModel(b)) - Number(isZenFreeModel(a)) || a.localeCompare(b)
+    ));
+}
+
+export function pickZenFreeModel(models) {
+    // No paid fallback, even when paid models are enabled. That switch permits
+    // an EXPLICIT selection; an empty model field must never start spending credits.
+    return models.find((model) => isZenFreeModel(model)) ?? "";
+}
+
+export function validateZenModel(model, allowPaid = false) {
+    const id = normalizeZenModel(model);
+    if (!isZenChatModel(id)) {
+        throw new Error("OpenCode Zen currently supports Chat Completions models here (for example Big Pickle, MiMo, DeepSeek, GLM, Kimi and MiniMax). Choose one from Load models; Responses, Claude/Qwen Messages and Gemini models are not supported by this connection yet.");
+    }
+    if (!allowPaid && !isZenFreeModel(id)) {
+        throw new Error("Paid OpenCode Zen models are disabled. Choose a free model, or enable paid Zen models in AI settings and check your Zen balance. A Go subscription does not pay for Zen requests.");
+    }
+    return id;
+}

--- a/src/Game/AI/openCodeZen.test.js
+++ b/src/Game/AI/openCodeZen.test.js
@@ -1,0 +1,161 @@
+/*! Open Historia — portions (OpenCode Zen adapter regression tests) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+    OPENCODE_ZEN_ENDPOINT, normalizeZenModel, isZenChatModel, isZenFreeModel,
+    zenChatModels, pickZenFreeModel, validateZenModel,
+} from "./openCodeZen.js";
+
+// Representative IDs from the public Zen catalogue and its documented endpoint
+// table, including the trap: some names ending in -free use Responses instead.
+const catalogue = { data: [
+    { id: "claude-haiku-4-5" }, { id: "gpt-5-nano" }, { id: "gemini-3-flash" },
+    { id: "qwen3.6-plus" }, { id: "grok-4.5" },
+    { id: "muse-spark-1.3-contributor-free" },
+    { id: "deepseek-v4-flash" }, { id: "mimo-v2.5-free" },
+    { id: "big-pickle" }, { id: "glm-5" }, { id: "minimax-m2.5" },
+    { id: "kimi-k2.5" }, { id: "nemotron-3-ultra-free" },
+    { id: "ling-3.0-flash-fin-free" }, { id: "mimo-v2.5-free" },
+    {}, null, { id: 12 },
+] };
+
+test("Zen catalogue only offers supported Chat Completions models, free first", () => {
+    const ids = zenChatModels(catalogue);
+    assert.equal(ids[0], "big-pickle");
+    assert.equal(ids.length, 8);
+    assert.ok(ids.every(isZenChatModel));
+    assert.equal(ids.filter((id) => id === "mimo-v2.5-free").length, 1);
+    assert.deepEqual(zenChatModels({ data: null }), []);
+    assert.deepEqual(zenChatModels({ data: {} }), []);
+    assert.deepEqual(zenChatModels(null), []);
+    for (const id of ["gpt-5-nano", "claude-haiku-4-5", "gemini-3-flash", "qwen3.6-plus", "grok-4.5", "muse-spark-1.3-contributor-free"]) {
+        assert.equal(isZenChatModel(id), false);
+        assert.equal(isZenFreeModel(id), false);
+        assert.throws(() => validateZenModel(id, true), /not supported/);
+    }
+});
+
+test("auto-selection never falls back to a paid or unsupported model", () => {
+    assert.equal(pickZenFreeModel(zenChatModels(catalogue)), "big-pickle");
+    assert.equal(pickZenFreeModel(["deepseek-v4-flash", "mimo-v2.5-free"]), "mimo-v2.5-free");
+    assert.equal(pickZenFreeModel(["deepseek-v4-flash", "muse-spark-1.3-contributor-free"]), "");
+    assert.equal(pickZenFreeModel([]), "");
+});
+
+test("manual models accept the OpenCode prefix, but paid models need opt-in", () => {
+    assert.equal(normalizeZenModel("  opencode/big-pickle  "), "big-pickle");
+    assert.equal(validateZenModel("opencode/mimo-v2.5-free"), "mimo-v2.5-free");
+    assert.throws(() => validateZenModel("deepseek-v4-flash"), /Paid.*disabled/);
+    assert.equal(validateZenModel("deepseek-v4-flash", true), "deepseek-v4-flash");
+    assert.throws(() => validateZenModel(""), /not supported/);
+    assert.throws(() => validateZenModel("unknown-free"), /not supported/);
+});
+
+// main.jsx imports the whole game/DOM graph. Exercise its actual adapter body
+// with injected transport/config, as the desktop port-probe tests do, without
+// booting a map or making network requests in the test suite. The shared SSE
+// parser and structured ladder have their own regression tests.
+const source = readFileSync(new URL("./main.jsx", import.meta.url), "utf8");
+const adapterSource = source.slice(source.indexOf("export async function discoverOpenCodeZenModels("), source.indexOf("async function callOpenAICompatible("))
+    .replace("export async function", "async function");
+
+function adapter({ model = "", taskModel = "", apiKey = "test-only-key", allowPaid = "", customParams = "", local = true, fetchError, data = catalogue, status = 200 } = {}) {
+    const requests = [];
+    const calls = [];
+    const recent = [];
+    const dependencies = {
+        OPENCODE_ZEN_ENDPOINT, pickZenFreeModel, validateZenModel, zenChatModels,
+        PAGE_IS_LOCAL: local,
+        providerFetch: async (url, options) => {
+            requests.push({ url, options });
+            if (fetchError) throw fetchError;
+            return new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } });
+        },
+        getProviderSettings: (provider) => {
+            assert.equal(provider, "opencode-zen");
+            return { apiKey, customParams, structuredMode: "json_object" };
+        },
+        getProviderField: (provider, field) => { assert.equal(provider, "opencode-zen"); assert.equal(field, "allowPaid"); return allowPaid; },
+        getModelForTask: (provider, task) => { assert.equal(provider, "opencode-zen"); return task === "advisor" && taskModel ? taskModel : model; },
+        parseCustomParams: (raw) => raw ? JSON.parse(raw) : {},
+        saveRecentModel: (provider, id) => recent.push({ provider, id }),
+        callOpenAIStyleChatCompletions: async (options) => { calls.push(options); return "answer"; },
+        readErrorPayload: (response) => response.json(),
+        extractErrorMessage: (payload, fallback) => payload.error?.message ?? fallback,
+    };
+    const functions = new Function(...Object.keys(dependencies), `${adapterSource}\nreturn { callOpenCodeZen, discoverOpenCodeZenModels, zenFetch };`)(...Object.values(dependencies));
+    return { ...functions, calls, requests, recent };
+}
+
+test("Zen dispatch, key, fixed endpoint and shared streaming/tool transport", async () => {
+    const a = adapter({ model: "opencode/mimo-v2.5-free", customParams: '{"temperature":0.2}' });
+    const signal = new AbortController().signal;
+    const tool = { name: "submit_test", schema: { type: "object" } };
+    let reported;
+    const onChunk = () => {};
+    assert.equal(await a.callOpenCodeZen("system", [], { signal, tool, onChunk, onModel: (id) => { reported = id; } }), "answer");
+    assert.equal(a.requests.length, 0);
+    const call = a.calls[0];
+    assert.equal(call.endpoint, "https://opencode.ai/zen/v1");
+    assert.equal(call.headers.Authorization, "Bearer test-only-key");
+    assert.equal(call.model, "mimo-v2.5-free");
+    assert.equal(reported, call.model);
+    assert.deepEqual(call.customParams, { temperature: 0.2 });
+    assert.equal(call.signal, signal);
+    assert.equal(call.tool, tool);
+    assert.equal(call.onChunk, onChunk);
+    assert.equal(call.allowJsonSchemaFallback, true);
+    assert.equal(call.configuredStructuredMode, "json_object");
+    assert.equal(call.observerKey, "opencode-zen|mimo-v2.5-free");
+    // Pin the wiring as well as the adapter: normal callAI dispatch must reach it.
+    assert.match(source, /case "opencode-zen":\s*return callOpenCodeZen\(systemPrompt, history, providerOpts\)/);
+});
+
+test("discovery sends no key and blank model only uses the public free catalogue", async () => {
+    const a = adapter();
+    await a.callOpenCodeZen("system", []);
+    assert.equal(a.requests[0].url, `${OPENCODE_ZEN_ENDPOINT}/models`);
+    assert.equal(a.requests[0].options.method, "GET");
+    assert.equal(a.requests[0].options.headers, undefined);
+    assert.equal(a.calls[0].model, "big-pickle");
+    const paidOnly = adapter({ data: { data: [{ id: "deepseek-v4-flash" }] }, allowPaid: "1" });
+    await assert.rejects(paidOnly.callOpenCodeZen("system", []), /No supported free/);
+    assert.equal(paidOnly.calls.length, 0);
+});
+
+test("missing key, task overrides and custom JSON cannot bypass paid opt-in", async () => {
+    const missing = adapter({ apiKey: " " });
+    await assert.rejects(missing.callOpenCodeZen("s", []), /create and paste/);
+    assert.equal(missing.requests.length, 0);
+    for (const options of [
+        { model: "deepseek-v4-flash" },
+        { model: "big-pickle", taskModel: "deepseek-v4-flash" },
+        { model: "big-pickle", customParams: '{"model":"deepseek-v4-flash"}' },
+    ]) {
+        const blocked = adapter(options);
+        await assert.rejects(blocked.callOpenCodeZen("s", [], { taskKey: "advisor" }), /Paid.*disabled/);
+        assert.equal(blocked.calls.length, 0);
+        const allowed = adapter({ ...options, allowPaid: "1" });
+        await allowed.callOpenCodeZen("s", [], { taskKey: "advisor" });
+        assert.equal(allowed.calls[0].model, "deepseek-v4-flash");
+        assert.equal(allowed.calls[0].customParams.model, undefined);
+    }
+});
+
+test("Zen fetch errors explain CORS on hosted pages and preserve cancellation/HTTP errors", async () => {
+    const cors = adapter({ local: false, fetchError: new TypeError("Failed to fetch") });
+    await assert.rejects(cors.discoverOpenCodeZenModels(), /CORS.*desktop/);
+    const local = adapter({ fetchError: new TypeError("offline") });
+    await assert.rejects(local.discoverOpenCodeZenModels(), /offline/);
+    const controller = new AbortController();
+    controller.abort();
+    const abort = new DOMException("Aborted", "AbortError");
+    const cancelled = adapter({ local: false, fetchError: abort });
+    await assert.rejects(cancelled.discoverOpenCodeZenModels({ signal: controller.signal }), (error) => error === abort);
+    const unavailable = adapter({ status: 503, data: { error: { message: "Zen unavailable" } } });
+    await assert.rejects(unavailable.discoverOpenCodeZenModels(), /Zen unavailable/);
+    const explicitModel = adapter({ model: "big-pickle", local: false, fetchError: new TypeError("Failed to fetch") });
+    await explicitModel.callOpenCodeZen("s", []);
+    await assert.rejects(explicitModel.calls[0].fetchRequest(`${OPENCODE_ZEN_ENDPOINT}/chat/completions`, {}), /CORS.*desktop/);
+});

--- a/src/Game/AI/providerConfig.js
+++ b/src/Game/AI/providerConfig.js
@@ -26,6 +26,13 @@ export const PROVIDER_OPTIONS = [
         searchTerms: ["claude", "haiku", "sonnet", "opus"],
     },
     {
+        value: "opencode-zen",
+        label: "OpenCode Zen",
+        group: "Gateways and self-hosted",
+        description: "Zen free and paid Chat Completions models (separate from Go)",
+        searchTerms: ["opencode", "zen", "free", "big pickle", "mimo", "deepseek", "glm", "kimi", "minimax"],
+    },
+    {
         value: "openai-compatible",
         label: "OpenAI Compatible",
         group: "Gateways and self-hosted",
@@ -42,6 +49,13 @@ export const PROVIDER_OPTIONS = [
 ];
 
 const PROVIDER_SETTINGS = {
+    "opencode-zen": {
+        apiKey: { storageKey: "opencode_zen_api_key", defaultValue: "" },
+        model: { storageKey: "opencode_zen_model", defaultValue: "" },
+        customParams: { storageKey: "opencode_zen_custom_params", defaultValue: "" },
+        structuredMode: { storageKey: "opencode_zen_structured_mode", defaultValue: "auto" },
+        allowPaid: { storageKey: "opencode_zen_allow_paid", defaultValue: "" },
+    },
     gemini: {
         apiKey: { storageKey: "gemini_api_key", defaultValue: "" },
         model: { storageKey: "gemini_model", defaultValue: "gemini-3.5-flash-lite" },
@@ -91,6 +105,11 @@ const PROVIDER_SETTINGS = {
 };
 
 const FORM_FIELD_MAP = {
+    opencodeZenApiKey: { provider: "opencode-zen", field: "apiKey" },
+    opencodeZenModel: { provider: "opencode-zen", field: "model" },
+    opencodeZenCustomParams: { provider: "opencode-zen", field: "customParams" },
+    opencodeZenStructuredMode: { provider: "opencode-zen", field: "structuredMode" },
+    opencodeZenAllowPaid: { provider: "opencode-zen", field: "allowPaid" },
     geminiApiKey: { provider: "gemini", field: "apiKey" },
     geminiModel: { provider: "gemini", field: "model" },
     geminiCustomParams: { provider: "gemini", field: "customParams" },
@@ -170,7 +189,7 @@ export function getProviderMeta(provider) {
 
 export function providerSupportsModelDiscovery(provider) {
     const normalized = normalizeProvider(provider);
-    return normalized === "openai" || normalized === "openai-compatible";
+    return normalized === "openai" || normalized === "openai-compatible" || normalized === "opencode-zen";
 }
 
 export function getProviderField(provider, field) {

--- a/src/Game/AI/providerConfig.test.js
+++ b/src/Game/AI/providerConfig.test.js
@@ -92,6 +92,37 @@ test("profiles: stock entries are seeded once, then saved, updated and deleted l
   assert.equal(config.getSavedPresets().length, 2);
 });
 
+test("OpenCode Zen is a separate, key-required provider with free-only defaults", () => {
+  assert.equal(config.normalizeProvider("opencode-zen"), "opencode-zen");
+  assert.equal(config.getProviderMeta("opencode-zen").label, "OpenCode Zen");
+  assert.equal(config.providerSupportsModelDiscovery("opencode-zen"), true);
+  assert.equal(config.providerSetupRequirement("opencode-zen"), "apiKey");
+  assert.equal(config.isProviderConfigured("opencode-zen"), false);
+  assert.equal(config.getProviderField("opencode-zen", "model"), "");
+  assert.equal(config.getProviderField("opencode-zen", "allowPaid"), "");
+  config.persistProviderSetting("opencodeZenApiKey", "test-only-key");
+  config.persistProviderSetting("opencodeZenModel", "big-pickle");
+  config.persistProviderSetting("opencodeZenCustomParams", '{"top_p":0.9}');
+  config.persistProviderSetting("opencodeZenStructuredMode", "json_object");
+  config.persistProviderSetting("opencodeZenAllowPaid", "1");
+  assert.equal(config.isProviderConfigured("opencode-zen"), true);
+  const state = config.loadProviderSettingsFormState();
+  assert.equal(state.opencodeZenApiKey, "test-only-key");
+  assert.equal(state.opencodeZenModel, "big-pickle");
+  assert.equal(state.opencodeZenCustomParams, '{"top_p":0.9}');
+  assert.equal(state.opencodeZenStructuredMode, "json_object");
+  assert.equal(state.opencodeZenAllowPaid, "1");
+  assert.equal(config.getProviderField("openai-compatible", "apiKey"), "");
+  assert.equal(config.getProviderField("gemini", "apiKey"), "");
+  config.setProviderField("opencode-zen", "model_advisor", "mimo-v2.5-free");
+  assert.equal(config.getModelForTask("opencode-zen", "advisor"), "mimo-v2.5-free");
+  assert.equal(config.getModelForTask("opencode-zen", "jumpForward"), "big-pickle");
+  config.setProviderField("opencode-zen", "model", "mimo-v2.5-free");
+  assert.equal(config.getProviderField("opencode-zen", "structuredMode"), "auto");
+  config.setProviderField("opencode-zen", "apiKey", "   ");
+  assert.equal(config.isProviderConfigured("opencode-zen"), false);
+});
+
 test("recent models: newest first, no duplicates, capped at ten", () => {
   config.saveRecentModel("openai", "a");
   config.saveRecentModel("openai", "b");

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -17,6 +17,7 @@ import {
     setReasoningEnabled,
     updatePreset,
 } from "../AI/providerConfig.js";
+import { isZenFreeModel, OPENCODE_ZEN_ENDPOINT } from "../AI/openCodeZen.js";
 import {
     isRatingEnabled,
     isTelemetryEnabled,
@@ -268,6 +269,10 @@ const Toggle = ({ label, enabled, onToggle }) => (
     >
     <span style={{ fontSize: "0.9rem" }}>{label}</span>
     <button
+    type="button"
+    role="switch"
+    aria-label={label}
+    aria-checked={Boolean(enabled)}
     onClick={onToggle}
     style={{
         width: "3.5rem",
@@ -485,11 +490,12 @@ const SettingsInput = ({
     const list = Array.isArray(suggestions) && suggestions.length ? suggestions : null;
     return (
         <div style={fieldGroupStyle}>
-        <label style={labelStyle}>
+        <label style={labelStyle} htmlFor={`${listId}-input`}>
         {label}
         </label>
         {multiline ? (
             <textarea
+            id={`${listId}-input`}
             rows={4}
             value={value}
             onChange={(event) => onChange(event.target.value)}
@@ -500,6 +506,7 @@ const SettingsInput = ({
             />
         ) : (
             <input
+            id={`${listId}-input`}
             type={type}
             value={value}
             onChange={(event) => onChange(event.target.value)}
@@ -743,6 +750,11 @@ const PROVIDER_EXPERT_FIELDS = {
     gemini: { customParams: "geminiCustomParams", placeholder: '{"generationConfig": {"topP": 0.9}}' },
     openai: { customParams: "openaiCustomParams", placeholder: '{"top_p": 0.9}', structuredMode: "openaiStructuredMode" },
     anthropic: { customParams: "anthropicCustomParams", placeholder: '{"top_p": 0.9}' },
+    "opencode-zen": {
+        customParams: "opencodeZenCustomParams",
+        placeholder: '{"top_p": 0.9}',
+        structuredMode: "opencodeZenStructuredMode",
+    },
     "openai-compatible": {
         customParams: "openaiCompatibleCustomParams",
         placeholder: '{"top_p": 0.9}',
@@ -754,6 +766,105 @@ const PROVIDER_EXPERT_FIELDS = {
         placeholder: '{"top_p": 0.9}',
         structuredMode: "anthropicCompatibleStructuredMode",
     },
+};
+
+// Keep the beginner steps visible, not behind an advanced-settings disclosure.
+// Model discovery is a catalogue lookup, NOT proof that a key has credit/access.
+const OpenCodeZenConnection = ({ settings, onSettingChange, recentModels }) => {
+    const [models, setModels] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+    const request = useRef(null);
+    useEffect(() => () => request.current?.abort(), []);
+    const allowPaid = settings.opencodeZenAllowPaid === "1";
+    const visibleModels = models.filter((model) => allowPaid || isZenFreeModel(model));
+
+    const loadModels = async () => {
+        request.current?.abort();
+        const controller = new AbortController();
+        request.current = controller;
+        setLoading(true);
+        setError("");
+        try {
+            const { discoverOpenCodeZenModels } = await import("../AI/main.jsx");
+            const available = await discoverOpenCodeZenModels({ signal: controller.signal });
+            if (controller.signal.aborted) return;
+            setModels(available);
+            if (!available.some(isZenFreeModel)) setError("No supported free model is currently listed. No paid model will be selected automatically.");
+        } catch (nextError) {
+            if (!controller.signal.aborted) setError(nextError.message);
+        } finally {
+            if (!controller.signal.aborted) setLoading(false);
+        }
+    };
+
+    const linkStyle = { color: "#93c5fd" };
+    return (
+        <>
+        <div style={{ ...helperStyle, marginTop: 0, marginBottom: "1rem", color: "rgba(255,255,255,0.8)" }}>
+        <strong>First time? Start here</strong>
+        <ol style={{ paddingLeft: "1.3rem", lineHeight: 1.65 }}>
+        <li>Open <a href="https://opencode.ai/auth" target="_blank" rel="noopener noreferrer" style={linkStyle}>OpenCode Zen</a> and sign in (or create an account).</li>
+        <li>In your OpenCode workspace, open <strong>API Keys</strong>, choose <strong>Create API Key</strong>, give it a name such as <strong>Open Historia</strong>, and create it.</li>
+        <li>Copy the entire secret key and paste it into <strong>OpenCode Zen API Key</strong> below. This is not your password or the key's name. Keep it private; do not put it in screenshots or bug reports.</li>
+        <li>Leave <strong>Enable paid Zen models</strong> off. Click <strong>Load models</strong> and choose a free model, or leave Model blank to automatically try a currently listed free model.</li>
+        <li>Settings save automatically in this browser. Return to the game and send a short message to your advisor to test the key. Loading the model list alone does not test your key or balance.</li>
+        </ol>
+        <p><strong>Go is not Zen credit.</strong> An OpenCode account key used with Go may also work for Zen's free models, but the Go subscription does not cover paid Zen requests. You do not need to enable paid models here to try the free ones. To use paid models, check Zen Billing, add credit if needed, set a spending limit, then explicitly enable and select a paid model below.</p>
+        <p><strong>Use the desktop app or your own local server.</strong> Zen currently blocks cross-origin browser requests (CORS), so the hosted website may not connect. Never use a public proxy to work around this with your key.</p>
+        <p>Free availability and limits can change. Some free providers may use prompts and replies to improve their models: do not send personal or confidential information. Check <a href="https://opencode.ai/docs/zen/#pricing" target="_blank" rel="noopener noreferrer" style={linkStyle}>pricing</a> and <a href="https://opencode.ai/docs/zen/#privacy" target="_blank" rel="noopener noreferrer" style={linkStyle}>privacy terms</a>.</p>
+        </div>
+        <SettingsInput
+        label="OpenCode Zen API Key"
+        type="password"
+        value={settings.opencodeZenApiKey ?? ""}
+        onChange={(value) => onSettingChange("opencodeZenApiKey", value)}
+        placeholder="Paste the secret key from OpenCode → API Keys"
+        helperText="Stored only in this browser, like the other AI keys. Sent to OpenCode Zen directly, or through your own local game server when necessary."
+        />
+        <div style={{ ...helperStyle, marginBottom: "0.85rem", overflowWrap: "anywhere" }}>Fixed API address: {OPENCODE_ZEN_ENDPOINT} — not the /zen/go/v1 subscription endpoint.</div>
+        <Toggle
+        label="Enable paid Zen models"
+        enabled={allowPaid}
+        onToggle={() => onSettingChange("opencodeZenAllowPaid", allowPaid ? "" : "1")}
+        />
+        <div style={{ ...helperStyle, marginTop: "-0.6rem", marginBottom: "0.85rem" }}>
+        Off by default. Turning this on allows explicitly selected paid models, including per-task overrides, to spend Zen credit. Blank Model still auto-picks only a free model. Free labels follow Zen's model names and published offers, not a live price quote.
+        </div>
+        <SettingsInput
+        label="Model"
+        value={settings.opencodeZenModel ?? ""}
+        onChange={(value) => onSettingChange("opencodeZenModel", value)}
+        suggestions={[...new Set([...visibleModels, ...recentModels.filter((model) => allowPaid || isZenFreeModel(model))])]}
+        placeholder="Leave blank to auto-pick a free model"
+        helperText="Supports Zen Chat Completions models such as Big Pickle, MiMo, DeepSeek, GLM, Kimi and MiniMax. Models requiring Responses, Claude/Qwen Messages or Gemini APIs are not supported here yet."
+        />
+        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "0.85rem" }}>
+        <button type="button" disabled={loading} onClick={loadModels} style={primaryButtonStyle}>{loading ? "Loading models…" : "Load models"}</button>
+        {visibleModels.length > 0 && (
+            <select aria-label="Choose an OpenCode Zen model" style={{ ...inputStyle, flex: 1, minWidth: "12rem" }} value="" onChange={(event) => onSettingChange("opencodeZenModel", event.target.value)}>
+            <option value="" disabled>Choose a model…</option>
+            {[false, true].filter((paid) => !paid || allowPaid).map((paid) => (
+                <optgroup key={String(paid)} label={paid ? "Paid — uses Zen credit" : "Free tier"}>
+                {visibleModels.filter((model) => isZenFreeModel(model) !== paid).map((model) => <option key={model} value={model}>{model}</option>)}
+                </optgroup>
+            ))}
+            </select>
+        )}
+        </div>
+        {error && <div role="alert" style={{ ...helperStyle, color: "#fca5a5", marginBottom: "0.85rem" }}>{error}</div>}
+        <details style={{ ...helperStyle, marginBottom: "0.85rem" }}>
+        <summary style={{ cursor: "pointer" }}>Not working? Quick fixes</summary>
+        <ul style={{ paddingLeft: "1.3rem", lineHeight: 1.65 }}>
+        <li><strong>Invalid API key:</strong> copy the full secret again. If it was revoked, create a new one. Never share it to get help.</li>
+        <li><strong>Insufficient balance:</strong> switch to a free model, or check Zen Billing. Paying for Go does not top up Zen.</li>
+        <li><strong>Rate limit / busy:</strong> wait and retry, or choose another free model. Free access is limited, not unlimited.</li>
+        <li><strong>Model not found / access denied:</strong> load the list again and check that the model is enabled in your OpenCode workspace.</li>
+        <li><strong>Failed to fetch / CORS:</strong> use the desktop app or your own local server; do not disable browser security or share your key with a proxy.</li>
+        </ul>
+        </details>
+        </>
+    );
 };
 
 // The connection: where the provider is and what runs there. Everything a
@@ -841,6 +952,10 @@ const ProviderConnectionPanel = ({ provider, settings, onSettingChange }) => {
             helperText="Claude model ids are manual here. Leave blank to use the built-in default."
             />
             </>
+        )}
+
+        {provider === "opencode-zen" && (
+            <OpenCodeZenConnection settings={settings} onSettingChange={onSettingChange} recentModels={recentModels} />
         )}
 
         {provider === "openai-compatible" && (


### PR DESCRIPTION
Adds OpenCode Zen to beta's AI Connections and Fallback list. Players can create a key using the visible setup guide, load supported Chat Completions models, and start with free models. Paid Zen models require an explicit opt-in for each connection; a Go subscription does not fund paid Zen requests.

- Uses the fixed Zen endpoint and existing local relay, streaming, cancellation, lookup tools and structured-output ladder. Hosted-browser CORS failures provide setup guidance and participate in fallback handling.
- Filters the public catalogue to supported Chat Completions families and shows free models first. A blank model only discovers a free model. Paid-model checks cover entry models, per-task picks and custom JSON overrides.
- Migrates the earlier Zen settings into Connections and Fallback entries, preserving keys, models, task picks, structured mode and explicit paid opt-in. Different Zen connections keep separate billing permissions.
- Records paid-model settings in the diagnostic snapshot and scopes structured-output suggestions to the selected entry.
- Includes an English setup guide and Russian quick start. Responses, Messages and Gemini-native models are not supported by this adapter.

Updated against current upstream beta to resolve the PR's conflicts and integrate with the new connection-based settings.

Validation:

- `npm test`: **2070 passed, 0 failed**, with 1 skipped and 2 TODO tests.
- `npm run build`: **passed**; Vite reports large-chunk warnings.
- ESLint on all changed JavaScript/JSX files: **0 errors**, 1 existing warning. Repository-wide lint reports 18 errors and 69 warnings; every error is in map files unchanged from upstream beta.
- Browser check in Edge at 1280px and 390px, using the real Settings component and a mocked catalogue: masked key, free-only picker, paid opt-in, persisted model selection, no page errors or horizontal overflow.
- Regression coverage includes legacy migration, separate connection permissions, task picks, custom model overrides, fallback after blocked models/catalogue outages, cancellation and CORS errors.
- `git diff --check` passed. No live paid inference was used for this update.

The conflict resolution and integration update were prepared with OpenAI Codex assistance. Project code remains under AGPL-3.0-or-later.
